### PR TITLE
Empty new line in "description" and "note" field causes error due to invalid JSON

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -137,10 +137,10 @@ class SubscriptionTemplatesController < ApplicationController
       method: "POST",
       json: {
         entity: "#{@entity_url}/${id}?type=${type}",
-        subject: @subscription_template.subject,
-        description: @subscription_template.description,
+        subject: @subscription_template.subject.chomp,
+        description: @subscription_template.description.chomp,
         attachments: @subscription_template.attachments,
-        notes: @subscription_template.notes,
+        notes: @subscription_template.notes.chomp,
         geometry: @subscription_template.geometry
       }
     }


### PR DESCRIPTION
Fixes #36

Changes proposed in this pull request:
- Remove empty new line at the end of description and note when building JSON