### PR TITLE
feat: plugin-side entity mapping — broker becomes pub/sub only (Phase 1)

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -23,6 +23,10 @@ class SubscriptionIssuesController < ApplicationController
   # validation (a permanent error the broker should not retry).
   def create
     entities = notification_entities
+    if entities == :invalid_json
+      render json: { error: 'Malformed JSON' }, status: :bad_request
+      return
+    end
     if entities.empty?
       render json: { error: 'No entities in notification' }, status: :unprocessable_entity
       return
@@ -53,7 +57,10 @@ class SubscriptionIssuesController < ApplicationController
   # process. Reads the raw JSON body directly (not filtered params) so
   # arbitrary entity attribute names survive untouched. Accepts the NGSIv2
   # notification shape `{ "data": [ {entity}, ... ] }`, a bare entity array, or
-  # a single entity object; anything else yields an empty list.
+  # a single entity object; a well-formed body with none of these yields an
+  # empty list. Returns the :invalid_json sentinel for a malformed body so
+  # #create can answer 400 (bad request) rather than 422 (well-formed but
+  # unprocessable).
   def notification_entities
     body = JSON.parse(request.raw_post)
 
@@ -70,7 +77,7 @@ class SubscriptionIssuesController < ApplicationController
 
     entities.select { |entity| entity.is_a?(Hash) }
   rescue JSON::ParserError
-    []
+    :invalid_json
   end
 
   # Authenticates the notification on the template's webhook secret, then acts

--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -1,7 +1,11 @@
-require 'uri'
-require 'rack'
+require 'json'
 
-# This controller handles the creation of issues from subscription templates.
+# Receives broker notifications and turns their entities into Redmine issues.
+#
+# Since #64 the broker does pub/sub only: it POSTs the raw NGSIv2/NGSI-LD
+# notification (entities under `data`) and this controller runs each entity
+# through NotificationProcessor, which applies the template's field mapping and
+# the create-vs-update dedup rule. All templating happens plugin-side.
 class SubscriptionIssuesController < ApplicationController
 
   # The notification endpoint is a machine callback authenticated solely by the
@@ -14,22 +18,60 @@ class SubscriptionIssuesController < ApplicationController
 
   WEBHOOK_SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
 
-  # Creates a new issue or updates an existing one based on the provided parameters.
+  # Processes every entity in the notification. Returns 200 with a summary when
+  # at least one issue was persisted, and 422 only when the whole batch failed
+  # validation (a permanent error the broker should not retry).
   def create
-    @issue = find_or_initialize_issue
-
-    if params[:attachments]
-      handle_attachments
+    entities = notification_entities
+    if entities.empty?
+      render json: { error: 'No entities in notification' }, status: :unprocessable_entity
+      return
     end
 
-    if @issue.save
-      render json: @issue.as_json(include: [:status, :tracker, :author, :assigned_to, :attachments, :journals]), status: :ok
+    processor = RedmineGttFiware::NotificationProcessor.new(@subscription_template)
+    results = entities.map { |entity| processor.process(entity) }
+    saved = results.select(&:saved?)
+
+    if saved.empty?
+      render json: {
+        processed: results.size,
+        errors: results.flat_map { |r| r.issue.errors.full_messages }.uniq
+      }, status: :unprocessable_entity
     else
-      render json: { errors: @issue.errors.full_messages }, status: :unprocessable_entity
+      render json: {
+        processed: results.size,
+        created: saved.count(&:created?),
+        updated: saved.count { |r| !r.created? },
+        issues: saved.map { |r| r.issue.as_json(only: [:id, :subject, :fiware_entity]) }
+      }, status: :ok
     end
   end
 
   private
+
+  # Parses the broker notification body and returns the entity hashes to
+  # process. Reads the raw JSON body directly (not filtered params) so
+  # arbitrary entity attribute names survive untouched. Accepts the NGSIv2
+  # notification shape `{ "data": [ {entity}, ... ] }`, a bare entity array, or
+  # a single entity object; anything else yields an empty list.
+  def notification_entities
+    body = JSON.parse(request.raw_post)
+
+    entities =
+      if body.is_a?(Hash) && body['data'].is_a?(Array)
+        body['data']
+      elsif body.is_a?(Array)
+        body
+      elsif body.is_a?(Hash) && body['id'].present?
+        [body]
+      else
+        []
+      end
+
+    entities.select { |entity| entity.is_a?(Hash) }
+  rescue JSON::ParserError
+    []
+  end
 
   # Authenticates the notification on the template's webhook secret, then acts
   # as the template's configured member for the rest of the request.
@@ -60,98 +102,6 @@ class SubscriptionIssuesController < ApplicationController
     unless User.current.allowed_to?(:add_issues, @subscription_template.project)
       render json: { error: 'Not authorized to create issues' }, status: :forbidden
       return
