### PR TITLE
fix: bare-geometry conversion + prove update logic without notes (#47)

### DIFF
--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -113,10 +113,20 @@ module RedmineGttFiware
       geometry = TemplateRenderer.render_geometry(@template.geometry, entity)
       return nil if geometry.blank?
 
-      RedmineGtt::Conversions.to_geom(geometry.to_json)
+      RedmineGtt::Conversions.to_geom(as_feature(geometry).to_json)
     rescue StandardError => e
       @logger.warn "[FIWARE] Failed to convert geometry data: #{e.message}"
       nil
+    end
+
+    # RedmineGtt::Conversions.to_geom expects a GeoJSON Feature (it calls
+    # .geometry on the decoded result), so a template resolving to a bare
+    # geometry — the common `${location}` case — is wrapped in one.
+    def as_feature(geometry)
+      return geometry unless geometry.is_a?(Hash)
+      return geometry if geometry['type'].to_s == 'Feature'
+
+      { 'type' => 'Feature', 'geometry' => geometry, 'properties' => nil }
     end
 
     def gtt_enabled?

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -115,13 +115,16 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_not_nil issue.geom
 
     moved = { 'type' => 'geo:json', 'value' => { 'type' => 'Point', 'coordinates' => [136.0, 36.0] } }
+    original_geom = issue.geom
     assert_no_difference 'Issue.count' do
       post_notification(entities: [entity('location' => moved)])
     end
     assert_response :success
     issue.reload
+    assert_not_equal original_geom, issue.geom, 'the geometry must actually change'
     journal = issue.journals.order(:id).last
     assert_not_nil journal
+    assert journal.notes.blank?, 'no notes template configured, so the journal has no notes'
     assert journal.details.any? { |d| d.prop_key == 'geom' },
            'geometry change must be recorded as a journal detail'
   end
@@ -155,6 +158,9 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :success
     issue.reload
     assert_equal ['reading-30.png', 'reading-31.png'], issue.attachments.map(&:filename).sort
+    # No notes template configured: the update journals must carry no notes.
+    assert issue.journals.all? { |j| j.notes.blank? },
+           'no notes template configured, so update journals have no notes'
   ensure
     tempfile&.close!
   end

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -100,6 +100,65 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal 'Latest reading: 42', issue.journals.order(:id).last.notes
   end
 
+  # #47: value updates must be applied even when the template has no notes
+  # configured. A geometry change within the threshold window updates the
+  # issue's geom and records a journal detail, notes or not.
+  def test_update_applies_geometry_change_without_notes_configured
+    skip 'redmine_gtt not installed' unless Redmine::Plugin.installed?(:redmine_gtt)
+    Project.find(1).enabled_module_names |= ['gtt']
+    @template.update_columns(notes: nil, geometry: '${location}')
+
+    location = { 'type' => 'geo:json', 'value' => { 'type' => 'Point', 'coordinates' => [135.0, 35.0] } }
+    post_notification(entities: [entity('location' => location)])
+    assert_response :success
+    issue = Issue.order(id: :desc).first
+    assert_not_nil issue.geom
+
+    moved = { 'type' => 'geo:json', 'value' => { 'type' => 'Point', 'coordinates' => [136.0, 36.0] } }
+    assert_no_difference 'Issue.count' do
+      post_notification(entities: [entity('location' => moved)])
+    end
+    assert_response :success
+    issue.reload
+    journal = issue.journals.order(:id).last
+    assert_not_nil journal
+    assert journal.details.any? { |d| d.prop_key == 'geom' },
+           'geometry change must be recorded as a journal detail'
+  end
+
+  # #47: new attachments (e.g. new photos) are added on update even when the
+  # template has no notes configured; already-attached filenames are skipped.
+  def test_update_adds_new_attachments_without_notes_configured
+    set_tmp_attachments_directory
+    tempfile = Tempfile.new(['fetched', '.png'])
+    tempfile.binmode
+    tempfile.write('PNGDATA')
+    tempfile.rewind
+    result = RedmineGttFiware::AttachmentFetcher::Result.new(
+      tempfile: tempfile, content_type: 'image/png'
+    )
+    RedmineGttFiware::AttachmentFetcher.stubs(:for_template).returns(FakeFetcher.new(result))
+    @template.update_columns(
+      notes: nil,
+      attachments: [{ 'url' => 'https://broker.example.com/photo.png', 'filename' => 'reading-${attrs.temperature.value}.png' }]
+    )
+
+    post_notification
+    assert_response :success
+    issue = Issue.order(id: :desc).first
+    assert_equal ['reading-30.png'], issue.attachments.map(&:filename)
+
+    # Same filename again: skipped. New reading -> new filename: attached.
+    assert_no_difference 'Issue.count' do
+      post_notification(entities: [entity, entity('temperature' => { 'type' => 'Number', 'value' => 31 })])
+    end
+    assert_response :success
+    issue.reload
+    assert_equal ['reading-30.png', 'reading-31.png'], issue.attachments.map(&:filename).sort
+  ensure
+    tempfile&.close!
+  end
+
   # Outside the threshold_create window a new notification creates a new issue.
   def test_create_makes_a_new_issue_outside_the_threshold_window
     post_notification


### PR DESCRIPTION
## Summary

Closes out the last code item of Phase 1: #47 (review issue-update logic). Writing the missing tests uncovered a real bug in the Phase 1 pipeline, fixed here.

## Bug fix

`RedmineGtt::Conversions.to_geom` decodes GeoJSON and calls `.geometry` on the result, so it only accepts a **Feature**. A geometry template resolving to a bare geometry — the common `${location}` case — raised `NoMethodError` inside the rescue and silently produced no geom at all. `NotificationProcessor` now wraps a bare geometry hash in a Feature before conversion (an explicit Feature template still passes through unchanged).

## #47 requirements proven by tests (no `notes` configured)

- A geometry change within the `threshold_create` window updates `issue.geom` **and** records a `geom` journal detail.
- New attachments (e.g. new photos) are added on update; already-attached filenames are skipped (dedup), and templated filenames (`reading-${attrs.temperature.value}.png`) produce distinct attachments per reading.

Since #85, the update path never depended on `notes`: `init_journal` is called with the rendered notes (or nil), geometry and attachments are processed regardless, and Redmine persists the journal when it has notes **or** details.

## Remaining #47 scope

The geofence enter/leave checkboxes are stateful feature work (a single notification cannot tell you the entity *was* inside), split out to #87.

Closes #47