### PR TITLE
Phase 0: harden notification attachment downloads against SSRF

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'uri'
 require 'rack'
 
 # This controller handles the creation of issues from subscription templates.
@@ -100,33 +100,32 @@ class SubscriptionIssuesController < ApplicationController
   end
 
   # Handles attachments by downloading them and attaching them to the issue.
+  # Downloads go through AttachmentFetcher, which enforces the SSRF
+  # protections: https only, host allowlist, public addresses only, no
+  # redirects, timeouts, content-type allowlist and a size limit. The
+  # stored content type is the one the server responded with; a type
+  # claimed in the notification payload is not trusted. Rejected
+  # attachments are skipped and logged so one bad attachment does not
+  # fail the whole notification.
   def handle_attachments
+    fetcher = RedmineGttFiware::AttachmentFetcher.for_template(@subscription_template)
     existing_filenames = @issue.attachments.map { |a| a.filename }
 
     params[:attachments].each do |attachment|
-      uri = URI.parse(attachment['url'])
-      filename = attachment['filename'] || File.basename(uri.path)
-
-      next if existing_filenames.include?(filename)
-
       begin
-        response = Net::HTTP.get_response(uri)
+        filename = attachment['filename'].presence ||
+                   File.basename(URI.parse(attachment['url'].to_s).path.to_s)
 
-        if response.is_a?(Net::HTTPSuccess)
-          file = Tempfile.new('attachment')
-          file.binmode
-          file.write(response.body)
-          file.rewind
+        next if filename.empty? || existing_filenames.include?(filename)
 
-          description = attachment['description'] || ''
-          content_type = attachment['content_type'] || response.content_type
-
-          uploaded_file = Rack::Multipart::UploadedFile.new(file.path, content_type, true, filename: filename)
-
-          @issue.attachments.build(file: uploaded_file, description: description, author: User.current)
-        else
-          logger.warn "Failed to download file: #{response.message}"
-        end
+        result = fetcher.fetch(attachment['url'])
+        description = attachment['description'] || ''
+        uploaded_file = Rack::Multipart::UploadedFile.new(
+          result.tempfile.path, result.content_type, true, filename: filename
+        )
+        @issue.attachments.build(file: uploaded_file, description: description, author: User.current)
+      rescue RedmineGttFiware::AttachmentFetcher::RejectedError => e
+        logger.warn "Rejected attachment download from #{attachment['url'].inspect}: #{e.message}"
       rescue => e
         logger.warn "Failed to attach file: #{e.message}"
       end

--- a/app/views/gtt_fiware/_settings.html.erb
+++ b/app/views/gtt_fiware/_settings.html.erb
@@ -26,3 +26,21 @@
     @settings['fiware_broker_subscription_throttling'], :min => 0, :step => 1 %>
 </p>
 </div>
+
+<div class="box tabular settings">
+<h3><%= l(:gtt_fiware_settings_attachment_download) %></h3>
+
+<p>
+  <%= content_tag(:label, l(:field_attachment_download_hosts)) %>
+  <%= text_area_tag 'settings[attachment_download_hosts]',
+    @settings['attachment_download_hosts'], rows: 3 %>
+  <em class="info"><%= l(:text_attachment_download_hosts_info) %></em>
+</p>
+
+<p>
+  <%= content_tag(:label, l(:field_attachment_download_content_types)) %>
+  <%= text_area_tag 'settings[attachment_download_content_types]',
+    @settings['attachment_download_content_types'], rows: 5 %>
+  <em class="info"><%= l(:text_attachment_download_content_types_info) %></em>
+</p>
+</div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -63,6 +63,12 @@ de:
   field_subscription_template_threshold_create_hours_hint: 'Schwellenwert für die
     Erstellung eines neuen Tickets in Stunden.'
   field_fiware_broker_subscription_throttling: 'Drosslung von Subscriptions'
+
+  gtt_fiware_settings_attachment_download: 'Download von Benachrichtigungsanhängen'
+  field_attachment_download_hosts: 'Zusätzlich erlaubte Hosts'
+  text_attachment_download_hosts_info: 'Ein Host pro Zeile. Anhänge werden nur per HTTPS von diesen Hosts oder vom Broker-Host der Subskriptionsvorlage heruntergeladen.'
+  field_attachment_download_content_types: 'Erlaubte Inhaltstypen'
+  text_attachment_download_content_types_info: 'Ein Inhaltstyp pro Zeile, Platzhalter wie image/* werden unterstützt. Leer lassen, um die Standardliste zu verwenden.'
   field_subscription_template_comment_placeholder: 'Diese Anmerkung wird nur intern
     verwendet.'
   field_subscription_template_geometry_placeholder: '{"type": "Feature", "geometry":

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,12 @@ en:
   button_connect_via_proxy_text: "PROXY"
   field_fiware_broker_subscription_throttling: "Subscription Throttling"
 