-    end
-  end
-
-  # Finds an existing issue or initializes a new one.
-  def find_or_initialize_issue
-    existing_issue = Issue.where(fiware_entity: params["entity"], subscription_template_id: @subscription_template.id)
-                      .where("created_on >= ?", Time.now - @subscription_template.threshold_create.seconds)
-                      .order(created_on: :desc)
-                      .first
-
-    if existing_issue
-      handle_existing_issue(existing_issue)
-      existing_issue
-    else
-      handle_new_issue
-      @issue
-    end
-  end
-
-  # Handles an existing issue by initializing a journal and updating the geometry if necessary.
-  def handle_existing_issue(existing_issue)
-    note = existing_issue.init_journal(User.current, params["notes"])
-
-    if Redmine::Plugin.installed?(:redmine_gtt) && @subscription_template.project.module_enabled?('gtt') && params[:geometry]
-      begin
-        new_geom = RedmineGtt::Conversions.to_geom(params[:geometry].to_json)
-        if new_geom != existing_issue.geom
-          old_geom = existing_issue.geom
-          existing_issue.geom = new_geom
-          note.details.build(property: 'attr', prop_key: 'geom', old_value: old_geom, value: new_geom)
-        end
-      rescue => e
-        logger.warn "Failed to convert geometry data: #{e.message}"
-      end
-    end
-  end
-
-  # Handles a new issue by initializing it with the provided parameters and the subscription template.
-  def handle_new_issue
-    @issue = Issue.new()
-    @issue.project = @subscription_template.project
-    @issue.tracker = @subscription_template.tracker
-    @issue.subject = params[:subject]
-    @issue.description = params[:description]
-    @issue.is_private = @subscription_template.is_private
-    @issue.status = @subscription_template.issue_status
-    @issue.author = User.current
-    @issue.category = @subscription_template.issue_category
-    @issue.priority = @subscription_template.issue_priority
-    @issue.fixed_version = @subscription_template.version
-    @issue.fiware_entity = params["entity"]
-    @issue.subscription_template_id = @subscription_template.id
-
-    if Redmine::Plugin.installed?(:redmine_gtt) && @subscription_template.project.module_enabled?('gtt') && params[:geometry]
-      begin
-        @issue.geom = RedmineGtt::Conversions.to_geom(params[:geometry].to_json)
-      rescue => e
-        logger.warn "Failed to convert geometry data: #{e.message}"
-      end
-    end
-  end
-
-  # Handles attachments by downloading them and attaching them to the issue.
-  # Downloads go through AttachmentFetcher, which enforces the SSRF
-  # protections: https only, host allowlist, public addresses only, no
-  # redirects, timeouts, content-type allowlist and a size limit. The
-  # stored content type is the one the server responded with; a type
-  # claimed in the notification payload is not trusted. Rejected
-  # attachments are skipped and logged so one bad attachment does not
-  # fail the whole notification.
-  def handle_attachments
-    fetcher = RedmineGttFiware::AttachmentFetcher.for_template(@subscription_template)
-    existing_filenames = @issue.attachments.map { |a| a.filename }
-
-    params[:attachments].each do |attachment|
-      begin
-        filename = attachment['filename'].presence ||
-                   File.basename(URI.parse(attachment['url'].to_s).path.to_s)
-
-        next if filename.empty? || existing_filenames.include?(filename)
-
-        result = fetcher.fetch(attachment['url'])
-        description = attachment['description'] || ''
-        uploaded_file = Rack::Multipart::UploadedFile.new(
-          result.tempfile.path, result.content_type, true, filename: filename
-        )
-        @issue.attachments.build(file: uploaded_file, description: description, author: User.current)
-      rescue RedmineGttFiware::AttachmentFetcher::RejectedError => e
-        logger.warn "Rejected attachment download from #{attachment['url'].inspect}: #{e.message}"
-      rescue => e
-        logger.warn "Failed to attach file: #{e.message}"
-      end
     end
   end
 end

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -144,25 +144,22 @@ class SubscriptionTemplatesController < ApplicationController
     @broker_url = broker_url.merge("#{version_path}subscriptions").to_s
     @entity_url = broker_url.merge("#{version_path}entities").to_s
 
