### PR TITLE
chore: set plugin author to Daniel Kastl

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -7,8 +7,8 @@ Mime::Type.register 'application/ld+json', :jsonld
 Redmine::Plugin.register :redmine_gtt_fiware do
   # Plugin metadata
   name 'Redmine GTT FIWARE plugin'
-  author 'Georepublic'
-  author_url 'https://github.com/georepublic'
+  author 'Daniel Kastl'
+  author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
   version '2.0.1'


### PR DESCRIPTION
Sets the plugin's current author metadata to Daniel Kastl (@dkastl), the plugin's creator and maintainer.

`init.rb` still credited `Georepublic`. Historical authorship remains in the git history; the README Authors section already lists Daniel first.

```diff
-  author 'Georepublic'
-  author_url 'https://github.com/georepublic'
+  author 'Daniel Kastl'
+  author_url 'https://github.com/dkastl'
```