+  gtt_fiware_settings_attachment_download: "Notification Attachment Downloads"
+  field_attachment_download_hosts: "Additional allowed hosts"
+  text_attachment_download_hosts_info: "One host per line. Attachments are only downloaded via HTTPS from these hosts or from the subscription template's broker host."
+  field_attachment_download_content_types: "Allowed content types"
+  text_attachment_download_content_types_info: "One content type per line, wildcards like image/* are supported. Leave blank to use the default list."
+
   gtt_fiware_subscription_template_general: "General"
   field_subscription_template_standard: "NGSI standard"
   field_subscription_template_name: "Name"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,4 @@
-en:
+ja:
   project_module_gtt_fiware: "GTT FIWARE"
   permission_view_gtt_fiware_ngsi: "View NGSI-LD Context files"
   permission_manage_subscription_templates: "Manage Subscription Templates"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,12 @@ en:
   button_connect_via_proxy_text: "PROXY"
   field_fiware_broker_subscription_throttling: "Subscription Throttling"
 
+  gtt_fiware_settings_attachment_download: "通知添付ファイルのダウンロード"
+  field_attachment_download_hosts: "追加で許可するホスト"
+  text_attachment_download_hosts_info: "1行に1ホストを指定します。添付ファイルは、これらのホストまたはサブスクリプションテンプレートのブローカーホストから、HTTPS経由でのみダウンロードされます。"
+  field_attachment_download_content_types: "許可するコンテンツタイプ"
+  text_attachment_download_content_types_info: "1行に1タイプを指定します。image/* のようなワイルドカードが使えます。空欄の場合は既定のリストが使われます。"
+
   gtt_fiware_subscription_template_general: "General"
   field_subscription_template_standard: "NGSI standard"
   field_subscription_template_name: "Name"

