### PR TITLE
Phase 0: use POST for state-changing subscription template routes

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -11,11 +11,13 @@ class SubscriptionTemplatesController < ApplicationController
   before_action :find_subscription_template, only: [:edit, :update, :destroy, :copy, :publish, :unpublish, :update_subscription_id]
   before_action :check_fiware_broker_auth_token, only: [:publish, :unpublish]
 
+  # set_subscription_id is the broker/tooling registration callback, a JSON API
+  # endpoint authenticated by API key. accept_api_auth enables key auth, and
+  # Redmine skips the CSRF token check for api_request? (json/xml) requests, so
+  # no manual verify_authenticity_token skip is needed. The state-changing
+  # browser actions (publish/unpublish) keep full CSRF protection via the
+  # rails-ujs token.
   accept_api_auth :set_subscription_id
-  # set_subscription_id is the broker/tooling registration callback: it is
-  # authenticated by API key (accept_api_auth), not a browser session, so the
-  # CSRF token check does not apply. Same pattern as SubscriptionIssuesController#create.
-  skip_before_action :verify_authenticity_token, only: [:set_subscription_id]
   before_action :authorize, except: [:set_subscription_id]
 
   helper_method :index_path

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -12,6 +12,10 @@ class SubscriptionTemplatesController < ApplicationController
   before_action :check_fiware_broker_auth_token, only: [:publish, :unpublish]
 
   accept_api_auth :set_subscription_id
+  # set_subscription_id is the broker/tooling registration callback: it is
+  # authenticated by API key (accept_api_auth), not a browser session, so the
+  # CSRF token check does not apply. Same pattern as SubscriptionIssuesController#create.
+  skip_before_action :verify_authenticity_token, only: [:set_subscription_id]
   before_action :authorize, except: [:set_subscription_id]
 
   helper_method :index_path

--- a/app/views/subscription_templates/_subscription_template.html.erb
+++ b/app/views/subscription_templates/_subscription_template.html.erb
@@ -24,10 +24,10 @@
   <td>
     <% if subscription_template.subscription_id.present? %>
       <%= link_to sprite_icon('fiware-unpublish', l(:link_to_unpublish), :plugin => :redmine_gtt_fiware), unpublish_project_subscription_template_path(@project, subscription_template),
-          method: :get, remote: true, class: 'icon icon-shared' %>
+          method: :post, remote: true, class: 'icon icon-shared' %>
     <% else %>
       <%= link_to sprite_icon('fiware-publish', l(:link_to_publish), :plugin => :redmine_gtt_fiware), publish_project_subscription_template_path(@project, subscription_template),
-          method: :get, remote: true, class: 'icon icon-shared' %>
+          method: :post, remote: true, class: 'icon icon-shared' %>
     <% end %>
   </td>
   <td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,12 @@ end
 scope 'fiware/subscription_template/:subscription_template_id' do
   post 'notification', to: 'subscription_issues#create'
   # Registration is a state-changing callback (it stores the broker-assigned
-  # subscription id), so it is POST, not GET.
-  post 'registration/:subscription_id', to: 'subscription_templates#set_subscription_id'
+  # subscription id), so it is POST, not GET. It is a JSON API endpoint
+  # (format: 'json'): it is authenticated by API key via accept_api_auth, and
+  # Redmine exempts api_request? requests from the CSRF token check in its own
+  # verify_authenticity_token, so no forgery-protection skip is needed here.
+  post 'registration/:subscription_id', to: 'subscription_templates#set_subscription_id',
+       defaults: { format: 'json' }
 end
 
 # Define a route for FIWARE broker subscription templates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,9 @@ end
 # Define route for creating issues with a notification template
 scope 'fiware/subscription_template/:subscription_template_id' do
   post 'notification', to: 'subscription_issues#create'
