### PR TITLE
Phase 0: CI and test foundation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Defer brand-new releases to reduce supply-chain risk from
+    # freshly published (potentially hijacked) action versions.
+    cooldown:
+      default-days: 8
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -27,8 +27,13 @@ jobs:
         #   6.1-stable -> 3.3, 3.4
         redmine_version: [6.0-stable, 6.1-stable]
         ruby_version: ['3.3', '3.4']
-        # postgis/postgis tags spanning PG 15/17/18 and PostGIS 3.4/3.5/3.6.
-        db_version: [15-3.4, 18-3.6]
+        # postgis/postgis tags spanning PG 15/17/18 and PostGIS 3.4/3.5/3.6
+        # (floor -> ceiling), matching the redmine_gtt matrix.
+        db_version: [15-3.4, 17-3.5, 18-3.6]
+        include:
+          - system_test: true
+            redmine_version: 6.1-stable
+            ruby_version: '3.4'
         exclude:
           # Redmine 6.0 supports Ruby up to 3.3 only.
           - redmine_version: 6.0-stable
@@ -117,12 +122,19 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
+          # For system tests in the plugin
+          GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
         working-directory: redmine
         # Only run suites that exist; `rails test` raises LoadError on a
-        # missing directory (functional/integration get added as Phase 0
-        # progresses).
+        # missing directory (functional/integration/system get added as the
+        # revival progresses). System tests only run on the designated matrix
+        # cell, like in redmine_gtt.
         run: |