--- a/doc/subscription_template.md
+++ b/doc/subscription_template.md
@@ -125,6 +125,21 @@ be created or updated based on the subscription notifications.
   ]
   ```
 
+  For security reasons, attachment downloads are restricted:
+
+  - Only `https` URLs are downloaded.
+  - The URL host must be the subscription template's broker host, or one
+    of the additional hosts configured in the plugin settings
+    (*Administration → Plugins → Redmine GTT FIWARE plugin → Configure*).
+  - Hosts that resolve to private, loopback, or otherwise non-public
+    addresses are rejected, and redirects are not followed.
+  - The response content type must be on the configured allowlist
+    (images, PDF, plain text, CSV, and JSON by default), and downloads
+    are limited by Redmine's maximum attachment size.
+
+  Rejected attachments are skipped and logged; the issue itself is still
+  created or updated.
+
 - **Issue status**: Set the status of the issue (e.g., *New*).
 - **Priority**: Define the priority of the issue (e.g., *Normal*).
 - **Issue category**: Select the issue category. Categories can be created in

--- a/init.rb
+++ b/init.rb
@@ -22,6 +22,8 @@ Redmine::Plugin.register :redmine_gtt_fiware do
       'ngsi_ld_format' => false,
       'connect_via_proxy' => false,
       'fiware_broker_subscription_throttling' => '10',
+      'attachment_download_hosts' => '',
+      'attachment_download_content_types' => "image/jpeg\nimage/png\nimage/gif\nimage/webp\napplication/pdf\ntext/plain\ntext/csv\napplication/json",
     },
     partial: 'gtt_fiware/settings'
   )

--- a/lib/redmine_gtt_fiware/attachment_fetcher.rb
+++ b/lib/redmine_gtt_fiware/attachment_fetcher.rb
@@ -1,0 +1,203 @@
+require 'net/http'
+require 'resolv'
+require 'ipaddr'
+require 'tempfile'
+
+module RedmineGttFiware
+  # Downloads notification attachments with SSRF protections:
+  #
+  # - https URLs only
+  # - the host must be allowlisted (the subscription template's broker
+  #   host plus any hosts configured in the plugin settings)
+  # - every address the host resolves to must be public, and the TCP
+  #   connection is pinned to the vetted address so a DNS rebind between
+  #   check and request cannot redirect the fetch
+  # - redirects are not followed
+  # - connect/read timeouts apply
+  # - the response content type must be allowlisted
+  # - the body is streamed and the download aborted once it exceeds the
+  #   size limit (Redmine's attachment size limit)
+  class AttachmentFetcher
+    class RejectedError < StandardError; end
+
+    Result = Struct.new(:tempfile, :content_type, keyword_init: true)
+
+    OPEN_TIMEOUT = 5   # seconds
+    READ_TIMEOUT = 10  # seconds
+
+    # Used when Redmine's attachment_max_size is 0 (unlimited uploads):
+    # remote downloads still need a hard cap.
+    FALLBACK_MAX_BYTES = 25.megabytes
+
+    DEFAULT_CONTENT_TYPES = %w[
+      image/jpeg
+      image/png
+      image/gif
+      image/webp
+      application/pdf
+      text/plain
+      text/csv
+      application/json
+    ].freeze
+
+    # Address ranges that must never be fetched from, beyond what
+    # IPAddr#private?/#loopback?/#link_local? already cover.
+    BLOCKED_RANGES = %w[
+      0.0.0.0/8
+      100.64.0.0/10
+      192.0.0.0/24
+      198.18.0.0/15
+      224.0.0.0/3
+      ::/128
+      64:ff9b::/96
+    ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+    def self.for_template(template)
+      settings = Setting.plugin_redmine_gtt_fiware
+      hosts = settings['attachment_download_hosts'].to_s.split(/[\s,]+/)
+      begin
+        broker_host = URI.parse(template.broker_url.to_s).host
+        hosts << broker_host if broker_host
+      rescue URI::InvalidURIError
+        # An unparsable broker URL simply contributes no host.
+      end
+
+      content_types = settings['attachment_download_content_types'].to_s.split(/[\s,]+/)
+      content_types = DEFAULT_CONTENT_TYPES if content_types.empty?
+
+      max_size_kb = Setting.attachment_max_size.to_i
+      max_bytes = max_size_kb > 0 ? max_size_kb.kilobytes : FALLBACK_MAX_BYTES
+
+      new(allowed_hosts: hosts, allowed_content_types: content_types, max_bytes: max_bytes)
+    end
+
+    # resolver and transport are injectable for tests. transport is a
+    # callable receiving (uri, ip, &block) that yields a Net::HTTPResponse
+    # (or an object quacking like one) to the block.
+    def initialize(allowed_hosts:, allowed_content_types:, max_bytes:, resolver: Resolv, transport: nil)
+      @allowed_hosts = allowed_hosts.map { |h| h.to_s.strip.downcase }.reject(&:empty?)
+      @allowed_content_types = allowed_content_types.map { |t| t.to_s.strip.downcase }.reject(&:empty?)
+      @max_bytes = max_bytes
+      @resolver = resolver
+      @transport = transport || method(:start_request)
+    end
+
+    # Returns a Result on success, raises RejectedError otherwise.
+    def fetch(url)
+      uri = parse_https_uri(url)
+      check_host!(uri)
+      ip = vetted_address(uri.host)
+      @transport.call(uri, ip) do |response|
+        process_response(response)
+      end
+    end
+
+    private
+
+    def parse_https_uri(url)
+      uri = URI.parse(url.to_s)
+      raise RejectedError, 'only https attachment URLs are allowed' unless uri.is_a?(URI::HTTPS)
+      raise RejectedError, 'attachment URL has no host' if uri.host.to_s.empty?
+      uri
+    rescue URI::InvalidURIError
+      raise RejectedError, 'attachment URL is not a valid URI'
+    end
+
+    def check_host!(uri)
+      host = uri.host.downcase
+      return if @allowed_hosts.include?(host)
+      raise RejectedError, "host #{host} is not on the attachment download allowlist"
+    end
+
+    def vetted_address(host)
+      addresses = @resolver.getaddresses(host)
+      raise RejectedError, "could not resolve #{host}" if addresses.empty?
+      ips = addresses.map { |address| IPAddr.new(address.to_s) }
+      if ips.any? { |ip| blocked_address?(ip) }
+        raise RejectedError, "#{host} resolves to a non-public address"
+      end
+      ips.first.to_s
+    end
+
+    def blocked_address?(ip)
+      # Unwrap IPv4-mapped IPv6 addresses so they are judged by the IPv4
+      # rules. Ranges are compared per family: IPAddr#include? would
+      # otherwise map every IPv4 address into IPv6 space and match it
+      # against IPv6 ranges.
+      ip = ip.native if ip.ipv6? && ip.ipv4_mapped?
+      return true if ip.private? || ip.loopback? || ip.link_local?
+      BLOCKED_RANGES.any? { |range| range.family == ip.family && range.include?(ip) }
+    end
+
+    def start_request(uri, ip)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.ipaddr = ip
+      http.use_ssl = true
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+      http.start do |session|
+        session.request_get(uri.request_uri) do |response|
+          return yield(response)
+        end
+      end
+    rescue Timeout::Error, SystemCallError, SocketError, IOError,
+           OpenSSL::SSL::SSLError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError => e
+      raise RejectedError, "download failed: #{e.class}: #{e.message}"
+    end
+
+    def process_response(response)
+      code = response.code.to_i
+      unless (200..299).cover?(code)
+        raise RejectedError, "unexpected HTTP response #{response.code} (redirects are not followed)"
+      end
+      check_content_type!(response.content_type)
+      check_declared_length!(response['Content-Length'])
+      tempfile = read_body_limited(response)
+      Result.new(tempfile: tempfile, content_type: media_type_of(response.content_type))
+    end
+
+    def check_content_type!(content_type)
+      media_type = media_type_of(content_type)
+      allowed = @allowed_content_types.any? do |pattern|
+        if pattern.end_with?('/*')
+          media_type.start_with?(pattern[0..-2])
+        else
+          media_type == pattern
+        end
+      end
+      return if allowed
+      raise RejectedError, "content type #{media_type.empty? ? '(none)' : media_type} is not allowed"
+    end
+
+    def media_type_of(content_type)
+      content_type.to_s.split(';').first.to_s.strip.downcase
+    end
+
+    def check_declared_length!(content_length)
+      return if content_length.to_s.empty?
+      return if content_length.to_i <= @max_bytes
+      raise RejectedError, "attachment exceeds the maximum size of #{@max_bytes} bytes"
+    end
+
+    def read_body_limited(response)
+      tempfile = Tempfile.new(['gtt_fiware_attachment', '.bin'])
+      tempfile.binmode
+      bytes = 0
+      response.read_body do |chunk|
+        bytes += chunk.bytesize
+        if bytes > @max_bytes
+          raise RejectedError, "attachment exceeds the maximum size of #{@max_bytes} bytes"
+        end
+        tempfile.write(chunk)
+      end
+      tempfile.rewind
+      tempfile
+    rescue StandardError
+      if tempfile
+        tempfile.close
+        tempfile.unlink
+      end
+      raise
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/attachment_fetcher.rb
+++ b/lib/redmine_gtt_fiware/attachment_fetcher.rb
@@ -50,6 +50,8 @@ module RedmineGttFiware
       224.0.0.0/3
       ::/128
       64:ff9b::/96
+      ff00::/8
+      2001:2::/48
     ].map { |cidr| IPAddr.new(cidr) }.freeze
 
     def self.for_template(template)
@@ -150,7 +152,8 @@ module RedmineGttFiware
     def process_response(response)
       code = response.code.to_i
       unless (200..299).cover?(code)
-        raise RejectedError, "unexpected HTTP response #{response.code} (redirects are not followed)"
+        detail = (300..399).cover?(code) ? ' (redirects are not followed)' : ''
+        raise RejectedError, "unexpected HTTP response #{response.code}#{detail}"
       end
       check_content_type!(response.content_type)
       check_declared_length!(response['Content-Length'])

--- a/lib/redmine_gtt_fiware/attachment_fetcher.rb
+++ b/lib/redmine_gtt_fiware/attachment_fetcher.rb
@@ -110,7 +110,9 @@ module RedmineGttFiware
     end
 
     def vetted_address(host)
-      addresses = @resolver.getaddresses(host)
+      # DNS is case-insensitive, but Ruby 3.4's RFC 3986 URI parser
+      # preserves the host's case, so normalize before resolving.
+      addresses = @resolver.getaddresses(host.downcase)
       raise RejectedError, "could not resolve #{host}" if addresses.empty?
       ips = addresses.map { |address| IPAddr.new(address.to_s) }
       if ips.any? { |ip| blocked_address?(ip) }

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -93,6 +93,19 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
   end
 
+  # Fake fetcher that returns a canned result without any network access.
+  # Stubbed in via the AttachmentFetcher.for_template factory (Mocha, which
+  # Redmine's own test harness loads) rather than any_instance.
+  class FakeFetcher
+    def initialize(result)
+      @result = result
+    end
+
+    def fetch(_url)
+      @result
+    end
+  end
+
   def test_create_attaches_allowed_attachments
     set_tmp_attachments_directory
     tempfile = Tempfile.new(['fetched', '.png'])
@@ -102,13 +115,14 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     result = RedmineGttFiware::AttachmentFetcher::Result.new(
       tempfile: tempfile, content_type: 'image/png'
     )
-    RedmineGttFiware::AttachmentFetcher.any_instance.stubs(:fetch).returns(result)
+    RedmineGttFiware::AttachmentFetcher.stubs(:for_template).returns(FakeFetcher.new(result))
 
     assert_difference 'Issue.count', 1 do
       post :create, params: notification_params(
         attachments: [{ url: 'https://broker.example.com/photo.png', filename: 'photo.png' }]
       )
     end
+
     assert_response :success
     issue = Issue.order(id: :desc).first
     assert_equal 1, issue.attachments.count

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -1,0 +1,121 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class SubscriptionIssuesControllerTest < ActionController::TestCase
+  fixtures :projects, :trackers, :projects_trackers, :issue_statuses,
+           :users, :email_addresses, :members, :member_roles, :roles,
+           :enumerations, :issues, :journals
+
+  def setup
+    @template = SubscriptionTemplate.create!(
+      standard: 'NGSIv2',
+      status: 'active',
+      name: 'Temperature alerts',
+      broker_url: 'https://broker.example.com',
+      subject: 'Sensor ${id}',
+      description: 'A monitored value changed',
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      project_id: 1,
+      tracker_id: 1,
+      issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id,
+      member_id: 1
+    )
+    @request.session[:user_id] = 2 # jsmith, manager of project 1
+  end
+
+  def notification_params(overrides = {})
+    {
+      subscription_template_id: @template.id,
+      subject: 'Sensor urn:ngsi-ld:TemperatureSensor:001',
+      description: 'Temperature above threshold',
+      entity: 'urn:ngsi-ld:TemperatureSensor:001',
+    }.merge(overrides)
+  end
+
+  def test_create_returns_404_for_unknown_template
+    post :create, params: notification_params(subscription_template_id: 987654)
+    assert_response :not_found
+  end
+
+  def test_create_requires_add_issues_permission
+    @request.session[:user_id] = nil
+    # Builtin roles may grant add_issues on public projects; strip it so
+    # the anonymous request is unauthorized regardless of fixture details.
+    Role.all.each { |role| role.remove_permission!(:add_issues) }
+    assert_no_difference 'Issue.count' do
+      post :create, params: notification_params
+    end
+    assert_response :forbidden
+  end
+
+  def test_create_creates_an_issue
+    assert_difference 'Issue.count', 1 do
+      post :create, params: notification_params
+    end
+    assert_response :success
+    issue = Issue.order(id: :desc).first
+    assert_equal 'Sensor urn:ngsi-ld:TemperatureSensor:001', issue.subject
+    assert_equal 'urn:ngsi-ld:TemperatureSensor:001', issue.fiware_entity
+    assert_equal @template.id, issue.subscription_template_id
+    assert_equal @template.project, issue.project
+  end
+
+  def test_create_skips_attachments_with_non_https_urls
+    assert_difference 'Issue.count', 1 do
+      post :create, params: notification_params(
+        attachments: [{ url: 'http://169.254.169.254/latest/meta-data', filename: 'meta.txt' }]
+      )
+    end
+    assert_response :success
+    assert_equal 0, Issue.order(id: :desc).first.attachments.count
+  end
+
+  def test_create_skips_attachments_from_hosts_not_on_the_allowlist
+    assert_difference 'Issue.count', 1 do
+      post :create, params: notification_params(
+        attachments: [{ url: 'https://evil.example.org/file.png', filename: 'file.png' }]
+      )
+    end
+    assert_response :success
+    assert_equal 0, Issue.order(id: :desc).first.attachments.count
+  end
+
+  def test_create_skips_attachments_resolving_to_non_public_addresses
+    # localhost is allowlisted via the broker URL here, but resolves to a
+    # loopback address, so the download must still be rejected.
+    @template.update_column(:broker_url, 'https://localhost')
+    assert_difference 'Issue.count', 1 do
+      post :create, params: notification_params(
+        attachments: [{ url: 'https://localhost/file.png', filename: 'file.png' }]
+      )
+    end
+    assert_response :success
+    assert_equal 0, Issue.order(id: :desc).first.attachments.count
+  end
+
+  def test_create_attaches_allowed_attachments
+    set_tmp_attachments_directory
+    tempfile = Tempfile.new(['fetched', '.png'])
+    tempfile.binmode
+    tempfile.write('PNGDATA')
+    tempfile.rewind
+    result = RedmineGttFiware::AttachmentFetcher::Result.new(
+      tempfile: tempfile, content_type: 'image/png'
+    )
+    RedmineGttFiware::AttachmentFetcher.any_instance.stubs(:fetch).returns(result)
+
+    assert_difference 'Issue.count', 1 do
+      post :create, params: notification_params(
+        attachments: [{ url: 'https://broker.example.com/photo.png', filename: 'photo.png' }]
+      )
+    end
+    assert_response :success
+    issue = Issue.order(id: :desc).first
+    assert_equal 1, issue.attachments.count
+    attachment = issue.attachments.first
+    assert_equal 'photo.png', attachment.filename
+    assert_equal 'image/png', attachment.content_type
+  ensure
+    tempfile&.close!
+  end
+end

--- a/test/unit/attachment_fetcher_test.rb
+++ b/test/unit/attachment_fetcher_test.rb
@@ -110,6 +110,8 @@ class AttachmentFetcherTest < ActiveSupport::TestCase
       ::1
       fe80::1
       fc00::1
+      ff02::1
+      2001:2::1
       ::ffff:10.0.0.1
     ].each do |address|
       fetcher = build_fetcher(resolver: FakeResolver.new('broker.example.com' => [address]))
@@ -125,7 +127,16 @@ class AttachmentFetcherTest < ActiveSupport::TestCase
 
   def test_rejects_redirects
     fetcher = build_fetcher(transport: with_response(FakeResponse.new(code: '302')))
-    assert_rejected fetcher, 'https://broker.example.com/file.png', /redirects are not followed/
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /302 \(redirects are not followed\)/
+  end
+
+  def test_rejects_non_redirect_errors_without_redirect_wording
+    fetcher = build_fetcher(transport: with_response(FakeResponse.new(code: '500')))
+    error = assert_raises(RedmineGttFiware::AttachmentFetcher::RejectedError) do
+      fetcher.fetch('https://broker.example.com/file.png')
+    end
+    assert_match(/unexpected HTTP response 500/, error.message)
+    assert_no_match(/redirects/, error.message)
   end
 
   def test_rejects_disallowed_content_types

--- a/test/unit/attachment_fetcher_test.rb
+++ b/test/unit/attachment_fetcher_test.rb
@@ -1,0 +1,203 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class AttachmentFetcherTest < ActiveSupport::TestCase
+
+  # Resolves hosts from a static map; unknown hosts resolve to nothing.
+  class FakeResolver
+    def initialize(map)
+      @map = map
+    end
+
+    def getaddresses(host)
+      @map.fetch(host, [])
+    end
+  end
+
+  # Quacks like the parts of Net::HTTPResponse the fetcher uses.
+  class FakeResponse
+    attr_reader :code
+
+    def initialize(code: '200', content_type: 'image/png', body_chunks: ['data'], content_length: nil)
+      @code = code
+      @content_type = content_type
+      @body_chunks = body_chunks
+      @content_length = content_length
+    end
+
+    def content_type
+      @content_type
+    end
+
+    def [](name)
+      @content_length if name.to_s.casecmp('content-length').zero?
+    end
+
+    def read_body(&block)
+      @body_chunks.each(&block)
+    end
+  end
+
+  NO_TRANSPORT = lambda do |_uri, _ip, &_block|
+    raise 'transport must not be reached'
+  end
+
+  def build_fetcher(overrides = {})
+    RedmineGttFiware::AttachmentFetcher.new(**{
+      allowed_hosts: ['broker.example.com'],
+      allowed_content_types: ['image/png', 'application/pdf'],
+      max_bytes: 1024,
+      resolver: FakeResolver.new('broker.example.com' => ['203.0.113.10']),
+      transport: NO_TRANSPORT,
+    }.merge(overrides))
+  end
+
+  def with_response(response)
+    lambda { |_uri, _ip, &block| block.call(response) }
+  end
+
+  def assert_rejected(fetcher, url, message_fragment)
+    error = assert_raises(RedmineGttFiware::AttachmentFetcher::RejectedError) do
+      fetcher.fetch(url)
+    end
+    assert_match message_fragment, error.message
+  end
+
+  def test_rejects_http_urls
+    assert_rejected build_fetcher, 'http://broker.example.com/file.png', /https/
+  end
+
+  def test_rejects_non_http_schemes
+    assert_rejected build_fetcher, 'ftp://broker.example.com/file.png', /https/
+    assert_rejected build_fetcher, 'file:///etc/passwd', /https/
+  end
+
+  def test_rejects_invalid_urls
+    assert_rejected build_fetcher, 'https://exa mple.com/x', /valid URI/
+  end
+
+  def test_rejects_hosts_not_on_the_allowlist
+    assert_rejected build_fetcher, 'https://evil.example.org/file.png', /allowlist/
+  end
+
+  def test_host_match_is_case_insensitive
+    resolver = FakeResolver.new('BROKER.example.com'.downcase => ['203.0.113.10'])
+    fetcher = build_fetcher(
+      resolver: resolver,
+      transport: with_response(FakeResponse.new)
+    )
+    result = fetcher.fetch('https://BROKER.example.com/file.png')
+    assert_equal 'image/png', result.content_type
+  ensure
+    result&.tempfile&.close!
+  end
+
+  def test_rejects_unresolvable_hosts
+    fetcher = build_fetcher(resolver: FakeResolver.new({}))
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /could not resolve/
+  end
+
+  def test_rejects_hosts_resolving_to_non_public_addresses
+    %w[
+      10.0.0.1
+      172.16.0.1
+      192.168.1.1
+      127.0.0.1
+      169.254.169.254
+      100.64.0.1
+      0.0.0.0
+      198.18.0.1
+      224.0.0.1
+      ::1
+      fe80::1
+      fc00::1
+      ::ffff:10.0.0.1
+    ].each do |address|
+      fetcher = build_fetcher(resolver: FakeResolver.new('broker.example.com' => [address]))
+      assert_rejected fetcher, 'https://broker.example.com/file.png', /non-public address/
+    end
+  end
+
+  def test_rejects_when_any_resolved_address_is_non_public
+    resolver = FakeResolver.new('broker.example.com' => ['203.0.113.10', '10.0.0.1'])
+    fetcher = build_fetcher(resolver: resolver)
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /non-public address/
+  end
+
+  def test_rejects_redirects
+    fetcher = build_fetcher(transport: with_response(FakeResponse.new(code: '302')))
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /redirects are not followed/
+  end
+
+  def test_rejects_disallowed_content_types
+    fetcher = build_fetcher(transport: with_response(FakeResponse.new(content_type: 'text/html')))
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /content type text\/html/
+  end
+
+  def test_content_type_wildcards_match_subtypes
+    fetcher = build_fetcher(
+      allowed_content_types: ['image/*'],
+      transport: with_response(FakeResponse.new(content_type: 'image/webp'))
+    )
+    result = fetcher.fetch('https://broker.example.com/file.webp')
+    assert_equal 'image/webp', result.content_type
+  ensure
+    result&.tempfile&.close!
+  end
+
+  def test_rejects_oversized_content_length
+    response = FakeResponse.new(content_length: '2048')
+    fetcher = build_fetcher(transport: with_response(response))
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /maximum size/
+  end
+
+  def test_rejects_oversized_streamed_bodies_without_content_length
+    response = FakeResponse.new(body_chunks: ['a' * 600, 'b' * 600])
+    fetcher = build_fetcher(transport: with_response(response))
+    assert_rejected fetcher, 'https://broker.example.com/file.png', /maximum size/
+  end
+
+  def test_fetches_allowed_attachments
+    response = FakeResponse.new(
+      content_type: 'application/pdf; charset=binary',
+      body_chunks: ['%PDF', '-1.7']
+    )
+    fetcher = build_fetcher(transport: with_response(response))
+    result = fetcher.fetch('https://broker.example.com/report.pdf')
+    assert_equal 'application/pdf', result.content_type
+    assert_equal '%PDF-1.7', result.tempfile.read
+  ensure
+    result&.tempfile&.close!
+  end
+
+  def test_for_template_allows_the_broker_host_and_configured_hosts
+    template = SubscriptionTemplate.new(broker_url: 'https://broker.example.com:1026/v2')
+    with_settings_hosts("cdn.example.net\nMedia.Example.org") do
+      fetcher = RedmineGttFiware::AttachmentFetcher.for_template(template)
+      hosts = fetcher.instance_variable_get(:@allowed_hosts)
+      assert_equal %w[cdn.example.net media.example.org broker.example.com], hosts
+    end
+  end
+
+  def test_for_template_falls_back_to_default_content_types
+    template = SubscriptionTemplate.new(broker_url: 'https://broker.example.com')
+    with_settings_hosts('') do
+      fetcher = RedmineGttFiware::AttachmentFetcher.for_template(template)
+      types = fetcher.instance_variable_get(:@allowed_content_types)
+      assert_equal RedmineGttFiware::AttachmentFetcher::DEFAULT_CONTENT_TYPES, types
+      assert_not_includes types, 'text/html'
+    end
+  end
+
+  private
+
+  def with_settings_hosts(hosts)
+    saved = Setting.plugin_redmine_gtt_fiware
+    Setting.plugin_redmine_gtt_fiware = saved.merge(
+      'attachment_download_hosts' => hosts,
+      'attachment_download_content_types' => ''
+    )
+    yield
+  ensure
+    Setting.plugin_redmine_gtt_fiware = saved
+  end
+end


### PR DESCRIPTION
Closes #59

## Problem

`SubscriptionIssuesController#handle_attachments` downloaded any `attachments[].url` from the notification payload with `Net::HTTP.get_response` — any scheme, any host, no timeouts, no size or content-type limits. Anyone able to reach the notification endpoint could make the Redmine server fetch internal URLs (SSRF), e.g. cloud metadata services or services on the internal network.