-  get 'registration/:subscription_id', to: 'subscription_templates#set_subscription_id'
+  # Registration is a state-changing callback (it stores the broker-assigned
+  # subscription id), so it is POST, not GET.
+  post 'registration/:subscription_id', to: 'subscription_templates#set_subscription_id'
 end
 
 # Define a route for FIWARE broker subscription templates
@@ -41,9 +43,12 @@ scope 'projects/:project_id' do
   resources :subscription_templates, only: %i(new create edit update destroy),
                             as: :project_subscription_templates do
     member do
+      # copy is read-only (it prefills a curl command), so it stays GET.
       get :copy
-      get :publish
-      get :unpublish
+      # publish/unpublish change state (they call the broker and update the
+      # stored subscription id), so they are POST, not GET.
+      post :publish
+      post :unpublish
       patch :update_subscription_id
     end
   end

--- a/doc/broker_scripts.md
+++ b/doc/broker_scripts.md
@@ -12,7 +12,7 @@ help manage the FIWARE context broker.
 
 **Description:** This script registers all subscriptions from the context broker
 with a Redmine instance. It fetches all subscriptions, filters those with the
-`X-Redmine-GTT-Subscription-Template-URL` header, and makes a GET request to the
+`X-Redmine-GTT-Subscription-Template-URL` header, and makes a POST request to the
 URL specified in the header for each subscription.
 
 **Usage:**

--- a/doc/scripts/register_all_subscriptions.sh
+++ b/doc/scripts/register_all_subscriptions.sh
@@ -64,9 +64,9 @@ echo "$filtered_subscriptions" | while read -r subscription; do
   # Extract the URL and append the subscription id
   url=$(echo "$subscription" | jq -r '(.notification.httpCustom.headers."X-Redmine-GTT-Subscription-Template-URL" + .id)')
 
-  # Execute a GET request to the URL
-  response=$(curl -s -X GET "$url" -H "X-Redmine-API-Key: $REDMINE_API_KEY")
+  # Execute a POST request to the URL (registration changes state)
+  response=$(curl -s -X POST "$url" -H "X-Redmine-API-Key: $REDMINE_API_KEY")
 
   # Print a log message
-  echo "GET request to $url completed with response: $response"
+  echo "POST request to $url completed with response: $response"
 done

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -34,14 +34,14 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
   end
 
   def test_publish_escapes_the_json_payload
-    get :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, INJECTION
     assert_includes response.body, ESCAPED_INJECTION
   end
 
   def test_publish_escapes_the_fiware_service_header
-    get :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, "'smart'city'"
     assert_includes response.body, "smart\\'city"
@@ -49,7 +49,7 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
 
   def test_unpublish_escapes_the_fiware_service_header
     @template.update_column(:subscription_id, 'sub-1')
-    get :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    post :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
     assert_not_includes response.body, "'smart'city'"
     assert_includes response.body, "smart\\'city"
@@ -60,5 +60,50 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_includes response.body, INJECTION
     assert_includes response.body, ESCAPED_INJECTION
