### PR TITLE
feat: NGSI-LD subscription support via per-standard builder (Phase 1, #63)

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -101,9 +101,7 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def unpublish
-    broker_url = URI(@subscription_template.broker_url)
-    version_path = broker_url.path.match(/\/v2\.\d+\//) ? broker_url.path : "/v2/"
-    @broker_url = broker_url.merge("#{version_path}subscriptions/#{@subscription_template.subscription_id}").to_s
+    @broker_url = subscription_request.subscription_url
     handle_publish_unpublish('unpublish', l(:subscription_unpublished), 'unpublish')
   end
 
@@ -138,67 +136,23 @@ class SubscriptionTemplatesController < ApplicationController
     end
   end
 
+  # Builds the broker request via SubscriptionRequest, which picks the NGSIv2 or
+  # NGSI-LD payload shape from the template's standard (#63). The broker is
+  # pub/sub only (#64): the notification block carries just the callback URL and
+  # auth headers; all field mapping happens plugin-side in NotificationProcessor.
   def prepare_payload
-    broker_url = URI(@subscription_template.broker_url)
-    version_path = broker_url.path.match(/\/v2\.\d+\//) ? broker_url.path : "/v2/"
-    @broker_url = broker_url.merge("#{version_path}subscriptions").to_s
-    @entity_url = broker_url.merge("#{version_path}entities").to_s
+    request_builder = subscription_request
+    @broker_url = request_builder.subscriptions_url
+    @entity_url = request_builder.entities_url
+    @json_payload = request_builder.to_json
+  end
 
-    # httpCustom carries only the callback URL and headers now (#64). The broker
-    # is pub/sub only: it POSTs the raw notification (entities under `data`) and
-    # the plugin renders all fields (subject/description/notes/geometry/
-    # attachments) itself in NotificationProcessor. No `json` templating block
-    # is sent, so no template expressions leave Redmine.
-    http_custom = {
-      url: URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/notification").to_s,
-      headers: {
-        "Content-Type" => "application/json",
-        # Per-template webhook secret, NOT a Redmine API key: it authenticates
-        # the notification and grants nothing beyond creating issues from this
-        # template (see #58). Backfilled on publish, then stable.
-        "X-Gtt-Webhook-Secret" => @subscription_template.webhook_secret,
-        "X-Redmine-GTT-Subscription-Template-URL" => URI.join(request.base_url, "/fiware/subscription_template/#{@subscription_template.id}/registration/").to_s
-      },
-      method: "POST"
-    }
-
-    @json_payload = {
-      description: CGI.escape(@subscription_template.name),
-      subject: {
-        entities: @subscription_template.entities,
-        condition: {
-          notifyOnMetadataChange: @subscription_template.notify_on_metadata_change
-        }
-      },
-      notification: {
-        attrsFormat: "normalized",
-        metadata: ["dateCreated", "*"],
-        onlyChangedAttrs: false,
-        covered: false,
-        httpCustom: http_custom
-      },
-      throttling: Setting.plugin_redmine_gtt_fiware['fiware_broker_subscription_throttling'].to_i || 1,
-      status: @subscription_template.status
-    }
-
-    @json_payload[:id] = @subscription_template.subscription_id if @subscription_template.subscription_id.present?
-    @json_payload[:expires] = @subscription_template.expires if @subscription_template.expires.present?
-
-    expression = {}
-
-    if @subscription_template.expression_georel.present? && @subscription_template.expression_geometry.present? && @subscription_template.expression_coords.present?
-      expression[:georel] = @subscription_template.expression_georel
-      expression[:geometry] = @subscription_template.expression_geometry
-      expression[:coords] = @subscription_template.expression_coords
-    end
-
-    expression[:q] = @subscription_template.expression_query if @subscription_template.expression_query.present?
-
-    @json_payload[:subject][:condition][:expression] = expression if expression.present?
-    @json_payload[:subject][:condition][:attrs] = JSON.parse(@subscription_template.attrs) if @subscription_template.attrs.present?
-    @json_payload[:subject][:condition][:alterationTypes] = @subscription_template.alteration_types if @subscription_template.alteration_types.present?
-
-    @json_payload = JSON.generate(@json_payload)
+  def subscription_request
+    RedmineGttFiware::SubscriptionRequest.build(
+      @subscription_template,
+      base_url: request.base_url,
+      throttling: Setting.plugin_redmine_gtt_fiware['fiware_broker_subscription_throttling'].to_i
+    )
   end
 
   def new_path

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -22,10 +22,21 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   belongs_to :issue_category, optional: true
   belongs_to :issue_priority, optional: true, class_name: 'IssuePriority', foreign_key: 'issue_priority_id'
 
-  STANDARDS = ['NGSIv2'].freeze
+  STANDARDS = ['NGSIv2', 'NGSI-LD'].freeze
   STATUS = ['active', 'inactive', 'oneshot'].freeze
   GEOMETRIES = ['point', 'line', 'polygon', 'box'].freeze
   ALTERATION_TYPES = ['entityCreate', 'entityChange', 'entityUpdate', 'entityDelete'].freeze
+
+  # Maps the stored NGSIv2 alteration types to their NGSI-LD notification
+  # triggers. NGSI-LD replaces `alterationTypes` with `notificationTrigger`
+  # and has no distinct "change" trigger, so both entityChange and
+  # entityUpdate collapse to entityUpdated (deduplicated in #notification_triggers).
+  NGSI_LD_TRIGGER_MAP = {
+    'entityCreate' => 'entityCreated',
+    'entityChange' => 'entityUpdated',
+    'entityUpdate' => 'entityUpdated',
+    'entityDelete' => 'entityDeleted'
+  }.freeze
 
   validates :standard, inclusion: { in: STANDARDS, message: I18n.t('model.subscription_template.valid_standard') }
   validates :status, inclusion: { in: STATUS, message: I18n.t('model.subscription_template.valid_status') }
@@ -37,6 +48,9 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   validates :subject, presence: true
   validates :description, presence: true
   validates :entities_string, presence: true
+  # NGSI-LD resolves the entity/attribute terms through @context, so a template
+  # for that standard must carry one. NGSIv2 has no context.
+  validates :context, presence: true, if: :ngsi_ld?
 
   validate :name_uniqueness
   validate :take_json_entities
@@ -50,6 +64,17 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
 
   def self.generate_webhook_secret
     SecureRandom.hex(WEBHOOK_SECRET_BYTES)
+  end
+
+  def ngsi_ld?
+    standard.to_s.casecmp('NGSI-LD').zero?
+  end
+
+  # The NGSI-LD notification triggers for this template's alteration types,
+  # deduplicated (see NGSI_LD_TRIGGER_MAP). Empty for a template with no
+  # alteration types configured.
+  def notification_triggers
+    Array(alteration_types).filter_map { |type| NGSI_LD_TRIGGER_MAP[type] }.uniq
   end
 
   # Persist a secret only if the template does not already have one (e.g. a

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -1,0 +1,72 @@
+require 'cgi'
+require 'json'
+require 'uri'
+
+module RedmineGttFiware
+  # Builds the broker subscription request (endpoints + JSON body) for a
+  # subscription template. NgsiV2 and NgsiLd subclass this with the standard's
+  # payload shape and API path; SubscriptionRequest.build picks the right one.
+  #
+  # The broker is pub/sub only (#64): the notification block carries only the
+  # callback endpoint and the webhook-auth headers (webhook secret +
+  # registration URL). All entity-to-issue mapping happens plugin-side in
+  # NotificationProcessor, so no field templating is sent to the broker.
+  class SubscriptionRequest
+    WEBHOOK_SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
+    REGISTRATION_URL_HEADER = 'X-Redmine-GTT-Subscription-Template-URL'.freeze
+
+    # base_url: the Redmine base URL (request.base_url) for callback endpoints.
+    def self.build(template, base_url:, throttling: 1)
+      klass = template.ngsi_ld? ? NgsiLd : NgsiV2
+      klass.new(template, base_url: base_url, throttling: throttling)
+    end
+
+    def initialize(template, base_url:, throttling: 1)
+      @template = template
+      @base_url = base_url
+      @throttling = throttling
+    end
+
+    # POST target that creates a subscription.
+    def subscriptions_url
+      broker_uri.merge("#{version_path}subscriptions").to_s
+    end
+
+    # DELETE target that removes the template's current subscription.
+    def subscription_url
+      broker_uri.merge("#{version_path}subscriptions/#{@template.subscription_id}").to_s
+    end
+
+    # Broker entities collection (used by the copy-as-curl helper).
+    def entities_url
+      broker_uri.merge("#{version_path}entities").to_s
+    end
+
+    def to_json(*_args)
+      JSON.generate(payload)
+    end
+
+    private
+
+    # Subclasses implement these.
+    def version_path
+      raise NotImplementedError
+    end
+
+    def payload
+      raise NotImplementedError
+    end
+
+    def broker_uri
+      URI(@template.broker_url)
+    end
+
+    def callback_url
+      URI.join(@base_url, "/fiware/subscription_template/#{@template.id}/notification").to_s
+    end
+
+    def registration_url
+      URI.join(@base_url, "/fiware/subscription_template/#{@template.id}/registration/").to_s
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -48,8 +48,22 @@ module RedmineGttFiware
 
     private
 
-    # Subclasses implement these.
+    # Preserve an explicit versioned API path in the broker URL, with or
+    # without a trailing slash (normalized to end with one), otherwise fall
+    # back to the standard's default prefix.
     def version_path
+      path = broker_uri.path
+      return default_version_path unless path.match?(versioned_path_pattern)
+
+      path.end_with?('/') ? path : "#{path}/"
+    end
+
+    # Subclasses implement these.
+    def default_version_path
+      raise NotImplementedError
+    end
+
+    def versioned_path_pattern
       raise NotImplementedError
     end
 

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -12,11 +12,14 @@ module RedmineGttFiware
     class NgsiLd < SubscriptionRequest
       private
 
-      # Preserve an explicit /ngsi-ld/v1/-style path in the broker URL,
-      # otherwise default to the standard prefix.
-      def version_path
-        path = broker_uri.path
-        path.match(%r{/ngsi-ld/v\d+/}) ? path : '/ngsi-ld/v1/'
+      # An explicit /ngsi-ld/v1-style path in the broker URL is preserved by
+      # SubscriptionRequest#version_path; otherwise the standard prefix.
+      def default_version_path
+        '/ngsi-ld/v1/'
+      end
+
+      def versioned_path_pattern
+        %r{/ngsi-ld/v\d+(/|\z)}
       end
 
       def payload

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -10,6 +10,16 @@ module RedmineGttFiware
     # `notification.format` is `normalized` so entities arrive in
     # Property/Relationship/GeoProperty form, which Entity#from_ngsi_ld expects.
     class NgsiLd < SubscriptionRequest
+      # The template stores NGSIv2 geometry names (SubscriptionTemplate::
+      # GEOMETRIES); NGSI-LD geoQ.geometry takes GeoJSON type names. `box` has
+      # no NGSI-LD equivalent and passes through verbatim, so the broker
+      # rejects it with a clear error instead of the plugin guessing a shape.
+      GEOMETRY_TYPE_MAP = {
+        'point' => 'Point',
+        'line' => 'LineString',
+        'polygon' => 'Polygon'
+      }.freeze
+
       private
 
       # An explicit /ngsi-ld/v1-style path in the broker URL is preserved by
@@ -63,9 +73,10 @@ module RedmineGttFiware
                           @template.expression_geometry.present? &&
                           @template.expression_coords.present?
 
+        geometry = @template.expression_geometry
         {
           georel: @template.expression_georel,
-          geometry: @template.expression_geometry,
+          geometry: GEOMETRY_TYPE_MAP.fetch(geometry, geometry),
           coordinates: @template.expression_coords
         }
       end

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -1,0 +1,96 @@
+module RedmineGttFiware
+  class SubscriptionRequest
+    # Builds an NGSI-LD subscription (`/ngsi-ld/v1/subscriptions`). The LD shape
+    # differs from NGSIv2: the selector fields sit at the top level (`entities`,
+    # `q`, `geoQ`, `watchedAttributes`), change filtering uses
+    # `notificationTrigger` (not `alterationTypes`), the callback is
+    # `notification.endpoint` with `receiverInfo` headers, and JSON-LD terms are
+    # resolved through `@context`.
+    #
+    # `notification.format` is `normalized` so entities arrive in
+    # Property/Relationship/GeoProperty form, which Entity#from_ngsi_ld expects.
+    class NgsiLd < SubscriptionRequest
+      private
+
+      # Preserve an explicit /ngsi-ld/v1/-style path in the broker URL,
+      # otherwise default to the standard prefix.
+      def version_path
+        path = broker_uri.path
+        path.match(%r{/ngsi-ld/v\d+/}) ? path : '/ngsi-ld/v1/'
+      end
+
+      def payload
+        payload = {
+          type: 'Subscription',
+          description: @template.name,
+          entities: @template.entities,
+          notification: notification,
+          isActive: @template.status == 'active',
+          throttling: @throttling
+        }
+
+        payload[:id] = @template.subscription_id if @template.subscription_id.present?
+        payload['@context'] = ld_context if ld_context
+        payload[:watchedAttributes] = parsed_attrs if parsed_attrs.present?
+        payload[:q] = @template.expression_query if @template.expression_query.present?
+        payload[:geoQ] = geo_q if geo_q
+        triggers = @template.notification_triggers
+        payload[:notificationTrigger] = triggers if triggers.present?
+        payload[:expiresAt] = expires_at if expires_at
+
+        payload
+      end
+
+      def notification
+        {
+          format: 'normalized',
+          endpoint: {
+            uri: callback_url,
+            accept: 'application/json',
+            receiverInfo: [
+              { key: WEBHOOK_SECRET_HEADER, value: @template.webhook_secret },
+              { key: REGISTRATION_URL_HEADER, value: registration_url }
+            ]
+          }
+        }
+      end
+
+      def geo_q
+        return nil unless @template.expression_georel.present? &&
+                          @template.expression_geometry.present? &&
+                          @template.expression_coords.present?
+
+        {
+          georel: @template.expression_georel,
+          geometry: @template.expression_geometry,
+          coordinates: @template.expression_coords
+        }
+      end
+
+      # @context may be a single URL or a JSON array/object of contexts. Parse
+      # it when it is JSON, otherwise pass the URL string through unchanged.
+      def ld_context
+        raw = @template.context.to_s.strip
+        return nil if raw.empty?
+
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        raw
+      end
+
+      def parsed_attrs
+        return nil if @template.attrs.blank?
+
+        JSON.parse(@template.attrs)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def expires_at
+        return nil if @template.expires.blank?
+
+        @template.expires.respond_to?(:iso8601) ? @template.expires.iso8601 : @template.expires.to_s
+      end
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
@@ -6,11 +6,14 @@ module RedmineGttFiware
     class NgsiV2 < SubscriptionRequest
       private
 
-      # Preserve an explicit versioned path in the broker URL (e.g. /v2.1/),
-      # otherwise default to /v2/.
-      def version_path
-        path = broker_uri.path
-        path.match(%r{/v2\.\d+/}) ? path : '/v2/'
+      # An explicit versioned path in the broker URL (e.g. /orion/v2.1) is
+      # preserved by SubscriptionRequest#version_path; otherwise /v2/.
+      def default_version_path
+        '/v2/'
+      end
+
+      def versioned_path_pattern
+        %r{/v2\.\d+(/|\z)}
       end
 
       def payload

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
@@ -1,0 +1,81 @@
+module RedmineGttFiware
+  class SubscriptionRequest
+    # Builds an NGSIv2 subscription (Orion `/v2/subscriptions`). Since #64 the
+    # httpCustom block carries only the callback URL and auth headers; the
+    # `json` field-templating block is gone (the plugin renders fields itself).
+    class NgsiV2 < SubscriptionRequest
+      private
+
+      # Preserve an explicit versioned path in the broker URL (e.g. /v2.1/),
+      # otherwise default to /v2/.
+      def version_path
+        path = broker_uri.path
+        path.match(%r{/v2\.\d+/}) ? path : '/v2/'
+      end
+
+      def payload
+        payload = {
+          description: CGI.escape(@template.name),
+          subject: {
+            entities: @template.entities,
+            condition: {
+              notifyOnMetadataChange: @template.notify_on_metadata_change
+            }
+          },
+          notification: {
+            attrsFormat: 'normalized',
+            metadata: ['dateCreated', '*'],
+            onlyChangedAttrs: false,
+            covered: false,
+            httpCustom: http_custom
+          },
+          throttling: @throttling,
+          status: @template.status
+        }
+
+        payload[:id] = @template.subscription_id if @template.subscription_id.present?
+        payload[:expires] = @template.expires if @template.expires.present?
+
+        condition = payload[:subject][:condition]
+        condition[:expression] = expression if expression.present?
+        condition[:attrs] = parsed_attrs if parsed_attrs.present?
+        condition[:alterationTypes] = @template.alteration_types if @template.alteration_types.present?
+
+        payload
+      end
+
+      def http_custom
+        {
+          url: callback_url,
+          headers: {
+            'Content-Type' => 'application/json',
+            WEBHOOK_SECRET_HEADER => @template.webhook_secret,
+            REGISTRATION_URL_HEADER => registration_url
+          },
+          method: 'POST'
+        }
+      end
+
+      def expression
+        expression = {}
+        if @template.expression_georel.present? &&
+           @template.expression_geometry.present? &&
+           @template.expression_coords.present?
+          expression[:georel] = @template.expression_georel
+          expression[:geometry] = @template.expression_geometry
+          expression[:coords] = @template.expression_coords
+        end
+        expression[:q] = @template.expression_query if @template.expression_query.present?
+        expression
+      end
+
+      def parsed_attrs
+        return nil if @template.attrs.blank?
+
+        JSON.parse(@template.attrs)
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -106,6 +106,36 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_includes response.body, ESCAPED_INJECTION
   end
 
+  # Publishing an NGSI-LD template builds the LD subscription (#63): the broker
+  # URL uses the /ngsi-ld/v1/ prefix and the payload carries the LD shape
+  # (@context, notification.endpoint.receiverInfo, notificationTrigger).
+  def test_publish_builds_an_ngsi_ld_subscription
+    ld_template = SubscriptionTemplate.create!(
+      standard: 'NGSI-LD',
+      status: 'active',
+      name: 'LD alerts',
+      broker_url: 'https://broker.example.com',
+      subject: 'Sensor ${id}',
+      description: 'A monitored value changed',
+      context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld',
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      project_id: 1,
+      tracker_id: 1,
+      issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id,
+      member_id: 1
+    )
+    post :publish, params: { project_id: @project.id, id: ld_template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_includes response.body, 'https://broker.example.com/ngsi-ld/v1/subscriptions'
+    assert_includes response.body, 'receiverInfo'
+    assert_includes response.body, 'notificationTrigger'
+    assert_includes response.body, '@context'
+    # The webhook secret rides in receiverInfo, and no NGSIv2 httpCustom shape.
+    assert_includes response.body, ld_template.reload.webhook_secret
+    assert_not_includes response.body, 'httpCustom'
+  end
+
   # State-changing endpoints must not be reachable via GET.
   def test_publish_and_unpublish_are_post_only
     assert_routing(

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -144,16 +144,32 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_equal %w[entityCreated entityUpdated entityDeleted], p['notificationTrigger']
   end
 
+  # geoQ uses the `coordinates` key, and the stored NGSIv2 geometry name is
+  # mapped to the GeoJSON type name NGSI-LD expects.
   def test_ngsi_ld_builds_geo_q_with_coordinates_key
     p = payload('NGSI-LD',
                 expression_georel: 'near;maxDistance==2000',
-                expression_geometry: 'Point',
+                expression_geometry: 'point',
                 expression_coords: '[135,35]')
     geo_q = p['geoQ']
     assert_equal 'near;maxDistance==2000', geo_q['georel']
     assert_equal 'Point', geo_q['geometry']
     assert_equal '[135,35]', geo_q['coordinates']
     assert_nil geo_q['coords']
+  end
+
+  def test_ngsi_ld_maps_line_and_polygon_geometry_names
+    line = payload('NGSI-LD', expression_georel: 'intersects', expression_geometry: 'line', expression_coords: '[[0,0],[1,1]]')
+    assert_equal 'LineString', line.dig('geoQ', 'geometry')
+    polygon = payload('NGSI-LD', expression_georel: 'within', expression_geometry: 'polygon', expression_coords: '[[[0,0],[1,0],[1,1],[0,0]]]')
+    assert_equal 'Polygon', polygon.dig('geoQ', 'geometry')
+  end
+
+  # `box` has no NGSI-LD equivalent: it passes through verbatim so the broker
+  # rejects it with a clear error rather than the plugin guessing a shape.
+  def test_ngsi_ld_passes_unmappable_box_geometry_through
+    p = payload('NGSI-LD', expression_georel: 'within', expression_geometry: 'box', expression_coords: '[[0,0],[1,1]]')
+    assert_equal 'box', p.dig('geoQ', 'geometry')
   end
 
   def test_ngsi_ld_watched_attributes_from_attrs

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -17,6 +17,9 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
         context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'
       }.merge(overrides)
     )
+    # Deterministic id without a DB write so callback URLs have a realistic
+    # shape (`.../subscription_template/123/notification`).
+    t.id = 123
     t.entities = [{ 'idPattern' => '.*', 'type' => 'TemperatureSensor' }]
     t.webhook_secret = 'secret-abc'
     t.alteration_types = overrides[:alteration_types] if overrides.key?(:alteration_types)
@@ -58,6 +61,23 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_equal 'https://broker.example.com/ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:1', req.subscription_url
   end
 
+  # An explicit versioned path in the broker URL is preserved, with or without
+  # a trailing slash (normalized to end with one).
+  def test_ngsi_v2_preserves_a_versioned_broker_path_without_trailing_slash
+    req = build('NGSIv2', broker_url: 'https://broker.example.com/orion/v2.1')
+    assert_equal 'https://broker.example.com/orion/v2.1/subscriptions', req.subscriptions_url
+  end
+
+  def test_ngsi_v2_preserves_a_versioned_broker_path_with_trailing_slash
+    req = build('NGSIv2', broker_url: 'https://broker.example.com/orion/v2.1/')
+    assert_equal 'https://broker.example.com/orion/v2.1/subscriptions', req.subscriptions_url
+  end
+
+  def test_ngsi_ld_preserves_a_versioned_broker_path_without_trailing_slash
+    req = build('NGSI-LD', broker_url: 'https://broker.example.com/broker/ngsi-ld/v1')
+    assert_equal 'https://broker.example.com/broker/ngsi-ld/v1/subscriptions', req.subscriptions_url
+  end
+
   # --- NGSIv2 payload -------------------------------------------------------
 
   def test_ngsi_v2_payload_shape
@@ -70,7 +90,7 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
 
   def test_ngsi_v2_notification_carries_only_callback_and_headers_no_templating
     http_custom = payload('NGSIv2').dig('notification', 'httpCustom')
-    assert_equal 'https://redmine.example.com/fiware/subscription_template//notification', http_custom['url']
+    assert_equal 'https://redmine.example.com/fiware/subscription_template/123/notification', http_custom['url']
     assert_equal 'POST', http_custom['method']
     assert_equal 'secret-abc', http_custom.dig('headers', 'X-Gtt-Webhook-Secret')
     # The broker does no field templating anymore (#64): no json block.
@@ -103,7 +123,7 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
 
   def test_ngsi_ld_endpoint_carries_receiver_info_headers
     endpoint = payload('NGSI-LD').dig('notification', 'endpoint')
-    assert_equal 'https://redmine.example.com/fiware/subscription_template//notification', endpoint['uri']
+    assert_equal 'https://redmine.example.com/fiware/subscription_template/123/notification', endpoint['uri']
     secret = endpoint['receiverInfo'].find { |h| h['key'] == 'X-Gtt-Webhook-Secret' }
     assert_equal 'secret-abc', secret['value']
     assert endpoint['receiverInfo'].any? { |h| h['key'] == 'X-Redmine-GTT-Subscription-Template-URL' }

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -1,0 +1,152 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class SubscriptionRequestTest < ActiveSupport::TestCase
+  BASE_URL = 'https://redmine.example.com'.freeze
+
+  # Builds an unsaved template (no DB write) with sensible defaults for the
+  # given standard; overrides win.
+  def template(standard, overrides = {})
+    t = SubscriptionTemplate.new(
+      {
+        standard: standard,
+        status: 'active',
+        name: 'Temperature alerts',
+        broker_url: 'https://broker.example.com',
+        subject: 'Sensor ${id}',
+        description: 'changed',
+        context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'
+      }.merge(overrides)
+    )
+    t.entities = [{ 'idPattern' => '.*', 'type' => 'TemperatureSensor' }]
+    t.webhook_secret = 'secret-abc'
+    t.alteration_types = overrides[:alteration_types] if overrides.key?(:alteration_types)
+    t
+  end
+
+  def build(standard, overrides = {})
+    RedmineGttFiware::SubscriptionRequest.build(template(standard, overrides), base_url: BASE_URL, throttling: 3)
+  end
+
+  def payload(standard, overrides = {})
+    JSON.parse(build(standard, overrides).to_json)
+  end
+
+  # --- factory / URLs -------------------------------------------------------
+
+  def test_build_selects_the_ngsi_v2_builder
+    assert_instance_of RedmineGttFiware::SubscriptionRequest::NgsiV2, build('NGSIv2')
+  end
+
+  def test_build_selects_the_ngsi_ld_builder
+    assert_instance_of RedmineGttFiware::SubscriptionRequest::NgsiLd, build('NGSI-LD')
+  end
+
+  def test_ngsi_v2_urls_use_the_v2_prefix
+    req = build('NGSIv2')
+    assert_equal 'https://broker.example.com/v2/subscriptions', req.subscriptions_url
+    assert_equal 'https://broker.example.com/v2/entities', req.entities_url
+  end
+
+  def test_ngsi_ld_urls_use_the_ngsi_ld_prefix
+    req = build('NGSI-LD')
+    assert_equal 'https://broker.example.com/ngsi-ld/v1/subscriptions', req.subscriptions_url
+    assert_equal 'https://broker.example.com/ngsi-ld/v1/entities', req.entities_url
+  end
+
+  def test_subscription_url_targets_the_current_subscription
+    req = build('NGSI-LD', subscription_id: 'urn:ngsi-ld:Subscription:1')
+    assert_equal 'https://broker.example.com/ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:1', req.subscription_url
+  end
+
+  # --- NGSIv2 payload -------------------------------------------------------
+
+  def test_ngsi_v2_payload_shape
+    p = payload('NGSIv2', alteration_types: %w[entityCreate entityChange])
+    assert_equal [{ 'idPattern' => '.*', 'type' => 'TemperatureSensor' }], p.dig('subject', 'entities')
+    assert_equal %w[entityCreate entityChange], p.dig('subject', 'condition', 'alterationTypes')
+    assert_equal 3, p['throttling']
+    assert_equal 'active', p['status']
+  end
+
+  def test_ngsi_v2_notification_carries_only_callback_and_headers_no_templating
+    http_custom = payload('NGSIv2').dig('notification', 'httpCustom')
+    assert_equal 'https://redmine.example.com/fiware/subscription_template//notification', http_custom['url']
+    assert_equal 'POST', http_custom['method']
+    assert_equal 'secret-abc', http_custom.dig('headers', 'X-Gtt-Webhook-Secret')
+    # The broker does no field templating anymore (#64): no json block.
+    assert_nil http_custom['json']
+  end
+
+  def test_ngsi_v2_builds_expression_when_geo_fields_and_query_present
+    p = payload('NGSIv2',
+                expression_georel: 'near;maxDistance==2000',
+                expression_geometry: 'point',
+                expression_coords: '135,35',
+                expression_query: 'temperature>30')
+    expr = p.dig('subject', 'condition', 'expression')
+    assert_equal 'near;maxDistance==2000', expr['georel']
+    assert_equal 'point', expr['geometry']
+    assert_equal '135,35', expr['coords']
+    assert_equal 'temperature>30', expr['q']
+  end
+
+  # --- NGSI-LD payload ------------------------------------------------------
+
+  def test_ngsi_ld_payload_shape
+    p = payload('NGSI-LD')
+    assert_equal 'Subscription', p['type']
+    assert_equal [{ 'idPattern' => '.*', 'type' => 'TemperatureSensor' }], p['entities']
+    assert_equal 'normalized', p.dig('notification', 'format')
+    assert_equal true, p['isActive']
+    assert_equal 3, p['throttling']
+  end
+
+  def test_ngsi_ld_endpoint_carries_receiver_info_headers
+    endpoint = payload('NGSI-LD').dig('notification', 'endpoint')
+    assert_equal 'https://redmine.example.com/fiware/subscription_template//notification', endpoint['uri']
+    secret = endpoint['receiverInfo'].find { |h| h['key'] == 'X-Gtt-Webhook-Secret' }
+    assert_equal 'secret-abc', secret['value']
+    assert endpoint['receiverInfo'].any? { |h| h['key'] == 'X-Redmine-GTT-Subscription-Template-URL' }
+  end
+
+  def test_ngsi_ld_context_url_passes_through
+    p = payload('NGSI-LD', context: 'https://example.test/context.jsonld')
+    assert_equal 'https://example.test/context.jsonld', p['@context']
+  end
+
+  def test_ngsi_ld_context_json_array_is_parsed
+    p = payload('NGSI-LD', context: '["https://a.test/ctx.jsonld","https://b.test/ctx.jsonld"]')
+    assert_equal ['https://a.test/ctx.jsonld', 'https://b.test/ctx.jsonld'], p['@context']
+  end
+
+  def test_ngsi_ld_maps_and_dedupes_notification_triggers
+    p = payload('NGSI-LD', alteration_types: %w[entityCreate entityChange entityUpdate entityDelete])
+    assert_equal %w[entityCreated entityUpdated entityDeleted], p['notificationTrigger']
+  end
+
+  def test_ngsi_ld_builds_geo_q_with_coordinates_key
+    p = payload('NGSI-LD',
+                expression_georel: 'near;maxDistance==2000',
+                expression_geometry: 'Point',
+                expression_coords: '[135,35]')
+    geo_q = p['geoQ']
+    assert_equal 'near;maxDistance==2000', geo_q['georel']
+    assert_equal 'Point', geo_q['geometry']
+    assert_equal '[135,35]', geo_q['coordinates']
+    assert_nil geo_q['coords']
+  end
+
+  def test_ngsi_ld_watched_attributes_from_attrs
+    p = payload('NGSI-LD', attrs: '["temperature","humidity"]')
+    assert_equal %w[temperature humidity], p['watchedAttributes']
+  end
+
+  def test_ngsi_ld_omits_optional_fields_when_absent
+    p = payload('NGSI-LD', alteration_types: [])
+    assert_not p.key?('q')
+    assert_not p.key?('geoQ')
+    assert_not p.key?('watchedAttributes')
+    assert_not p.key?('notificationTrigger')
+    assert_not p.key?('expiresAt')
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1, part 2 of the FIWARE plugin revival (#63). NGSI-LD becomes a first-class subscription standard alongside NGSIv2. It builds directly on the plugin-side mapping pipeline landed in #85 (broker is pub/sub only): the **receiving** side already normalizes and maps LD entities through `Entity` / `NotificationProcessor`, so this PR adds the **outbound** subscription-building side plus the model support.

## What changed

- **`SubscriptionRequest` builder** — extracted from the controller's fat `prepare_payload` into `lib/`, with two per-standard subclasses:
  - `NgsiV2` — same `/v2/subscriptions` payload as before (minus the removed `httpCustom.json` templating); behaviour-compatible.
  - `NgsiLd` — `/ngsi-ld/v1/subscriptions` payload: top-level `entities` / `q` / `geoQ` / `watchedAttributes`, `notificationTrigger` (mapped from alteration types), `@context` (URL string or JSON array), `notification.endpoint` with `receiverInfo` headers for the webhook secret + registration URL, `expiresAt`, and `isActive`. `notification.format` is `normalized` so entities arrive in Property/Relationship/GeoProperty form (what `Entity#from_ngsi_ld` expects).
- **`SubscriptionTemplate`** — `NGSI-LD` added to `STANDARDS`; `ngsi_ld?`; `notification_triggers` (maps NGSIv2 alteration types to LD triggers, deduped so `entityChange`/`entityUpdate` collapse to `entityUpdated`); `context` is now required for NGSI-LD templates (LD resolves terms through `@context`).
- **Controller** — `prepare_payload` and `unpublish` delegate to `SubscriptionRequest`; the standard-specific URL / version-path logic moves into the builder.

## Trigger mapping (NGSIv2 -> NGSI-LD)

| alteration type | notificationTrigger |
| --- | --- |
| entityCreate | entityCreated |
| entityChange | entityUpdated |
| entityUpdate | entityUpdated |
| entityDelete | entityDeleted |

Deduplicated, so `[entityCreate, entityChange, entityUpdate, entityDelete]` -> `[entityCreated, entityUpdated, entityDeleted]`.

## Tests

Full plugin suite green locally (92 tests). New coverage:
- `SubscriptionRequest` unit tests for both standards — URLs/version paths, payload shapes, trigger mapping + dedup, `@context` URL-vs-array handling, `geoQ` `coordinates` key, optional-field omission.
- NGSI-LD publish functional test through the controller (LD broker URL, `receiverInfo`, `notificationTrigger`, `@context`; no `httpCustom`).

## Follow-ups (not in this PR)

- Reference broker: verify against GeonicDB and Orion-LD live.
- Form UX still shows NGSIv2-only fields (e.g. `notify_on_metadata_change`) for LD templates; polishing the form belongs to Phase 2 (UX).

Closes #63