## Changes

Downloads now go through a new `RedmineGttFiware::AttachmentFetcher`, which enforces:

- **https only** — `http`, `file`, `ftp` etc. are rejected before any network activity.
- **Host allowlist** — the subscription template's broker host, plus any hosts configured in the new plugin setting *Additional allowed hosts*.
- **Public addresses only** — every address the host resolves to must be public (private, loopback, link-local, CGNAT, benchmark, multicast, unspecified, NAT64 and IPv4-mapped ranges are rejected). The TCP connection is pinned to the vetted IP (`Net::HTTP#ipaddr`) so a DNS rebind between check and request cannot redirect the fetch.
- **No redirects** — only 2xx responses are accepted.
- **Timeouts** — 5s connect / 10s read.
- **Content-type allowlist** — new plugin setting with wildcard support (`image/*`); defaults to images, PDF, plain text, CSV and JSON. The stored content type is the one the server responded with; a type claimed in the notification payload is no longer trusted.
- **Size cap** — the body is streamed and aborted once it exceeds Redmine's `attachment_max_size` (25 MB hard fallback when that is set to unlimited).

Rejected attachments are skipped and logged; the issue itself is still created/updated, so one bad attachment does not fail the whole notification.

Also adds the settings UI (EN/JA/DE locales) and documents the restrictions in `doc/subscription_template.md`.

## Tests

- `test/unit/attachment_fetcher_test.rb` — every rejection path (scheme, invalid URI, host, DNS-empty, each blocked address class, any-address-blocked, redirect, content type, declared and streamed size) plus wildcard matching, the happy path, and `for_template` settings wiring. DNS and HTTP are injected, no network access.
- `test/functional/subscription_issues_controller_test.rb` — first functional suite (auto-activates in CI): endpoint auth (404/403), issue creation, and end-to-end rejection of non-https URLs, non-allowlisted hosts, and hosts resolving to non-public addresses; happy path with a stubbed fetcher.
- Standalone smoke run of all fetcher paths passed locally; full suite runs in CI.

## Notes for review

- The SSRF check found a subtlety worth knowing about: `IPAddr#include?` maps IPv4 addresses into IPv6 space when compared against IPv6 ranges, which would have blocked *every* IPv4 address via `::ffff:0:0/96`. The fetcher unwraps IPv4-mapped addresses and compares ranges per family instead (covered by tests).
- Behavior change: attachment URLs must now be https and from the broker host (or configured hosts). Existing templates using other hosts need those hosts added in the plugin settings.