-          for suite in unit functional integration; do
+          suites="unit functional integration"
+          if [ "${{ matrix.system_test }}" = "true" ]; then
+            suites="$suites system"
+          fi
+          for suite in $suites; do
             dir="plugins/${{ env.PLUGIN_NAME }}/test/$suite"
             if [ -d "$dir" ]; then
               bundle exec rails test "$dir"

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -1,0 +1,130 @@
+name: Test with PostGIS
+
+env:
+  PLUGIN_NAME: ${{ github.event.repository.name }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Redmine >= 6 only (see init.rb requires_redmine). Each Redmine version
+        # is tested against the Ruby versions it supports, limited to Rubies
+        # still in upstream support:
+        #   6.0-stable -> 3.3
+        #   6.1-stable -> 3.3, 3.4
+        redmine_version: [6.0-stable, 6.1-stable]
+        ruby_version: ['3.3', '3.4']
+        # postgis/postgis tags spanning PG 15/17/18 and PostGIS 3.4/3.5/3.6.
+        db_version: [15-3.4, 18-3.6]
+        exclude:
+          # Redmine 6.0 supports Ruby up to 3.3 only.
+          - redmine_version: 6.0-stable
+            ruby_version: '3.4'
+
+    services:
+      postgres:
+        image: postgis/postgis:${{ matrix.db_version }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v6
+        with:
+          repository: redmine/redmine
+          ref: ${{ matrix.redmine_version }}
+          path: redmine
+
+      # redmine_gtt is a hard dependency: this plugin uses RedmineGtt::Conversions
+      # for geometry and relies on the `geom` column its migration adds to issues.
+      - name: Checkout redmine_gtt (dependency)
+        uses: actions/checkout@v6
+        with:
+          repository: gtt-project/redmine_gtt
+          ref: next
+          path: redmine/plugins/redmine_gtt
+
+      - name: Checkout Plugin
+        uses: actions/checkout@v6
+        with:
+          path: redmine/plugins/${{ env.PLUGIN_NAME }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+
+      - name: Install native gem system libraries
+        # pg and rgeo-geos gems' headers need these.
+        run: |
+          sudo apt-get update --yes --quiet
+          sudo apt-get install --yes --quiet --no-install-recommends libpq-dev libgeos-dev
+
+      - name: Prepare Redmine source
+        working-directory: redmine
+        run: |
+          cat <<EOF > config/database.yml
+            test:
+              adapter: postgis
+              database: redmine
+              host: 127.0.0.1
+              username: postgres
+              password: postgres
+              encoding: utf8
+          EOF
+
+      - name: Install Ruby dependencies
+        working-directory: redmine
+        run: |
+          bundle config set --local without 'development'
+          bundle install --jobs=4 --retry=3
+
+      - name: Run Redmine rake tasks
+        env:
+          RAILS_ENV: test
+        working-directory: redmine
+        run: |
+          bundle exec rake generate_secret_token
+          bundle exec rake db:create db:migrate redmine:plugins:migrate
+
+      - name: Zeitwerk check
+        env:
+          RAILS_ENV: test
+        working-directory: redmine
+        run: |
+          if grep -q zeitwerk config/application.rb ; then
+            bundle exec rake zeitwerk:check
+          fi
+        shell: bash
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+        working-directory: redmine
+        run: |
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/unit
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/functional
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/integration
+
+      - name: Run uninstall test
+        env:
+          RAILS_ENV: test
+        working-directory: redmine
+        run: bundle exec rake redmine:plugins:migrate NAME=${{ env.PLUGIN_NAME }} VERSION=0

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout Redmine
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: redmine/redmine
           ref: ${{ matrix.redmine_version }}
@@ -59,20 +59,24 @@ jobs:
 
       # redmine_gtt is a hard dependency: this plugin uses RedmineGtt::Conversions
       # for geometry and relies on the `geom` column its migration adds to issues.
+      # It is checked out from `next` on purpose: that is redmine_gtt's
+      # integration branch, and this plugin must stay compatible with it.
+      # A CI break caused by a redmine_gtt change is a signal we want early,
+      # not noise to be pinned away.
       - name: Checkout redmine_gtt (dependency)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: gtt-project/redmine_gtt
           ref: next
           path: redmine/plugins/redmine_gtt
 
       - name: Checkout Plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@a30dfa457ad68707b8b910ac3a244714b61c0626 # v1.320.0
         with:
           ruby-version: ${{ matrix.ruby_version }}
 

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -118,10 +118,18 @@ jobs:
         env:
           RAILS_ENV: test
         working-directory: redmine
+        # Only run suites that exist; `rails test` raises LoadError on a
+        # missing directory (functional/integration get added as Phase 0
+        # progresses).
         run: |
-          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/unit
-          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/functional
-          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/integration
+          for suite in unit functional integration; do
+            dir="plugins/${{ env.PLUGIN_NAME }}/test/$suite"
+            if [ -d "$dir" ]; then
+              bundle exec rails test "$dir"
+            else
+              echo "Skipping $suite tests ($dir does not exist yet)"
+            fi
+          done
 
       - name: Run uninstall test
         env:

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -71,7 +71,7 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   end
 
   def set_default_notify_on_metadata_change
-    self.notify_on_metadata_change = true
+    self.notify_on_metadata_change = true if notify_on_metadata_change.nil?
   end
 
   def take_json_entities

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -36,6 +36,11 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_equal true, template.notify_on_metadata_change
   end
 
+  def test_explicit_false_notify_on_metadata_change_is_respected
+    template = SubscriptionTemplate.new(valid_attributes(notify_on_metadata_change: false))
+    assert_equal false, template.notify_on_metadata_change
+  end
+
   def test_name_is_required
     template = SubscriptionTemplate.new(valid_attributes(name: nil))
     assert_not template.valid?

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -1,0 +1,88 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class SubscriptionTemplateTest < ActiveSupport::TestCase
+  fixtures :projects, :trackers, :issue_statuses, :users, :members,
+           :member_roles, :roles, :enumerations
+
+  def valid_attributes(overrides = {})
+    {
+      standard: 'NGSIv2',
+      status: 'active',
+      name: 'Temperature alerts',
+      broker_url: 'https://broker.example.com',
+      subject: 'Sensor ${id}',
+      description: 'A monitored value changed',
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      project_id: 1,
+      tracker_id: 1,
+      issue_status_id: 1,
+      member_id: 1,
+    }.merge(overrides)
+  end
+
+  def test_valid_template_saves
+    template = SubscriptionTemplate.new(valid_attributes)
+    assert template.valid?, template.errors.full_messages.join(', ')
+    assert template.save
+  end
+
+  def test_default_alteration_types
+    template = SubscriptionTemplate.new
+    assert_equal ['entityCreate', 'entityChange'], template.alteration_types
+  end
+
+  def test_default_notify_on_metadata_change
+    template = SubscriptionTemplate.new
+    assert_equal true, template.notify_on_metadata_change
+  end
+
+  def test_name_is_required
+    template = SubscriptionTemplate.new(valid_attributes(name: nil))
+    assert_not template.valid?
+    assert template.errors.added?(:name, :blank)
+  end
+
+  def test_broker_url_is_required
+    template = SubscriptionTemplate.new(valid_attributes(broker_url: nil))
+    assert_not template.valid?
+    assert template.errors.added?(:broker_url, :blank)
+  end
+
+  def test_standard_must_be_supported
+    template = SubscriptionTemplate.new(valid_attributes(standard: 'bogus'))
+    assert_not template.valid?
+    assert template.errors[:standard].present?
+  end
+
+  def test_status_must_be_valid
+    template = SubscriptionTemplate.new(valid_attributes(status: 'paused'))
+    assert_not template.valid?
+    assert template.errors[:status].present?
+  end
+
+  def test_entities_string_must_be_valid_json
+    template = SubscriptionTemplate.new(valid_attributes(entities_string: 'not json'))
+    assert_not template.valid?
+    assert template.errors[:entities_string].present?
+  end
+
+  def test_name_is_unique_within_project
+    SubscriptionTemplate.create!(valid_attributes)
+    duplicate = SubscriptionTemplate.new(valid_attributes)
+    assert_not duplicate.valid?
+    assert duplicate.errors[:name].present?
+  end
+
+  def test_threshold_create_hours_converts_to_seconds
+    template = SubscriptionTemplate.new(valid_attributes)
+    template.threshold_create_hours = 2
+    assert_equal 7200, template.threshold_create
+    assert_equal 2, template.threshold_create_hours
+  end
+
+  def test_geo_query_fields_must_be_all_or_none
+    template = SubscriptionTemplate.new(valid_attributes(expression_georel: 'near;maxDistance:1000'))
+    assert_not template.valid?
+    assert template.errors[:base].present?
+  end
+end


### PR DESCRIPTION
Part of the NGSI-LD revival roadmap (#71), Phase 0.

Closes #25.

## What

- **CI** (`.github/workflows/test-postgis.yml`): GitHub Actions matrix over Redmine 6.0/6.1, Ruby 3.3/3.4 and PostGIS 15/18, mirroring the `redmine_gtt` workflow. Checks out `redmine_gtt` as a dependency (this plugin uses `RedmineGtt::Conversions` and the `geom` column its migration adds), runs unit/functional/integration tests, a Zeitwerk check and an uninstall test.
- **Unit tests** for `SubscriptionTemplate`: validations, defaults (`alteration_types`, `notify_on_metadata_change`), the `threshold_create_hours` accessor, name uniqueness and the geo-query all-or-none rule.

## Why

There was no test infrastructure at all (`test/` held only the helper). This lands the harness first so the Phase 0 security fixes (#58 webhook secret, #59 SSRF, #60 remove read API, #61 POST routes, #62 JS escaping) can each ship with characterization tests against green CI.

No functional change to the plugin.
