### PR TITLE
chore: bump version to 2.1.0 (Phase 0 baseline)

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '2.0.1'
+  version '2.1.0'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Bumps the plugin version to `2.1.0`, marking the completed **Phase 0: Security & foundation** milestone as the release baseline.

Note: `init.rb` still read `2.0.1` even though `v2.0.2` was tagged (it was never bumped for that release), so this jumps straight to `2.1.0`.

Once merged, a lightweight `v2.1.0` tag + GitHub release will be cut summarizing the Phase 0 security work (CI/test foundation, SSRF, XSS, POST routes, removal of the dead NGSI read API, per-template webhook secret, unpublish desync fix).