### PR TITLE
Phase 0: keep subscription published when broker unpublish fails

### DIFF
--- a/app/views/subscription_templates/unpublish.js.erb
+++ b/app/views/subscription_templates/unpublish.js.erb
@@ -24,6 +24,10 @@ var deleteRequestOptions = {
 var subscriptionTemplateList = document.getElementById('subscriptionTemplateList');
 
 // Clears the stored subscription id on the Redmine side and refreshes the list.
+// Errors here are handled locally (not re-thrown): by the time this runs the
+// broker has already removed the subscription, so a failure of the Redmine-side
+// PATCH or list refresh must NOT reach the outer catch, which reports a
+// broker-side failure. The promise always resolves.
 function clearSubscriptionId() {
   return fetch('<%= update_subscription_id_project_subscription_template_path(@project, @subscription_template) %>', {
     method: 'PATCH',
@@ -35,7 +39,13 @@ function clearSubscriptionId() {
   })
     .then(response => response.text())
     .then(result => {
-      subscriptionTemplateList.innerHTML = result;
+      if (subscriptionTemplateList) {
+        subscriptionTemplateList.innerHTML = result;
+      }
+    })
+    .catch(error => {
+      // Broker removal already succeeded; only the local update failed.
+      console.log('error updating subscription list', error);
     });
 }
 

--- a/app/views/subscription_templates/unpublish.js.erb
+++ b/app/views/subscription_templates/unpublish.js.erb
@@ -21,30 +21,42 @@ var deleteRequestOptions = {
   redirect: 'follow'
 };
 
+var subscriptionTemplateList = document.getElementById('subscriptionTemplateList');
+
+// Clears the stored subscription id on the Redmine side and refreshes the list.
+function clearSubscriptionId() {
+  return fetch('<%= update_subscription_id_project_subscription_template_path(@project, @subscription_template) %>', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': '<%= form_authenticity_token %>'
+    },
+    body: JSON.stringify({ subscription_id: "" })
+  })
+    .then(response => response.text())
+    .then(result => {
+      subscriptionTemplateList.innerHTML = result;
+    });
+}
+
 // Send the DELETE request to the Orion broker
 fetch('<%= raw j(@broker_url) %>', deleteRequestOptions)
   .then(response => {
-    if (!response.ok) {
-      console.warn('Warning: Network response was not ok');
-      showNotification("<%= raw j(l(:subscription_unpublished_warning)) %>");
-    } else {
+    // Only clear the local subscription id when the broker actually removed the
+    // subscription (2xx) or it is already gone (404). Otherwise keep it: the
+    // subscription is still active on the broker, so the template must keep
+    // showing as published and the user must be told to retry (e.g. after
+    // fixing the authorization token). See #35.
+    if (response.ok || response.status === 404) {
       showNotification("<%= raw j(l(:subscription_unpublished)) %>");
+      return clearSubscriptionId();
     }
 
-    // Send the PATCH request to update the subscription_id
-    return fetch('<%= update_subscription_id_project_subscription_template_path(@project, @subscription_template) %>', {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': '<%= form_authenticity_token %>'
-      },
-      body: JSON.stringify({ subscription_id: "" }) // Clear the subscription_id field
-    });
+    console.warn('Broker did not remove the subscription (HTTP ' + response.status + ')');
+    showNotification("<%= raw j(l(:subscription_unpublished_warning)) %>");
   })
-  .then(response => response.text())
-  .then(result => {
-    // Update the subscription template list
-    var subscriptionTemplateList = document.getElementById('subscriptionTemplateList');
-    subscriptionTemplateList.innerHTML = result;
-  })
-  .catch(error => console.log('error', error));
+  .catch(error => {
+    // The broker could not be reached; leave the subscription id in place.
+    console.log('error', error);
+    showNotification("<%= raw j(l(:subscription_unpublished_warning)) %>");
+  });

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -45,8 +45,9 @@ de:
   field_subscription_template_attrs_placeholder: '["temperature"]'
   project_geometry_not_supported_multipolygon: 'Die Projektgrenze ist ein Multipolygon,
     das für räumliche Suchanfragen nicht unterstützt wird'