+    # httpCustom carries only the callback URL and headers now (#64). The broker
+    # is pub/sub only: it POSTs the raw notification (entities under `data`) and
+    # the plugin renders all fields (subject/description/notes/geometry/
+    # attachments) itself in NotificationProcessor. No `json` templating block
+    # is sent, so no template expressions leave Redmine.
     http_custom = {
       url: URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/notification").to_s,
       headers: {
         "Content-Type" => "application/json",
         # Per-template webhook secret, NOT a Redmine API key: it authenticates
         # the notification and grants nothing beyond creating issues from this
-        # template (see #58). Rotated on every publish.
+        # template (see #58). Backfilled on publish, then stable.
         "X-Gtt-Webhook-Secret" => @subscription_template.webhook_secret,
         "X-Redmine-GTT-Subscription-Template-URL" => URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/registration/").to_s
       },
-      method: "POST",
-      json: {
-        entity: "#{@entity_url}/${id}?type=${type}",
-        subject: @subscription_template.subject.chomp,
-        description: @subscription_template.description.chomp,
-        attachments: @subscription_template.attachments,
-        notes: @subscription_template.notes.chomp,
-        geometry: @subscription_template.geometry
-      }
+      method: "POST"
     }
 
     @json_payload = {

--- a/lib/redmine_gtt_fiware/entity.rb
+++ b/lib/redmine_gtt_fiware/entity.rb
@@ -53,12 +53,22 @@ module RedmineGttFiware
       new(id: entity['id'], type: entity['type'], attributes: attributes, geometry: geometry)
     end
 
+    # A typed GeoProperty is always geometry. Falling back on the attribute name
+    # alone would capture a plain `location` Property whose value is a scalar
+    # (e.g. "indoors"), so the name-based match additionally requires the value
+    # to look like GeoJSON. Combined with the caller's `||=` (first geometry
+    # wins), this keeps a real GeoProperty from being shadowed by such a value.
     def self.geo_property?(key, raw)
-      raw['type'].to_s == 'GeoProperty' || key == LOCATION_ATTRIBUTE
+      raw['type'].to_s == 'GeoProperty' || (key == LOCATION_ATTRIBUTE && geo_json_value?(raw['value']))
     end
 
     def self.geo_json?(key, raw)
-      raw['type'].to_s == 'geo:json' || (key == LOCATION_ATTRIBUTE && raw['value'].is_a?(Hash))
+      raw['type'].to_s == 'geo:json' || (key == LOCATION_ATTRIBUTE && geo_json_value?(raw['value']))
+    end
+
+    # A minimal GeoJSON geometry check: a hash with a type and coordinates.
+    def self.geo_json_value?(value)
+      value.is_a?(Hash) && value['type'].present? && value.key?('coordinates')
     end
 
     def initialize(id:, type:, attributes:, geometry: nil)

--- a/lib/redmine_gtt_fiware/entity.rb
+++ b/lib/redmine_gtt_fiware/entity.rb
@@ -1,0 +1,107 @@
+module RedmineGttFiware
+  # A broker entity, normalized to a uniform shape so the same plugin-side
+  # templating and issue-mapping pipeline works for both NGSI-LD and NGSIv2.
+  #
+  # After normalization an entity is:
+  #   - id, type      : strings
+  #   - attributes     : { "<name>" => { "value" => <scalar/hash>, "type" => "...", ... } }
+  #   - geometry       : GeoJSON geometry hash (from the location GeoProperty), or nil
+  #
+  # NGSI-LD attributes look like { "type" => "Property"|"Relationship"|"GeoProperty",
+  # "value"|"object" => ... }; NGSIv2 attributes look like { "type" => ...,
+  # "value" => ..., "metadata" => ... }. Both collapse to a common { "value", "type" }.
+  class Entity
+    RESERVED_KEYS = %w[id type @context].freeze
+    LOCATION_ATTRIBUTE = 'location'.freeze
+
+    attr_reader :id, :type, :attributes, :geometry
+
+    # standard: 'NGSI-LD' or 'NGSIv2' (case-insensitive)
+    def self.from(entity, standard)
+      normalized = entity.is_a?(Hash) ? entity : {}
+      if standard.to_s.casecmp('NGSI-LD').zero?
+        from_ngsi_ld(normalized)
+      else
+        from_ngsi_v2(normalized)
+      end
+    end
+
+    def self.from_ngsi_ld(entity)
+      attributes = {}
+      geometry = nil
+      entity.each do |key, raw|
+        next if RESERVED_KEYS.include?(key)
+        next unless raw.is_a?(Hash)
+
+        value = raw.key?('object') ? raw['object'] : raw['value']
+        attributes[key] = { 'value' => value, 'type' => raw['type'] }
+        geometry ||= raw['value'] if geo_property?(key, raw)
+      end
+      new(id: entity['id'], type: entity['type'], attributes: attributes, geometry: geometry)
+    end
+
+    def self.from_ngsi_v2(entity)
+      attributes = {}
+      geometry = nil
+      entity.each do |key, raw|
+        next if %w[id type].include?(key)
+        next unless raw.is_a?(Hash)
+
+        attributes[key] = { 'value' => raw['value'], 'type' => raw['type'], 'metadata' => raw['metadata'] }
+        geometry ||= raw['value'] if geo_json?(key, raw)
+      end
+      new(id: entity['id'], type: entity['type'], attributes: attributes, geometry: geometry)
+    end
+
+    def self.geo_property?(key, raw)
+      raw['type'].to_s == 'GeoProperty' || key == LOCATION_ATTRIBUTE
+    end
+
+    def self.geo_json?(key, raw)
+      raw['type'].to_s == 'geo:json' || (key == LOCATION_ATTRIBUTE && raw['value'].is_a?(Hash))
+    end
+
+    def initialize(id:, type:, attributes:, geometry: nil)
+      @id = id
+      @type = type
+      @attributes = attributes || {}
+      @geometry = geometry
+    end
+
+    # Resolves a template path against the entity. Supported forms:
+    #   id, type
+    #   attrs.<name>.value  /  <name>.value
+    #   attrs.<name>        /  <name>          (shorthand for the value)
+    #   attrs.<name>.<key>  (e.g. metadata.unitCode on NGSIv2)
+    # Returns nil for an unknown path (callers coerce to "" for output).
+    def resolve(path)
+      segments = path.to_s.strip.split('.')
+      return nil if segments.empty?
+
+      case segments.first
+      when 'id' then return @id
+      when 'type' then return @type
+      end
+
+      segments = segments.drop(1) if segments.first == 'attrs'
+      name = segments.shift
+      attribute = @attributes[name]
+      return nil if attribute.nil?
+
+      # bare `<name>` is shorthand for the value
+      return attribute['value'] if segments.empty?
+      # `<name>.value` and deeper (metadata, etc.)
+      dig_value(attribute, segments)
+    end
+
+    private
+
+    def dig_value(node, segments)
+      segments.reduce(node) do |current, segment|
+        return nil unless current.is_a?(Hash)
+
+        current[segment]
+      end
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -1,0 +1,183 @@
+require 'uri'
+require 'rack'
+
+module RedmineGttFiware
+  # Turns one broker notification entity into a Redmine issue, applying the
+  # subscription template's field mapping and the create-vs-update dedup rule.
+  #
+  # Since #64 the broker is used for pub/sub only: it POSTs raw NGSIv2/NGSI-LD
+  # entities and the plugin does all templating here (previously the broker
+  # rendered the fields via httpCustom.json). Given a template and one raw
+  # entity, #process normalizes it, renders the mapped fields, decides whether
+  # this is a new issue or an update to a recent one (the threshold_create
+  # window, keyed on the entity id), and persists it.
+  #
+  # User.current must already be the template's member: the caller
+  # (SubscriptionIssuesController) authenticates the webhook and sets it. The
+  # issue is authored by that user and geometry/attachment work runs as them.
+  class NotificationProcessor
+    # Result of processing one entity. `saved` reflects Issue#save; on false the
+    # issue carries validation errors for the caller to surface.
+    Result = Struct.new(:issue, :created, :saved, keyword_init: true) do
+      def created?
+        created
+      end
+
+      def saved?
+        saved
+      end
+    end
+
+    def initialize(template, logger: Rails.logger)
+      @template = template
+      @logger = logger
+    end
+
+    # raw_entity: one entity hash from the notification's data[] array.
+    def process(raw_entity)
+      entity = Entity.from(raw_entity, @template.standard)
+      existing = find_recent_issue(entity)
+      existing ? process_update(existing, entity) : process_create(entity)
+    end
+
+    private
+
+    # A new notification for an entity already turned into an issue within the
+    # threshold_create window updates that issue instead of creating a duplicate
+    # (the heart of the plugin, #47). Outside the window a fresh issue is made.
+    def find_recent_issue(entity)
+      return nil if entity.id.blank?
+
+      window = @template.threshold_create.to_i
+      Issue
+        .where(fiware_entity: entity.id, subscription_template_id: @template.id)
+        .where('created_on >= ?', Time.now - window.seconds)
+        .order(created_on: :desc)
+        .first
+    end
+
+    def process_create(entity)
+      issue = build_issue(entity)
+      apply_new_geometry(issue, entity)
+      build_attachments(issue, entity)
+      Result.new(issue: issue, created: true, saved: issue.save)
+    end
+
+    def process_update(issue, entity)
+      journal = issue.init_journal(User.current, render(@template.notes, entity))
+      apply_updated_geometry(issue, entity, journal)
+      build_attachments(issue, entity)
+      Result.new(issue: issue, created: false, saved: issue.save)
+    end
+
+    def build_issue(entity)
+      issue = Issue.new
+      issue.project = @template.project
+      issue.tracker = @template.tracker
+      issue.subject = render(@template.subject, entity)
+      issue.description = render(@template.description, entity)
+      issue.is_private = @template.is_private
+      issue.status = @template.issue_status
+      issue.author = User.current
+      issue.category = @template.issue_category
+      issue.priority = @template.issue_priority
+      issue.fixed_version = @template.version
+      issue.fiware_entity = entity.id
+      issue.subscription_template_id = @template.id
+      issue
+    end
+
+    def apply_new_geometry(issue, entity)
+      return unless gtt_enabled?
+
+      geom = rendered_geom(entity)
+      issue.geom = geom if geom
+    end
+
+    def apply_updated_geometry(issue, entity, journal)
+      return unless gtt_enabled?
+
+      geom = rendered_geom(entity)
+      return if geom.nil? || geom == issue.geom
+
+      old_geom = issue.geom
+      issue.geom = geom
+      journal.details.build(property: 'attr', prop_key: 'geom', old_value: old_geom, value: geom)
+    end
+
+    # Renders the template's geometry against the entity and converts the
+    # resulting GeoJSON to a database geom. Returns nil (never raises) when
+    # there is no geometry template or the GeoJSON cannot be converted, so one
+    # bad geometry never fails the whole notification.
+    def rendered_geom(entity)
+      geometry = TemplateRenderer.render_geometry(@template.geometry, entity)
+      return nil if geometry.blank?
+
+      RedmineGtt::Conversions.to_geom(geometry.to_json)
+    rescue StandardError => e
+      @logger.warn "[FIWARE] Failed to convert geometry data: #{e.message}"
+      nil
+    end
+
+    def gtt_enabled?
+      Redmine::Plugin.installed?(:redmine_gtt) && @template.project.module_enabled?('gtt')
+    end
+
+    # Fetches and attaches each rendered attachment spec. Downloads go through
+    # AttachmentFetcher, which enforces the SSRF protections (https only, host
+    # allowlist, public addresses only, no redirects, timeouts, content-type
+    # allowlist, size limit). The stored content type is the one the server
+    # responded with; a type claimed in the payload is not trusted. Rejected or
+    # failed attachments are skipped and logged so one bad attachment does not
+    # fail the whole notification.
+    def build_attachments(issue, entity)
+      specs = rendered_attachment_specs(entity)
+      return if specs.empty?
+
+      fetcher = RedmineGttFiware::AttachmentFetcher.for_template(@template)
+      existing_filenames = issue.attachments.map(&:filename)
+
+      specs.each do |spec|
+        url = spec['url'].to_s
+        next if url.empty?
+
+        filename = spec['filename'].presence || File.basename(URI.parse(url).path.to_s)
+        next if filename.empty? || existing_filenames.include?(filename)
+
+        result = fetcher.fetch(url)
+        uploaded_file = Rack::Multipart::UploadedFile.new(
+          result.tempfile.path, result.content_type, true, filename: filename
+        )
+        issue.attachments.build(file: uploaded_file, description: spec['description'].to_s, author: User.current)
+        existing_filenames << filename
+      rescue RedmineGttFiware::AttachmentFetcher::RejectedError => e
+        @logger.warn "[FIWARE] Rejected attachment download from #{url.inspect}: #{e.message}"
+      rescue StandardError => e
+        @logger.warn "[FIWARE] Failed to attach file: #{e.message}"
+      end
+    end
+
+    # Renders the url/filename/description of each stored attachment template
+    # against the entity. The stored template.attachments is an array of
+    # `{ "url", "filename", "description" }` hashes whose values may contain
+    # `${...}` expressions.
+    def rendered_attachment_specs(entity)
+      specs = @template.attachments
+      return [] unless specs.is_a?(Array)
+
+      specs.filter_map do |spec|
+        next unless spec.is_a?(Hash)
+
+        {
+          'url' => render(spec['url'], entity),
+          'filename' => render(spec['filename'], entity),
+          'description' => render(spec['description'], entity)
+        }
+      end
+    end
+
+    def render(template, entity)
+      TemplateRenderer.render(template, entity)
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/template_renderer.rb
+++ b/lib/redmine_gtt_fiware/template_renderer.rb
@@ -1,0 +1,58 @@
+module RedmineGttFiware
+  # Renders a template string against a normalized Entity, substituting
+  # `${path}` expressions (see Entity#resolve for the path syntax). Unknown
+  # paths render as an empty string so a missing attribute never raises or
+  # leaves a literal `${...}` in the output.
+  module TemplateRenderer
+    EXPRESSION = /\$\{([^}]+)\}/
+
+    module_function
+
+    # Renders scalar text (subject, description, notes). Returns nil for a nil
+    # template so an absent optional field stays absent.
+    def render(template, entity)
+      return nil if template.nil?
+
+      template.to_s.gsub(EXPRESSION) do
+        value = entity.resolve(Regexp.last_match(1))
+        stringify(value)
+      end
+    end
+
+    # Renders a value into a GeoJSON geometry for the issue. The template's
+    # geometry field is a GeoJSON structure whose leaves may reference the
+    # entity (typically `${location}` or `${attrs.location.value}`). A path that
+    # resolves to a geometry hash is substituted structurally, not stringified,
+    # so the result stays valid GeoJSON.
+    def render_geometry(template_geometry, entity)
+      return nil if template_geometry.nil?
+
+      substitute_structure(template_geometry, entity)
+    end
+
+    def stringify(value)
+      case value
+      when nil then ''
+      when String then value
+      else value.to_json
+      end
+    end
+
+    # Walks a parsed-JSON structure. A string that is exactly one `${path}`
+    # expression is replaced by the resolved value (preserving hashes/arrays);
+    # a string with surrounding text is rendered as text.
+    def substitute_structure(node, entity)
+      case node
+      when Hash
+        node.each_with_object({}) { |(k, v), out| out[k] = substitute_structure(v, entity) }
+      when Array
+        node.map { |v| substitute_structure(v, entity) }
+      when String
+        whole = node.match(/\A\$\{([^}]+)\}\z/)
+        whole ? entity.resolve(whole[1]) : render(node, entity)
+      else
+        node
+      end
+    end
+  end
+end

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -133,6 +133,19 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  # A malformed body is a 400 (bad request), distinct from a well-formed
+  # notification that simply carries no entities (422). Sent without a JSON
+  # content type so the controller's own parse (not Rails' params middleware,
+  # which would 400 in the middleware layer) handles it.
+  def test_create_rejects_a_malformed_json_body
+    @request.headers[SECRET_HEADER] = @template.webhook_secret
+    @request.headers['CONTENT_TYPE'] = 'text/plain'
+    assert_no_difference 'Issue.count' do
+      post :create, params: { subscription_template_id: @template.id }, body: '{ not json'
+    end
+    assert_response :bad_request
+  end
+
   def test_create_rejects_when_the_member_cannot_add_issues
     Role.all.each { |role| role.remove_permission!(:add_issues) }
     assert_no_difference 'Issue.count' do

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -13,8 +13,12 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
       status: 'active',
       name: 'Temperature alerts',
       broker_url: 'https://broker.example.com',
