### PR TITLE
Phase 0: authenticate notifications with a per-template webhook secret

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -4,10 +4,15 @@ require 'rack'
 # This controller handles the creation of issues from subscription templates.
 class SubscriptionIssuesController < ApplicationController
 
-  # Before actions
-  before_action :find_template_and_authorize
+  # The notification endpoint is a machine callback authenticated solely by the
+  # template's webhook secret (see #58), not by a Redmine session or API key.
+  # Skip the CSRF token check and the global login requirement, then
+  # authenticate on the secret and act as the template's configured member.
   skip_before_action :verify_authenticity_token, only: [:create]
-  accept_api_auth :create
+  skip_before_action :check_if_login_required, only: [:create]
+  before_action :authenticate_webhook, only: [:create]
+
+  WEBHOOK_SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
 
   # Creates a new issue or updates an existing one based on the provided parameters.
   def create
@@ -26,13 +31,24 @@ class SubscriptionIssuesController < ApplicationController
 
   private
 
-  # Finds the subscription template and checks if the current user is authorized to create issues.
-  def find_template_and_authorize
+  # Authenticates the notification on the template's webhook secret, then acts
+  # as the template's configured member for the rest of the request.
+  #
+  # A missing template and a wrong/absent secret both return an identical 401
+  # so the endpoint never reveals whether a given template id exists. The
+  # secret is compared in constant time (SubscriptionTemplate#valid_webhook_secret?).
+  def authenticate_webhook
     @subscription_template = SubscriptionTemplate.find_by(id: params[:subscription_template_id])
-    unless @subscription_template
-      render json: { error: 'Subscription template not found' }, status: :not_found
+    provided_secret = request.headers[WEBHOOK_SECRET_HEADER].to_s
+
+    unless @subscription_template && @subscription_template.valid_webhook_secret?(provided_secret)
+      render json: { error: 'Unauthorized' }, status: :unauthorized
       return
     end
+
+    # Act as the configured member. The issue is authored by this user and all
+    # downstream permission checks (visibility, custom fields) use it.
+    User.current = @subscription_template.member.user
 
     unless User.current.allowed_to?(:add_issues, @subscription_template.project)
       render json: { error: 'Not authorized to create issues' }, status: :forbidden

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -93,6 +93,9 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def publish
+    # Rotate the webhook secret so each publish sends the broker a fresh
+    # credential; prepare_payload (below) then embeds the new value.
+    @subscription_template.rotate_webhook_secret!
     handle_publish_unpublish('publish', l(:subscription_published), 'publish')
   end
 
