### PR TITLE
Fix 'rake zeitwerk:check' error

### DIFF
--- a/app/controllers/ngsi/versions_controller.rb
+++ b/app/controllers/ngsi/versions_controller.rb
@@ -1,5 +1,5 @@
 module Ngsi
-  class ersionsController < BaseController
+  class VersionsController < BaseController
     before_action :set_version, only: [:show]
 
     def show


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix the following `rake zeitwerk:check` error
   ```zsh
   % bundle exec rake zeitwerk:check
   Hold on, I am eager loading the application.
   rake aborted!
   SyntaxError: /path/to/redmine-fiware/plugins/redmine_gtt_fiware/app/controllers/ngsi/versions_controller.rb:2: class/module name must be CONSTANT
     class ersionsController < BaseController
           ^~~~~~~~~~~~~~~~~
   ```

@gtt-project/maintainer