+      # Since #64 the broker POSTs raw entities and the plugin renders these
+      # ${...} expressions itself (see NotificationProcessor / TemplateRenderer).
       subject: 'Sensor ${id}',
-      description: 'A monitored value changed',
+      description: 'Temperature is ${attrs.temperature.value}',
+      notes: 'Latest reading: ${attrs.temperature.value}',
+      threshold_create: 3600,
       entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
       project_id: 1,
       tracker_id: 1,
@@ -24,31 +28,34 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     )
   end
 
-  def notification_params(overrides = {})
+  # One raw NGSIv2 entity as the broker sends it inside the notification's
+  # data[] array.
+  def entity(overrides = {})
     {
-      subscription_template_id: @template.id,
-      subject: 'Sensor urn:ngsi-ld:TemperatureSensor:001',
-      description: 'Temperature above threshold',
-      entity: 'urn:ngsi-ld:TemperatureSensor:001',
+      'id' => 'urn:ngsi-ld:TemperatureSensor:001',
+      'type' => 'TemperatureSensor',
+      'temperature' => { 'type' => 'Number', 'value' => 30 }
     }.merge(overrides)
   end
 
-  # Posts a notification with the given webhook secret in the request header.
-  def post_notification(params = notification_params, secret: @template.webhook_secret)
+  # Posts a broker notification (entities under `data`) with the webhook secret
+  # in the request header and a raw JSON body, as the broker does.
+  def post_notification(entities: [entity], template_id: @template.id, secret: @template.webhook_secret)
     @request.headers[SECRET_HEADER] = secret unless secret.nil?