-  subscription_unpublished_warning: 'Es gab ein Problem beim Aufheben der Subscription
-    im Broker'
+  subscription_unpublished_warning: 'Die Subscription konnte nicht vom Broker entfernt
+    werden und ist weiterhin aktiv. Prüfen Sie den Autorisierungstoken und versuchen
+    Sie es erneut.'
   link_to_insert_project_geometry_hint: 'Die Projektgrenze wird dabei als räumliche
     Suchmaske für die Subscription verwendet'
   gtt_fiware_subscription_template_variable_hint: 'Attributwerte können als <code>${Variable}</code>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,8 +109,8 @@ en:
   link_to_unpublish: "Unpublish"
   link_to_unpublish_hint: "Unpublish subscription to broker"
   subscription_unpublished: "Subscription unpublished from broker"
-  subscription_unpublished_warning: "There was a problem unpublishing the subscription
-    from the broker"
+  subscription_unpublished_warning: "The subscription could not be removed from the
+    broker and is still active. Check the authorization token and try again."
 
   subscription_unauthorized_error: "Unauthorized to perform this action"
   general_action_error: "There was an error performing this action"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -106,8 +106,8 @@ ja:
   link_to_unpublish: "Unpublish"
   link_to_unpublish_hint: "Unpublish subscription to broker"
   subscription_unpublished: "Subscription unpublished from broker"
-  subscription_unpublished_warning: "There was a problem unpublishing the subscription
-    from the broker"
+  subscription_unpublished_warning: "ブローカーからサブスクリプションを削除できませんでした。
+    サブスクリプションはまだ有効です。認証トークンを確認して再試行してください。"
 
   subscription_unauthorized_error: "Unauthorized to perform this action"
 

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -72,6 +72,27 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_includes response.body, "smart\\'city"
   end
 
+  # #35: the browser unpublish flow must only clear the local subscription id
+  # when the broker actually removed the subscription. The clear
+  # (clearSubscriptionId) must be gated behind a broker-success check, not run
+  # unconditionally, and a broker failure must notify the user.
+  def test_unpublish_clears_locally_only_on_broker_success
+    @template.update_column(:subscription_id, 'sub-1')
+    post :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    body = response.body
+
+    # The clear is defined once and gated behind a broker-success check.
+    assert_includes body, 'function clearSubscriptionId()'
+    assert_includes body, 'if (response.ok || response.status === 404)'
+    # It is invoked exactly once (inside the success guard), never
+    # unconditionally in the failure or catch branches.
+    assert_equal 1, body.scan(/return clearSubscriptionId\(\);/).length
+    # Both the HTTP-failure branch and the network-error catch warn the user
+    # that the subscription is still active (the rendered en warning text).
+    assert_equal 2, body.scan(/could not be removed from the/).length
+  end
+
   def test_copy_escapes_the_json_payload
     get :copy, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success


### PR DESCRIPTION
Closes #35

## Problem

The browser unpublish flow cleared the local `subscription_id` even when the broker-side DELETE failed (for example, a missing or invalid authorization token → 401). The subscription stayed active on the Orion broker while the plugin showed it as unpublished — a desync, and after #58 that subscription would keep authenticating (its webhook secret is unchanged) and creating issues. The user was shown a soft warning but the local state was cleared anyway.

## Changes

- **`unpublish.js.erb`**: clears the local `subscription_id` (via the `update_subscription_id` PATCH) **only** when the broker actually removed the subscription — HTTP 2xx, or 404 (already gone). On any other status, or a network error, the id is left in place so the template keeps showing as published, and the user is warned. The clear is now a single `clearSubscriptionId()` function invoked only inside the broker-success guard.
- **Warning message** (`subscription_unpublished_warning`, en/ja/de): now states the subscription could not be removed and **is still active**, prompting the user to check the authorization token and retry.
- The proxy path (`handle_fiware_action`) already only cleared on a broker 204, so it needed no change.

## Tests

Adds `test_unpublish_clears_locally_only_on_broker_success`, asserting the rendered JS defines `clearSubscriptionId()`, gates it behind `response.ok || response.status === 404`, invokes it exactly once, and warns the user in both the HTTP-failure and network-error branches.

**Verified locally** against a real RedMica 6.1 + redmine_gtt + PostGIS stack: full plugin suite green (52 runs, 208 assertions, 0 failures).

## Note

This is the last open issue in the Phase 0 milestone.