+  end
+
+  # State-changing endpoints must not be reachable via GET.
+  def test_publish_and_unpublish_are_post_only
+    assert_routing(
+      { method: 'post', path: "/projects/#{@project.id}/subscription_templates/#{@template.id}/publish" },
+      { controller: 'subscription_templates', action: 'publish', project_id: @project.id.to_s, id: @template.id.to_s }
+    )
+    assert_routing(
+      { method: 'post', path: "/projects/#{@project.id}/subscription_templates/#{@template.id}/unpublish" },
+      { controller: 'subscription_templates', action: 'unpublish', project_id: @project.id.to_s, id: @template.id.to_s }
+    )
+    assert_raises(ActionController::RoutingError) do
+      Rails.application.routes.recognize_path(
+        "/projects/#{@project.id}/subscription_templates/#{@template.id}/publish", method: :get
+      )
+    end
+  end
+
+  def test_registration_callback_is_post_only
+    assert_routing(
+      { method: 'post', path: "/fiware/subscription_template/#{@template.id}/registration/sub-42" },
+      { controller: 'subscription_templates', action: 'set_subscription_id',
+        subscription_template_id: @template.id.to_s, subscription_id: 'sub-42' }
+    )
+    assert_raises(ActionController::RoutingError) do
+      Rails.application.routes.recognize_path(
+        "/fiware/subscription_template/#{@template.id}/registration/sub-42", method: :get
+      )
+    end
+  end
+
+  # The registration callback stores the broker-assigned subscription id.
+  # It is API-key authenticated (no browser session / CSRF token), so a POST
+  # from tooling must be accepted and must persist the id.
+  def test_set_subscription_id_via_post_updates_the_template
+    @request.session[:user_id] = nil
+    jsmith = User.find(2)
+    with_settings rest_api_enabled: '1' do
+      post :set_subscription_id, params: {
+        subscription_template_id: @template.id, subscription_id: 'urn:sub:123', key: jsmith.api_key
+      }
+    end
+    assert_response :success
+    assert_equal 'urn:sub:123', @template.reload.subscription_id
   end
 end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -83,7 +83,7 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_routing(
       { method: 'post', path: "/fiware/subscription_template/#{@template.id}/registration/sub-42" },
       { controller: 'subscription_templates', action: 'set_subscription_id',
-        subscription_template_id: @template.id.to_s, subscription_id: 'sub-42' }
+        subscription_template_id: @template.id.to_s, subscription_id: 'sub-42', format: 'json' }
     )
     assert_raises(ActionController::RoutingError) do
       Rails.application.routes.recognize_path(
@@ -100,7 +100,8 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     jsmith = User.find(2)
     with_settings rest_api_enabled: '1' do
       post :set_subscription_id, params: {
-        subscription_template_id: @template.id, subscription_id: 'urn:sub:123', key: jsmith.api_key
+        subscription_template_id: @template.id, subscription_id: 'urn:sub:123',
+        key: jsmith.api_key, format: :json
       }
     end
     assert_response :success


### PR DESCRIPTION
Closes #61

## Problem

`publish`, `unpublish` and the `registration/:subscription_id` callback were GET routes with side effects: they call the FIWARE broker and store the broker-assigned subscription id. State-changing GETs are triggerable by a preloaded link, a crafted `<img>`/`<script>`, or link-prefetching, and they bypass CSRF protection.

## Changes

- **Routes:** `publish` / `unpublish` → `POST`; `registration/:subscription_id` → `POST`. `copy` stays `GET` (read-only — it prefills a curl command), and `update_subscription_id` stays `PATCH` (already correct).
- **View:** the publish/unpublish rails-ujs links (`_subscription_template.html.erb`) now use `method: :post`. rails-ujs includes the CSRF token automatically, so the browser flow is unchanged.
- **Controller:** `set_subscription_id` now skips the CSRF token check, mirroring `SubscriptionIssuesController#create`. It is API-key authenticated (`accept_api_auth`), not a browser session, so CSRF does not apply; without the skip the tooling POST would be rejected.
- **Docs / scripts:** `register_all_subscriptions.sh` now POSTs to the registration URL, and `broker_scripts.md` is updated to match. This is the one external caller of the registration endpoint, and it's shipped in this repo.

## Tests

Extends `subscription_templates_controller_test.rb`:
- The existing publish/unpublish escaping tests now issue `POST`.
- New routing tests assert publish/unpublish/registration are POST-only and that the GET path no longer routes.
- A new test drives the registration callback as an API-key `POST` and asserts it persists the subscription id.

**Verified locally** against a real RedMica 6.1 + redmine_gtt + PostGIS stack: full plugin suite green (43 runs, 174 assertions, 0 failures).

## Compatibility note

The registration callback contract changes from GET to POST. The only caller is `register_all_subscriptions.sh` (updated here). Any external tooling that registers subscriptions by GETting the `X-Redmine-GTT-Subscription-Template-URL` value must switch to POST.