-    post :create, params: params
+    @request.headers['CONTENT_TYPE'] = 'application/json'
+    post :create, params: { subscription_template_id: template_id }, body: { data: entities }.to_json
   end
 
   def test_create_rejects_a_missing_secret
     assert_no_difference 'Issue.count' do
-      post_notification(notification_params, secret: nil)
+      post_notification(secret: nil)
     end
     assert_response :unauthorized
   end
 
   def test_create_rejects_a_wrong_secret
     assert_no_difference 'Issue.count' do
-      post_notification(notification_params, secret: 'not-the-secret')
+      post_notification(secret: 'not-the-secret')
     end
     assert_response :unauthorized
   end
@@ -56,11 +63,11 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
   # A missing template returns the same 401 as a wrong secret, so the endpoint
   # never reveals whether a given template id exists.
   def test_create_does_not_leak_template_existence
-    post_notification(notification_params(subscription_template_id: 987_654), secret: 'anything')
+    post_notification(template_id: 987_654, secret: 'anything')
     assert_response :unauthorized
     missing_body = @response.body
 
-    post_notification(notification_params, secret: 'wrong-secret')
+    post_notification(secret: 'wrong-secret')
     assert_response :unauthorized
     assert_equal missing_body, @response.body
   end
@@ -72,9 +79,58 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :success
     issue = Issue.order(id: :desc).first
     assert_equal 'Sensor urn:ngsi-ld:TemperatureSensor:001', issue.subject
