### PR TITLE
Follow-up: stable webhook secret + guard nil member user (Copilot review on #81)

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -47,8 +47,15 @@ class SubscriptionIssuesController < ApplicationController
     end
 
     # Act as the configured member. The issue is authored by this user and all
-    # downstream permission checks (visibility, custom fields) use it.
-    User.current = @subscription_template.member.user
+    # downstream permission checks (visibility, custom fields) use it. The
+    # member or its user may have been removed since the template was created,
+    # so guard against a nil user instead of raising a 500.
+    member_user = @subscription_template.member&.user
+    unless member_user
+      render json: { error: 'Not authorized to create issues' }, status: :forbidden
+      return
+    end
+    User.current = member_user
 
     unless User.current.allowed_to?(:add_issues, @subscription_template.project)
       render json: { error: 'Not authorized to create issues' }, status: :forbidden

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -93,9 +93,10 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def publish
-    # Rotate the webhook secret so each publish sends the broker a fresh
-    # credential; prepare_payload (below) then embeds the new value.
-    @subscription_template.rotate_webhook_secret!
+    # Ensure the template has a webhook secret (backfills a blank one); the
+    # secret is stable for the life of the template so the broker and plugin
+    # never disagree on it. prepare_payload (below) embeds it.
+    @subscription_template.ensure_webhook_secret!
     handle_publish_unpublish('publish', l(:subscription_published), 'publish')
   end
 

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -52,9 +52,15 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     SecureRandom.hex(WEBHOOK_SECRET_BYTES)
   end
 
-  # Assign a fresh secret and persist it. Called on each (re)publish so the
-  # credential the broker holds is rotated every time the subscription is sent.
-  def rotate_webhook_secret!
+  # Persist a secret only if the template does not already have one (e.g. a
+  # template created before the webhook_secret column existed). The secret is
+  # otherwise stable for the life of the template: it must not change while a
+  # subscription is live on the broker, or the broker would keep sending a
+  # secret the plugin no longer accepts. Backfilling a blank secret is safe
+  # because nothing on the broker relies on the previous (absent) value.
+  def ensure_webhook_secret!
+    return if webhook_secret.present?
+
     update_column(:webhook_secret, self.class.generate_webhook_secret)
   end
 

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -85,6 +85,19 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # A valid secret whose member's user no longer exists must yield a controlled
+  # 403, not a 500 (#81 follow-up).
+  def test_create_handles_a_member_without_a_user
+    member = @template.member
+    member.stubs(:user).returns(nil)
+    # The controller loads its own template instance, so stub member there too.
+    SubscriptionTemplate.any_instance.stubs(:member).returns(member)
+    assert_no_difference 'Issue.count' do
+      post_notification
+    end
+    assert_response :forbidden
+  end
+
   def test_create_skips_attachments_with_non_https_urls
     assert_difference 'Issue.count', 1 do
       post_notification(notification_params(

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -50,11 +50,13 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_not_includes response.body, 'X-Redmine-API-Key'
   end
 
-  def test_publish_rotates_the_webhook_secret
+  # The secret is stable across publishes: it must not change while a
+  # subscription may be live on the broker (see the #81 follow-up).
+  def test_publish_keeps_the_webhook_secret_stable
     original = @template.webhook_secret
     post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
     assert_response :success
-    assert_not_equal original, @template.reload.webhook_secret
+    assert_equal original, @template.reload.webhook_secret
   end
 
   def test_publish_escapes_the_fiware_service_header

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -97,12 +97,19 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_equal 64, template.webhook_secret.length # SecureRandom.hex(32)
   end
 
-  def test_rotate_webhook_secret_changes_and_persists_it
+  def test_ensure_webhook_secret_keeps_an_existing_secret
     template = SubscriptionTemplate.create!(valid_attributes)
     original = template.webhook_secret
-    template.rotate_webhook_secret!
-    assert_not_equal original, template.webhook_secret
-    assert_equal template.webhook_secret, template.reload.webhook_secret
+    template.ensure_webhook_secret!
+    assert_equal original, template.reload.webhook_secret
+  end
+
+  def test_ensure_webhook_secret_backfills_a_blank_secret
+    template = SubscriptionTemplate.create!(valid_attributes)
+    template.update_column(:webhook_secret, nil)
+    template.ensure_webhook_secret!
+    assert_not_nil template.reload.webhook_secret
+    assert_equal 64, template.webhook_secret.length
   end
 
   def test_valid_webhook_secret_matches_only_the_stored_secret


### PR DESCRIPTION
Addresses the two findings from Copilot's review on #81, which landed just after that PR was merged.

## 1. Webhook-secret rotation desync (was: rotate on every publish)

`publish` called `rotate_webhook_secret!`, which persisted a **new** secret *before* the broker publish attempt. If the publish then failed (a proxy-mode broker error, or a browser-side fetch error), Redmine held a secret the broker never received — and since Orion keeps the existing subscription, that subscription would keep sending the old secret, so **every subsequent notification was rejected** until another successful publish. This is the same desync class as #35, on the publish side.

**Fix:** the webhook secret is now **stable for the life of the template**. It is generated once on create (`before_create`), and `ensure_webhook_secret!` only *backfills* a blank secret (e.g. a template that predates the column) — it never changes an existing one. This removes the desync entirely, with no new surface, and keeps every security property of #58 (per-template random secret, never a Redmine API key).

**Scope note:** this drops the "rotate on republish" behavior described in #58. Rotation-on-publish is inherently desync-prone here (orphaned broker subscriptions + a browser flow that can fail mid-way), so a stable secret is the correct baseline. If explicit rotation is wanted later (e.g. "this secret leaked, roll it"), that belongs in a dedicated action that resyncs the broker atomically — happy to file it as a follow-up.

## 2. `member.user` NoMethodError → 500

`authenticate_webhook` used `@subscription_template.member.user` unguarded. If the member was removed or the user deleted, that raised `NoMethodError` → 500. It now guards the nil user and returns a controlled 403.

## Tests

- Model: `ensure_webhook_secret!` keeps an existing secret and backfills a blank one; `valid_webhook_secret?` unchanged.
- Publish: the secret is stable across a publish (replaces the old rotation test).
- Notification: a member without a user yields a 403, not a 500.

**Verified locally** against a real RedMica 6.1 + redmine_gtt + PostGIS stack: full plugin suite green (54 runs, 212 assertions, 0 failures).