### PR TITLE
Phase 0: escape user-controlled values in subscription template JS views

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -87,18 +87,21 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def publish
-    handle_publish_unpublish('publish', l(:subscription_published), 'publish.js.erb')
+    handle_publish_unpublish('publish', l(:subscription_published), 'publish')
   end
 
   def unpublish
     broker_url = URI(@subscription_template.broker_url)
     version_path = broker_url.path.match(/\/v2\.\d+\//) ? broker_url.path : "/v2/"
     @broker_url = broker_url.merge("#{version_path}subscriptions/#{@subscription_template.subscription_id}").to_s
-    handle_publish_unpublish('unpublish', l(:subscription_unpublished), 'unpublish.js.erb')
+    handle_publish_unpublish('unpublish', l(:subscription_unpublished), 'unpublish')
   end
 
   private
 
+  # js_template is the template basename (e.g. 'publish'); Rails resolves it
+  # to <name>.js.erb for the js format. Passing the full 'publish.js.erb'
+  # filename here makes Rails look for publish.js.erb.js and 404.
   def handle_publish_unpublish(action, success_message, js_template)
     prepare_payload if action == 'publish'
 

--- a/app/views/subscription_templates/copy.js.erb
+++ b/app/views/subscription_templates/copy.js.erb
@@ -1,14 +1,14 @@
 // Build the cURL command with line breaks and formatted JSON
-var jsonPayload = JSON.parse('<%= @json_payload.html_safe %>');
+var jsonPayload = JSON.parse('<%= raw j(@json_payload) %>');
 var prettifiedJson = JSON.stringify(jsonPayload, null, 2);
 
-var command = "curl -i -X POST '<%= @broker_url %>' \\\n" +
+var command = "curl -i -X POST '<%= raw j(@broker_url) %>' \\\n" +
                 "-H 'Content-Type: application/json' \\\n" +
                 <% if @subscription_template&.fiware_service&.present? %>
-                "-H 'Fiware-Service: <%= @subscription_template.fiware_service %>' \\\n" +
+                "-H 'Fiware-Service: <%= raw j(@subscription_template.fiware_service) %>' \\\n" +
                 <% end %>
                 <% if @subscription_template&.fiware_servicepath&.present? %>
-                "-H 'Fiware-ServicePath: <%= @subscription_template.fiware_servicepath %>' \\\n" +
+                "-H 'Fiware-ServicePath: <%= raw j(@subscription_template.fiware_servicepath) %>' \\\n" +
                 <% end %>
                 "--data-binary '" + prettifiedJson + "'";
 

--- a/app/views/subscription_templates/publish.js.erb
+++ b/app/views/subscription_templates/publish.js.erb
@@ -3,11 +3,11 @@ var headers = new Headers();
 headers.append('Content-Type', 'application/json');
 
 <% if @subscription_template.fiware_service.present? %>
-  headers.append('Fiware-Service', '<%= @subscription_template.fiware_service %>');
+  headers.append('Fiware-Service', '<%= raw j(@subscription_template.fiware_service) %>');
 <% end %>
 
 <% if @subscription_template.fiware_servicepath.present? %>
-  headers.append('Fiware-ServicePath', '<%= @subscription_template.fiware_servicepath %>');
+  headers.append('Fiware-ServicePath', '<%= raw j(@subscription_template.fiware_servicepath) %>');
 <% end %>
 
 var authToken = document.getElementById('subscription_auth_token').value;
@@ -19,18 +19,18 @@ if (authToken) {
 var requestOptions = {
   method: 'POST',
   headers: headers,
-  body: '<%= @json_payload.html_safe %>',
+  body: '<%= raw j(@json_payload) %>',
   redirect: 'follow'
 };
 
 // Send the POST request
-fetch('<%= @broker_url %>', requestOptions)
+fetch('<%= raw j(@broker_url) %>', requestOptions)
   .then(response => {
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error("<%= l(:subscription_unauthorized_error) %>");
+        throw new Error("<%= raw j(l(:subscription_unauthorized_error)) %>");
       } else {
-        throw new Error("<%= l(:subscription_published_error) %>");
+        throw new Error("<%= raw j(l(:subscription_published_error)) %>");
       }
     }
 
@@ -66,7 +66,7 @@ fetch('<%= @broker_url %>', requestOptions)
     subscriptionTemplateList.innerHTML = result;
 
     // Show success notification
-    showNotification("<%= l(:subscription_published) %>");
+    showNotification("<%= raw j(l(:subscription_published)) %>");
   })
   .catch(error => {
     console.log('error', error);

--- a/app/views/subscription_templates/unpublish.js.erb
+++ b/app/views/subscription_templates/unpublish.js.erb
@@ -2,11 +2,11 @@
 var headers = new Headers();
 
 <% if @subscription_template.fiware_service.present? %>
-  headers.append('Fiware-Service', '<%= @subscription_template.fiware_service %>');
+  headers.append('Fiware-Service', '<%= raw j(@subscription_template.fiware_service) %>');
 <% end %>
 
 <% if @subscription_template.fiware_servicepath.present? %>
-  headers.append('Fiware-ServicePath', '<%= @subscription_template.fiware_servicepath %>');
+  headers.append('Fiware-ServicePath', '<%= raw j(@subscription_template.fiware_servicepath) %>');
 <% end %>
 
 var authToken = document.getElementById('subscription_auth_token').value;
@@ -22,13 +22,13 @@ var deleteRequestOptions = {
 };
 
 // Send the DELETE request to the Orion broker
-fetch('<%= @broker_url %>', deleteRequestOptions)
+fetch('<%= raw j(@broker_url) %>', deleteRequestOptions)
   .then(response => {
     if (!response.ok) {
       console.warn('Warning: Network response was not ok');
-      showNotification("<%= l(:subscription_unpublished_warning) %>");
+      showNotification("<%= raw j(l(:subscription_unpublished_warning)) %>");
     } else {
-      showNotification("<%= l(:subscription_unpublished) %>");
+      showNotification("<%= raw j(l(:subscription_unpublished)) %>");
     }
 
     // Send the PATCH request to update the subscription_id

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -1,0 +1,64 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class SubscriptionTemplatesControllerTest < ActionController::TestCase
+  fixtures :projects, :trackers, :issue_statuses, :users, :email_addresses,
+           :members, :member_roles, :roles, :enumerations, :enabled_modules
+
+  # A value that would break out of a single-quoted JavaScript string if
+  # rendered unescaped.
+  INJECTION = "'};alert('xss');//".freeze
+  ESCAPED_INJECTION = "\\'};alert(\\'xss\\');//".freeze
+
+  def setup
+    @project = Project.find(1)
+    @project.enabled_module_names = @project.enabled_module_names | ['gtt_fiware']
+    Role.find(1).add_permission!(:manage_subscription_templates)
+
+    @template = SubscriptionTemplate.create!(
+      standard: 'NGSIv2',
+      status: 'active',
+      name: 'Escaping test',
+      broker_url: 'https://broker.example.com',
+      subject: "Sensor #{INJECTION}",
+      description: "Desc #{INJECTION}",
+      notes: "Note #{INJECTION}",
+      fiware_service: "smart'city",
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      project_id: 1,
+      tracker_id: 1,
+      issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id,
+      member_id: 1
+    )
+    @request.session[:user_id] = 2 # jsmith, manager of project 1
+  end
+
+  def test_publish_escapes_the_json_payload
+    get :publish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    assert_response :success
+    assert_not_includes response.body, INJECTION
+    assert_includes response.body, ESCAPED_INJECTION
+  end
+
+  def test_publish_escapes_the_fiware_service_header
+    get :publish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    assert_response :success
+    assert_not_includes response.body, "'smart'city'"
+    assert_includes response.body, "smart\\'city"
+  end
+
+  def test_unpublish_escapes_the_fiware_service_header
+    @template.update_column(:subscription_id, 'sub-1')
+    get :unpublish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    assert_response :success
+    assert_not_includes response.body, "'smart'city'"
+    assert_includes response.body, "smart\\'city"
+  end
+
+  def test_copy_escapes_the_json_payload
+    get :copy, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    assert_response :success
+    assert_not_includes response.body, INJECTION
+    assert_includes response.body, ESCAPED_INJECTION
+  end
+end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -34,14 +34,14 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
   end
 
   def test_publish_escapes_the_json_payload
-    get :publish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    get :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, INJECTION
     assert_includes response.body, ESCAPED_INJECTION
   end
 
   def test_publish_escapes_the_fiware_service_header
-    get :publish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    get :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, "'smart'city'"
     assert_includes response.body, "smart\\'city"
@@ -49,14 +49,14 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
 
   def test_unpublish_escapes_the_fiware_service_header
     @template.update_column(:subscription_id, 'sub-1')
-    get :unpublish, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    get :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, "'smart'city'"
     assert_includes response.body, "smart\\'city"
   end
 
   def test_copy_escapes_the_json_payload
-    get :copy, params: { project_id: @project.id, id: @template.id }, format: 'js'
+    get :copy, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, INJECTION
     assert_includes response.body, ESCAPED_INJECTION


### PR DESCRIPTION
Closes #62

## Problem

`publish.js.erb` interpolated `@json_payload` with `.html_safe` inside a single-quoted JavaScript string, and `copy.js.erb` did the same inside `JSON.parse('...')`. The payload embeds user-controlled template fields (subject, description, notes, entities, attrs, expression fields), so a value containing a single quote breaks out of the JS string context and executes arbitrary JavaScript in the browser of whoever clicks publish/unpublish/copy. The `Fiware-Service` / `Fiware-ServicePath` headers and the broker URL were interpolated into JS strings unescaped as well.

## Changes

- All interpolations inside JavaScript strings in `publish.js.erb`, `unpublish.js.erb` and `copy.js.erb` now go through `escape_javascript` (`raw j(...)`), including locale strings for consistency.
- `raw` is required because these are pure JavaScript responses: ERB's output buffer would otherwise HTML-entity-escape the already backslash-escaped output (this is also why the original code reached for `html_safe`).
- **Bonus bug fix (surfaced by the tests):** `handle_publish_unpublish` was called with the full `'publish.js.erb'` / `'unpublish.js.erb'` filename, so `render js_template` looked for `publish.js.erb.js` and returned 404. Rails wants the template *basename* (`'publish'`). This path only runs in the non-proxy configuration (`connect_via_proxy = false`), which is why it went unnoticed. Fixed to pass the basename.

## Tests

`test/functional/subscription_templates_controller_test.rb` renders `publish`, `unpublish` and `copy` with template fields containing a `'};alert('xss');//` payload and a `smart'city` FIWARE service, asserting the raw breakout string is absent from the response and the escaped form is present. Requests are issued as XHR, matching how the real UI invokes these endpoints (a plain GET to a `.js` action is blocked by Rails' cross-origin JavaScript protection).

**Verified locally** against a real RedMica 6.1 + redmine_gtt + PostGIS stack (throwaway test DB): all 4 functional tests green, 12 unit tests still green.

## Notes for review

- This overlaps with #61 (converting these GET routes to POST) only in the actions touched; the escaping fix is independent and the tests will carry over.
- The render-basename fix means publish/unpublish now actually work in the non-proxy configuration; previously they 404'd.