+    assert_equal 'Temperature is 30', issue.description
     assert_equal 'urn:ngsi-ld:TemperatureSensor:001', issue.fiware_entity
     assert_equal @template.id, issue.subscription_template_id
     assert_equal @template.member.user_id, issue.author_id
+  end
+
+  # Two notifications for the same entity within the threshold_create window
+  # update the first issue instead of creating a duplicate (#47).
+  def test_create_updates_a_recent_issue_instead_of_duplicating
+    post_notification
+    assert_response :success
+    issue = Issue.order(id: :desc).first
+
+    assert_no_difference 'Issue.count' do
+      post_notification(entities: [entity('temperature' => { 'type' => 'Number', 'value' => 42 })])
+    end
+    assert_response :success
+    issue.reload
+    assert_equal 'Latest reading: 42', issue.journals.order(:id).last.notes
+  end
+
+  # Outside the threshold_create window a new notification creates a new issue.
+  def test_create_makes_a_new_issue_outside_the_threshold_window
+    post_notification
+    Issue.order(id: :desc).first.update_column(:created_on, 2.hours.ago)
+
+    assert_difference 'Issue.count', 1 do
+      post_notification
+    end
+    assert_response :success
+  end
+
+  # Every entity in a multi-entity notification is processed.
+  def test_create_processes_every_entity_in_the_notification
+    entities = [
+      entity('id' => 'urn:ngsi-ld:TemperatureSensor:001'),
+      entity('id' => 'urn:ngsi-ld:TemperatureSensor:002')
+    ]
+    assert_difference 'Issue.count', 2 do
+      post_notification(entities: entities)
+    end
+    assert_response :success
+    fiware_entities = Issue.order(id: :desc).limit(2).map(&:fiware_entity)
+    assert_includes fiware_entities, 'urn:ngsi-ld:TemperatureSensor:001'
+    assert_includes fiware_entities, 'urn:ngsi-ld:TemperatureSensor:002'
+  end
+
+  def test_create_rejects_a_notification_without_entities
+    assert_no_difference 'Issue.count' do
+      post_notification(entities: [])
+    end
+    assert_response :unprocessable_entity
   end
 
   def test_create_rejects_when_the_member_cannot_add_issues
@@ -98,21 +154,22 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # Attachments are configured on the template (not carried in the notification)
+  # and rendered/fetched plugin-side. The SSRF protections in AttachmentFetcher
+  # still apply on every download.
   def test_create_skips_attachments_with_non_https_urls
+    @template.update_column(:attachments, [{ 'url' => 'http://169.254.169.254/latest/meta-data', 'filename' => 'meta.txt' }])
     assert_difference 'Issue.count', 1 do
-      post_notification(notification_params(
-        attachments: [{ url: 'http://169.254.169.254/latest/meta-data', filename: 'meta.txt' }]
-      ))
+      post_notification
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
   end
 
   def test_create_skips_attachments_from_hosts_not_on_the_allowlist
+    @template.update_column(:attachments, [{ 'url' => 'https://evil.example.org/file.png', 'filename' => 'file.png' }])
     assert_difference 'Issue.count', 1 do
-      post_notification(notification_params(
-        attachments: [{ url: 'https://evil.example.org/file.png', filename: 'file.png' }]
-      ))
+      post_notification
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
@@ -120,10 +177,9 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
 
   def test_create_skips_attachments_resolving_to_non_public_addresses
     @template.update_column(:broker_url, 'https://localhost')
+    @template.update_column(:attachments, [{ 'url' => 'https://localhost/file.png', 'filename' => 'file.png' }])
     assert_difference 'Issue.count', 1 do
-      post_notification(notification_params(
-        attachments: [{ url: 'https://localhost/file.png', filename: 'file.png' }]
-      ))
+      post_notification
     end
     assert_response :success
     assert_equal 0, Issue.order(id: :desc).first.attachments.count
@@ -142,7 +198,7 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     end
   end
 
-  def test_create_attaches_allowed_attachments
+  def test_create_attaches_allowed_attachments_and_renders_their_templates
     set_tmp_attachments_directory
     tempfile = Tempfile.new(['fetched', '.png'])
     tempfile.binmode