@@ -139,13 +142,15 @@ class SubscriptionTemplatesController < ApplicationController
     version_path = broker_url.path.match(/\/v2\.\d+\//) ? broker_url.path : "/v2/"
     @broker_url = broker_url.merge("#{version_path}subscriptions").to_s
     @entity_url = broker_url.merge("#{version_path}entities").to_s
-    @member = Member.find(@subscription_template.member_id)
 
     http_custom = {
       url: URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/notification").to_s,
       headers: {
         "Content-Type" => "application/json",
-        "X-Redmine-API-Key" => User.find(@member.user_id).api_key,
+        # Per-template webhook secret, NOT a Redmine API key: it authenticates
+        # the notification and grants nothing beyond creating issues from this
+        # template (see #58). Rotated on every publish.
+        "X-Gtt-Webhook-Secret" => @subscription_template.webhook_secret,
         "X-Redmine-GTT-Subscription-Template-URL" => URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/registration/").to_s
       },
       method: "POST",

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -1,8 +1,18 @@
+require 'securerandom'
+require 'active_support/security_utils'
+
 class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   self.table_name = "fiware_subscription_templates"
 
+  # Number of random bytes for the per-template webhook secret. The broker
+  # stores this secret and sends it back on every notification; the
+  # notification endpoint authenticates on it alone (no Redmine API key is
+  # ever embedded in a broker payload). See #58.
+  WEBHOOK_SECRET_BYTES = 32
+
   after_initialize :set_default_alteration_types, if: :new_record?
   after_initialize :set_default_notify_on_metadata_change, if: :new_record?
+  before_create :ensure_webhook_secret
 
   belongs_to :project, optional: false
   belongs_to :tracker, optional: false
@@ -37,6 +47,26 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
 
   before_save :serialize_alteration_types
   after_find :deserialize_alteration_types
+
+  def self.generate_webhook_secret
+    SecureRandom.hex(WEBHOOK_SECRET_BYTES)
+  end
+
+  # Assign a fresh secret and persist it. Called on each (re)publish so the
+  # credential the broker holds is rotated every time the subscription is sent.
+  def rotate_webhook_secret!
+    update_column(:webhook_secret, self.class.generate_webhook_secret)
+  end
+
+  # Constant-time comparison of a provided secret against the stored one.
+  # Returns false (never raises) for a blank stored or provided secret.
+  def valid_webhook_secret?(provided)
+    provided = provided.to_s
+    secret = webhook_secret.to_s
+    return false if secret.empty? || provided.empty?
+
+    ActiveSupport::SecurityUtils.secure_compare(secret, provided)
+  end
 
   attr_accessor :threshold_create_hours
   # Override the getter for threshold_create_hours
@@ -126,5 +156,9 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     if scope.any?
       errors.add :name, I18n.t('model.subscription_template.name_uniqueness')
     end
+  end
+
+  def ensure_webhook_secret
+    self.webhook_secret = self.class.generate_webhook_secret if webhook_secret.blank?
   end
 end

--- a/db/migrate/20260723000000_add_webhook_secret_to_subscription_templates.rb
+++ b/db/migrate/20260723000000_add_webhook_secret_to_subscription_templates.rb
@@ -1,0 +1,5 @@
+class AddWebhookSecretToSubscriptionTemplates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fiware_subscription_templates, :webhook_secret, :string
+  end
+end

--- a/doc/subscription_template.md
+++ b/doc/subscription_template.md
@@ -146,9 +146,11 @@ be created or updated based on the subscription notifications.
   the project settings.
 - **Version**: Specify the version. Versions can be created in the project settings.
 - **Sent from user**: Select the user from whom the issue is sent. The user must
-  have the necessary permissions to create issues in this project. However, **for
-  security reasons the user should not have administrator rights**, because its
-  API key is stored in the subscription template.
+  have the necessary permissions to create issues in this project. Notifications
+  from the broker are authenticated by a per-template webhook secret (rotated on
+  every publish), not by this user's Redmine API key, so no Redmine credential is
+  stored on the broker. Still, **for security reasons prefer a dedicated,
+  non-administrator user** for this role.
 - **Private**: Check if the issue should be marked *private*.
 
 ## Applying Settings

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -5,6 +5,8 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
            :users, :email_addresses, :members, :member_roles, :roles,
            :enumerations, :issues, :journals
 
+  SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
+
   def setup
     @template = SubscriptionTemplate.create!(
       standard: 'NGSIv2',
@@ -18,9 +20,8 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
       tracker_id: 1,
       issue_status_id: 1,
       issue_priority_id: IssuePriority.first.id,
-      member_id: 1
+      member_id: 1 # jsmith on project 1 (Manager)
     )
-    @request.session[:user_id] = 2 # jsmith, manager of project 1
   end
 
   def notification_params(overrides = {})
@@ -32,39 +33,63 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     }.merge(overrides)
   end
 
-  def test_create_returns_404_for_unknown_template
-    post :create, params: notification_params(subscription_template_id: 987654)
-    assert_response :not_found
+  # Posts a notification with the given webhook secret in the request header.
+  def post_notification(params = notification_params, secret: @template.webhook_secret)
+    @request.headers[SECRET_HEADER] = secret unless secret.nil?
+    post :create, params: params
   end
 
-  def test_create_requires_add_issues_permission
-    @request.session[:user_id] = nil
-    # Builtin roles may grant add_issues on public projects; strip it so
-    # the anonymous request is unauthorized regardless of fixture details.
-    Role.all.each { |role| role.remove_permission!(:add_issues) }
+  def test_create_rejects_a_missing_secret
     assert_no_difference 'Issue.count' do
-      post :create, params: notification_params
+      post_notification(notification_params, secret: nil)
     end
-    assert_response :forbidden
+    assert_response :unauthorized
   end
 
-  def test_create_creates_an_issue
+  def test_create_rejects_a_wrong_secret
+    assert_no_difference 'Issue.count' do
+      post_notification(notification_params, secret: 'not-the-secret')
+    end
+    assert_response :unauthorized
+  end
+
+  # A missing template returns the same 401 as a wrong secret, so the endpoint
+  # never reveals whether a given template id exists.
+  def test_create_does_not_leak_template_existence
+    post_notification(notification_params(subscription_template_id: 987_654), secret: 'anything')
+    assert_response :unauthorized
+    missing_body = @response.body
+
+    post_notification(notification_params, secret: 'wrong-secret')
+    assert_response :unauthorized
+    assert_equal missing_body, @response.body
+  end
+
+  def test_create_creates_an_issue_and_authors_it_as_the_member
     assert_difference 'Issue.count', 1 do
-      post :create, params: notification_params
+      post_notification
     end
     assert_response :success
     issue = Issue.order(id: :desc).first
     assert_equal 'Sensor urn:ngsi-ld:TemperatureSensor:001', issue.subject
     assert_equal 'urn:ngsi-ld:TemperatureSensor:001', issue.fiware_entity
     assert_equal @template.id, issue.subscription_template_id
-    assert_equal @template.project, issue.project
+    assert_equal @template.member.user_id, issue.author_id
+  end
+
+  def test_create_rejects_when_the_member_cannot_add_issues
+    Role.all.each { |role| role.remove_permission!(:add_issues) }
+    assert_no_difference 'Issue.count' do
+      post_notification
+    end
+    assert_response :forbidden
   end
 
   def test_create_skips_attachments_with_non_https_urls
     assert_difference 'Issue.count', 1 do
-      post :create, params: notification_params(
+      post_notification(notification_params(
         attachments: [{ url: 'http://169.254.169.254/latest/meta-data', filename: 'meta.txt' }]
-      )
+      ))
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
@@ -72,30 +97,28 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
 
   def test_create_skips_attachments_from_hosts_not_on_the_allowlist
     assert_difference 'Issue.count', 1 do
-      post :create, params: notification_params(
+      post_notification(notification_params(
         attachments: [{ url: 'https://evil.example.org/file.png', filename: 'file.png' }]
-      )
+      ))
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
   end
 
   def test_create_skips_attachments_resolving_to_non_public_addresses
-    # localhost is allowlisted via the broker URL here, but resolves to a
-    # loopback address, so the download must still be rejected.
     @template.update_column(:broker_url, 'https://localhost')
     assert_difference 'Issue.count', 1 do
-      post :create, params: notification_params(
+      post_notification(notification_params(
         attachments: [{ url: 'https://localhost/file.png', filename: 'file.png' }]
-      )
+      ))
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
   end
 
-  # Fake fetcher that returns a canned result without any network access.
-  # Stubbed in via the AttachmentFetcher.for_template factory (Mocha, which
-  # Redmine's own test harness loads) rather than any_instance.
+  # Fake fetcher returning a canned result without any network access, stubbed
+  # in via the AttachmentFetcher.for_template factory (Mocha, loaded by
+  # Redmine's test harness).
   class FakeFetcher
     def initialize(result)
       @result = result
@@ -118,17 +141,15 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     RedmineGttFiware::AttachmentFetcher.stubs(:for_template).returns(FakeFetcher.new(result))
 
     assert_difference 'Issue.count', 1 do
-      post :create, params: notification_params(
+      post_notification(notification_params(
         attachments: [{ url: 'https://broker.example.com/photo.png', filename: 'photo.png' }]
-      )
+      ))
     end
-
     assert_response :success
     issue = Issue.order(id: :desc).first
     assert_equal 1, issue.attachments.count
-    attachment = issue.attachments.first
-    assert_equal 'photo.png', attachment.filename
-    assert_equal 'image/png', attachment.content_type
+    assert_equal 'photo.png', issue.attachments.first.filename
+    assert_equal 'image/png', issue.attachments.first.content_type
   ensure
     tempfile&.close!
   end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -40,6 +40,23 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_includes response.body, ESCAPED_INJECTION
   end
 
+  # The broker payload must carry the per-template webhook secret and must never
+  # embed a Redmine API key.
+  def test_publish_embeds_the_webhook_secret_and_no_api_key
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_includes response.body, 'X-Gtt-Webhook-Secret'
+    assert_includes response.body, @template.reload.webhook_secret
+    assert_not_includes response.body, 'X-Redmine-API-Key'
+  end
+
+  def test_publish_rotates_the_webhook_secret
+    original = @template.webhook_secret
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_not_equal original, @template.reload.webhook_secret
+  end
+
   def test_publish_escapes_the_fiware_service_header
     post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -90,4 +90,33 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_not template.valid?
     assert template.errors[:base].present?
   end
+
+  def test_generates_a_webhook_secret_on_create
+    template = SubscriptionTemplate.create!(valid_attributes)
+    assert_not_nil template.webhook_secret
+    assert_equal 64, template.webhook_secret.length # SecureRandom.hex(32)
+  end
+
+  def test_rotate_webhook_secret_changes_and_persists_it
+    template = SubscriptionTemplate.create!(valid_attributes)
+    original = template.webhook_secret
+    template.rotate_webhook_secret!
+    assert_not_equal original, template.webhook_secret
+    assert_equal template.webhook_secret, template.reload.webhook_secret
+  end
+
+  def test_valid_webhook_secret_matches_only_the_stored_secret
+    template = SubscriptionTemplate.create!(valid_attributes)
+    assert template.valid_webhook_secret?(template.webhook_secret)
+    assert_not template.valid_webhook_secret?('wrong')
+    assert_not template.valid_webhook_secret?('')
+    assert_not template.valid_webhook_secret?(nil)
+  end
+
+  def test_valid_webhook_secret_is_false_when_no_secret_is_stored
+    template = SubscriptionTemplate.new(valid_attributes)
+    template.webhook_secret = nil
+    assert_not template.valid_webhook_secret?('anything')
+    assert_not template.valid_webhook_secret?(nil)
+  end
 end


### PR DESCRIPTION
Closes #58

## Problem

Publishing a subscription embedded the template member's **full Redmine API key** in the broker payload (`httpCustom.headers` → `X-Redmine-API-Key`). The broker then permanently stored a credential granting that user's entire Redmine API surface — far more than the notification endpoint needs, and a serious leak if the broker is compromised.

## Changes

Replace the embedded API key with a per-template **webhook secret**:

- **Model** (`SubscriptionTemplate`): generates a random secret (`SecureRandom.hex(32)`) on create (`before_create`), rotates it on every publish (`rotate_webhook_secret!`), and compares in constant time (`valid_webhook_secret?` → `ActiveSupport::SecurityUtils.secure_compare`, false on blank).
- **Migration**: `add_column :fiware_subscription_templates, :webhook_secret, :string`.
- **Payload** (`prepare_payload`): sends the secret in an `X-Gtt-Webhook-Secret` header; the `X-Redmine-API-Key` header is gone. The `publish` action rotates the secret first so each publish ships a fresh credential.
- **Notification endpoint** (`SubscriptionIssuesController#create`): authenticates on the secret alone — drops `accept_api_auth`, skips `verify_authenticity_token` and the global `check_if_login_required` gate, verifies the secret, then sets `User.current` to the configured member for the rest of the request. A missing template and a wrong/absent secret both return an **identical 401**, so the endpoint never reveals whether a template id exists. A valid secret whose member lacks `add_issues` returns 403.
- **Docs**: the "Sent from user" note no longer claims the API key is stored on the broker.

Carrying the secret via NGSI-LD `notification.endpoint.receiverInfo` is deferred to the NGSI-LD work (Phase 1); this PR handles the NGSIv2 `httpCustom.headers` path that exists today.

## Tests

- **Model**: secret generated on create, rotation changes+persists, constant-time match true/false cases, false when no secret stored.
- **Notification**: missing/wrong/absent secret → 401; missing-vs-wrong responses byte-identical (no existence leak); valid secret creates the issue authored by the member; member without `add_issues` → 403; attachment SSRF paths still hold.
- **Publish**: payload carries the webhook secret and never `X-Redmine-API-Key`; the secret rotates on publish.

**Verified locally** against a real RedMica 6.1 + redmine_gtt + PostGIS stack: full plugin suite green (51 runs, 201 assertions, 0 failures).

## Compatibility

No backwards-compatibility requirement (no known deployments). Operators must republish existing templates so the broker receives the secret; the notification endpoint no longer accepts Redmine API-key auth. Related: #35 (reject unpublish with missing/invalid key) builds on this.