@@ -152,16 +208,16 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
       tempfile: tempfile, content_type: 'image/png'
     )
     RedmineGttFiware::AttachmentFetcher.stubs(:for_template).returns(FakeFetcher.new(result))
+    # The filename is templated against the entity to prove plugin-side rendering.
+    @template.update_column(:attachments, [{ 'url' => 'https://broker.example.com/photo.png', 'filename' => 'reading-${attrs.temperature.value}.png' }])
 
     assert_difference 'Issue.count', 1 do
-      post_notification(notification_params(
-        attachments: [{ url: 'https://broker.example.com/photo.png', filename: 'photo.png' }]
-      ))
+      post_notification
     end
     assert_response :success
     issue = Issue.order(id: :desc).first
     assert_equal 1, issue.attachments.count
-    assert_equal 'photo.png', issue.attachments.first.filename
+    assert_equal 'reading-30.png', issue.attachments.first.filename
     assert_equal 'image/png', issue.attachments.first.content_type
   ensure
     tempfile&.close!

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -19,11 +19,15 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
       status: 'active',
       name: 'Escaping test',
       broker_url: 'https://broker.example.com',
-      subject: "Sensor #{INJECTION}",
-      description: "Desc #{INJECTION}",
-      notes: "Note #{INJECTION}",
+      subject: 'Sensor ${id}',
+      description: 'A monitored value changed',
+      notes: 'Latest reading: ${attrs.temperature.value}',
       fiware_service: "smart'city",
-      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      # Since #64 the mapped fields (subject/description/notes/geometry/
+      # attachments) are rendered plugin-side and never leave Redmine. The
+      # entities selector still travels to the broker in the payload, so the
+      # payload-escaping tests inject through it.
+      entities_string: %([{"idPattern": "#{INJECTION}", "type": "TemperatureSensor"}]),
       project_id: 1,
       tracker_id: 1,
       issue_status_id: 1,

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -46,6 +46,26 @@ class EntityTest < ActiveSupport::TestCase
     assert_equal({ 'type' => 'Point', 'coordinates' => [135.5, 34.7] }, e.geometry)
   end
 
+  # A `location` attribute whose value is a scalar (a plain Property, not a
+  # GeoProperty) must not be captured as geometry.
+  def test_ignores_a_scalar_location_property
+    e = Entity.from(ngsi_ld_entity('location' => { 'type' => 'Property', 'value' => 'indoors' }), 'NGSI-LD')
+    assert_nil e.geometry
+  end
+
+  # A real GeoProperty is still captured even when a non-geo attribute sorts
+  # before it (the scalar must not shadow the GeoProperty via `||=`).
+  def test_real_geoproperty_wins_over_a_scalar_location
+    entity = {
+      'id' => 'urn:ngsi-ld:X:1',
+      'type' => 'X',
+      'location' => { 'type' => 'Property', 'value' => 'indoors' },
+      'footprint' => { 'type' => 'GeoProperty', 'value' => { 'type' => 'Point', 'coordinates' => [1, 2] } }
+    }
+    e = Entity.from(entity, 'NGSI-LD')
+    assert_equal({ 'type' => 'Point', 'coordinates' => [1, 2] }, e.geometry)
+  end
+
   def test_ignores_context_and_unknown_paths
     e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
     assert_nil e.resolve('@context')

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -1,0 +1,73 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class EntityTest < ActiveSupport::TestCase
+  Entity = RedmineGttFiware::Entity
+
+  def ngsi_ld_entity(overrides = {})
+    {
+      'id' => 'urn:ngsi-ld:TemperatureSensor:001',
+      'type' => 'TemperatureSensor',
+      '@context' => 'https://example/context.jsonld',
+      'temperature' => { 'type' => 'Property', 'value' => 21.5, 'unitCode' => 'CEL' },
+      'owner' => { 'type' => 'Relationship', 'object' => 'urn:ngsi-ld:Person:42' },
+      'location' => { 'type' => 'GeoProperty', 'value' => { 'type' => 'Point', 'coordinates' => [135.5, 34.7] } },
+    }.merge(overrides)
+  end
+
+  def ngsi_v2_entity(overrides = {})
+    {
+      'id' => 'Sensor:001',
+      'type' => 'TemperatureSensor',
+      'temperature' => { 'type' => 'Number', 'value' => 30, 'metadata' => { 'unitCode' => { 'value' => 'CEL' } } },
+      'location' => { 'type' => 'geo:json', 'value' => { 'type' => 'Point', 'coordinates' => [1, 2] } },
+    }.merge(overrides)
+  end
+
+  def test_normalizes_ngsi_ld_id_and_type
+    e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
+    assert_equal 'urn:ngsi-ld:TemperatureSensor:001', e.id
+    assert_equal 'TemperatureSensor', e.type
+  end
+
+  def test_resolves_ngsi_ld_property_value
+    e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
+    assert_equal 21.5, e.resolve('attrs.temperature.value')
+    assert_equal 21.5, e.resolve('temperature.value')
+    assert_equal 21.5, e.resolve('temperature') # shorthand
+  end
+
+  def test_resolves_ngsi_ld_relationship_object_as_value
+    e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
+    assert_equal 'urn:ngsi-ld:Person:42', e.resolve('owner')
+  end
+
+  def test_extracts_ngsi_ld_geoproperty_as_geometry
+    e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
+    assert_equal({ 'type' => 'Point', 'coordinates' => [135.5, 34.7] }, e.geometry)
+  end
+
+  def test_ignores_context_and_unknown_paths
+    e = Entity.from(ngsi_ld_entity, 'NGSI-LD')
+    assert_nil e.resolve('@context')
+    assert_nil e.resolve('humidity.value')
+    assert_nil e.resolve('')
+  end
+
+  def test_normalizes_ngsi_v2_value_and_metadata
+    e = Entity.from(ngsi_v2_entity, 'NGSIv2')
+    assert_equal 30, e.resolve('attrs.temperature.value')
+    assert_equal 'CEL', e.resolve('attrs.temperature.metadata.unitCode.value')
+  end
+
+  def test_extracts_ngsi_v2_geo_json_as_geometry
+    e = Entity.from(ngsi_v2_entity, 'NGSIv2')
+    assert_equal({ 'type' => 'Point', 'coordinates' => [1, 2] }, e.geometry)
+  end
+
+  def test_handles_non_hash_and_empty_entities
+    e = Entity.from(nil, 'NGSI-LD')
+    assert_nil e.id
+    assert_nil e.geometry
+    assert_nil e.resolve('anything')
+  end
+end

--- a/test/unit/template_renderer_test.rb
+++ b/test/unit/template_renderer_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class TemplateRendererTest < ActiveSupport::TestCase
+  Entity = RedmineGttFiware::Entity
+  Renderer = RedmineGttFiware::TemplateRenderer
+
+  def entity
+    Entity.from({
+      'id' => 'urn:ngsi-ld:TemperatureSensor:001',
+      'type' => 'TemperatureSensor',
+      'temperature' => { 'type' => 'Property', 'value' => 21.5 },
+      'location' => { 'type' => 'GeoProperty', 'value' => { 'type' => 'Point', 'coordinates' => [135.5, 34.7] } },
+    }, 'NGSI-LD')
+  end
+
+  def test_renders_scalar_expressions
+    assert_equal 'Sensor urn:ngsi-ld:TemperatureSensor:001: 21.5',
+                 Renderer.render('Sensor ${id}: ${attrs.temperature.value}', entity)
+  end
+
+  def test_renders_missing_path_as_empty_string
+    assert_equal 'x=', Renderer.render('x=${attrs.nope.value}', entity)
+  end
+
+  def test_returns_nil_for_nil_template
+    assert_nil Renderer.render(nil, entity)
+  end
+
+  def test_stringifies_a_hash_value_as_json
+    assert_equal 'loc={"type":"Point","coordinates":[135.5,34.7]}',
+                 Renderer.render('loc=${location}', entity)
+  end
+
+  def test_render_geometry_substitutes_structurally
+    template = { 'type' => 'Feature', 'geometry' => '${location}' }
+    assert_equal({ 'type' => 'Feature', 'geometry' => { 'type' => 'Point', 'coordinates' => [135.5, 34.7] } },
+                 Renderer.render_geometry(template, entity))
+  end
+
+  def test_render_geometry_nil_passthrough
+    assert_nil Renderer.render_geometry(nil, entity)
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1, part 1 of the FIWARE plugin revival: the **pivotal architecture change** (#64). The broker becomes **pub/sub only** — it POSTs raw NGSIv2 entities and the plugin does all field mapping itself, instead of the broker rendering fields via `httpCustom.json` template expressions.

This lands the plugin-side mapping pipeline and refits the NGSIv2 flow onto it. The NGSI-LD standard support (#63) builds on this pipeline in the follow-up PR.

## What changed

- **`NotificationProcessor`** (new): for each entity — normalize (`Entity`) → render `subject`/`description`/`notes`/`geometry`/`attachments` (`TemplateRenderer`) → apply the **create-vs-update dedup** rule keyed on the entity id within the `threshold_create` window (#47). Owns geometry conversion and attachment fetching; the SSRF protections in `AttachmentFetcher` are unchanged.
- **`Entity`** + **`TemplateRenderer`** (foundation, first commit): normalize an NGSIv2 *or* NGSI-LD entity into one uniform shape and substitute `${...}` expressions (`${id}`, `${type}`, `${attrs.<name>.value}`, `${<name>}` shorthand; missing paths render empty). Geometry templates are substituted structurally so a `${location}` leaf stays valid GeoJSON.
- **`SubscriptionIssuesController#create`**: thinned to parsing the raw JSON notification body, extracting the entity list (`data[]`, a bare entity array, or a single entity), and running each entity through the processor. Returns a batch summary — `200` when at least one issue persisted, `422` only when the whole batch fails validation (a permanent error the broker should not retry).
- **`prepare_payload`**: drops the `httpCustom.json` templating block entirely. `httpCustom` now carries only the callback URL and headers (webhook secret + registration URL). **No template expressions leave Redmine anymore.**

## Wire-format change (breaking, intentional)

The broker subscription no longer contains a `json` template; the broker POSTs raw entities. This is a deliberate breaking change to the notification contract, safe because there are no live deployments. Existing subscriptions must be re-published to pick up the new `httpCustom` shape.

## Security note

Removing the `httpCustom.json` block means user-controlled template fields (`subject`/`description`/`notes`) no longer travel to the broker, so the JS-payload escaping surface for those fields is gone. The only user-controlled field still sent is the `entities` selector, which the payload-escaping tests now target.

## Tests

Local run (RedMica test DB): functional 10 + 10, unit 17 + 8 + 17 + 6 — **0 failures, 0 errors**. New coverage: create/update dedup, `threshold_create` window expiry, multi-entity notifications, and attachment-template rendering.

Closes #64
Closes #65