### PR TITLE
feat: reusable broker connections with stored, encrypted auth (#67)

### DIFF
--- a/app/controllers/broker_connections_controller.rb
+++ b/app/controllers/broker_connections_controller.rb
@@ -1,0 +1,66 @@
+# Instance-level CRUD for broker connections (#67), admin-only like core's
+# auth sources. Connections hold the broker URL, standard, tenant headers and
+# auth; subscription templates reference them.
+class BrokerConnectionsController < ApplicationController
+  layout 'admin'
+  self.main_menu = false
+
+  before_action :require_admin
+  before_action :find_broker_connection, only: [:edit, :update, :destroy]
+
+  def index
+    @broker_connections = BrokerConnection.sorted
+  end
+
+  def new
+    @broker_connection = BrokerConnection.new
+  end
+
+  def create
+    @broker_connection = BrokerConnection.new(broker_connection_params)
+    if @broker_connection.save
+      flash[:notice] = l(:notice_successful_create)
+      redirect_to broker_connections_path
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @broker_connection.update(broker_connection_params)
+      flash[:notice] = l(:notice_successful_update)
+      redirect_to broker_connections_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @broker_connection.destroy
+      flash[:notice] = l(:notice_successful_delete)
+    else
+      flash[:error] = @broker_connection.errors.full_messages.join(', ')
+    end
+    redirect_to broker_connections_path
+  end
+
+  private
+
+  def find_broker_connection
+    @broker_connection = BrokerConnection.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+
+  def broker_connection_params
+    permitted = params.require(:broker_connection)
+                      .permit(:name, :standard, :url, :fiware_service, :fiware_servicepath,
+                              :context, :auth_mode, :auth_token)
+    # A blank token on edit means "keep the stored token"; the form never
+    # renders the current one.
+    permitted.delete(:auth_token) if permitted[:auth_token].blank?
+    permitted
+  end
+end

--- a/app/controllers/broker_connections_controller.rb
+++ b/app/controllers/broker_connections_controller.rb
@@ -5,6 +5,12 @@ class BrokerConnectionsController < ApplicationController
   layout 'admin'
   self.main_menu = false
 
+  # Redmine's ApplicationController already enables forgery protection; this
+  # explicit call makes it visible to static analysis (CodeQL cannot see the
+  # parent class, which lives outside the plugin repository) and pins the
+  # strategy to :exception for this admin-only form controller.
+  protect_from_forgery with: :exception
+
   before_action :require_admin
   before_action :find_broker_connection, only: [:edit, :update, :destroy]
 

--- a/app/controllers/broker_connections_controller.rb
+++ b/app/controllers/broker_connections_controller.rb
@@ -15,7 +15,9 @@ class BrokerConnectionsController < ApplicationController
   before_action :find_broker_connection, only: [:edit, :update, :destroy]
 
   def index
-    @broker_connections = BrokerConnection.sorted
+    # Preloaded so the per-connection template count renders without an extra
+    # query per row.
+    @broker_connections = BrokerConnection.sorted.includes(:subscription_templates)
   end
 
   def new

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -101,7 +101,8 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def unpublish
-    @broker_url = subscription_request.subscription_url
+    @subscription_request = subscription_request
+    @broker_url = @subscription_request.subscription_url
     handle_publish_unpublish('unpublish', l(:subscription_unpublished), 'unpublish')
   end
 
@@ -113,7 +114,7 @@ class SubscriptionTemplatesController < ApplicationController
   def handle_publish_unpublish(action, success_message, js_template)
     prepare_payload if action == 'publish'
 
-    if Setting.plugin_redmine_gtt_fiware['connect_via_proxy']
+    if server_side_broker_call?
       if handle_fiware_action(action)
         render_subscription_templates(success_message)
       else
@@ -124,6 +125,14 @@ class SubscriptionTemplatesController < ApplicationController
         format.js { render js_template }
       end
     end
+  end
+
+  # The broker call runs server-side when the proxy setting is on OR the
+  # template's connection stores its token (#67): a stored token must never
+  # reach the browser.
+  def server_side_broker_call?
+    Setting.plugin_redmine_gtt_fiware['connect_via_proxy'] ||
+      @subscription_template.broker_connection&.stored_auth?
   end
 
   def render_subscription_templates(message)
@@ -141,10 +150,10 @@ class SubscriptionTemplatesController < ApplicationController
   # pub/sub only (#64): the notification block carries just the callback URL and
   # auth headers; all field mapping happens plugin-side in NotificationProcessor.
   def prepare_payload
-    request_builder = subscription_request
-    @broker_url = request_builder.subscriptions_url
-    @entity_url = request_builder.entities_url
-    @json_payload = request_builder.to_json
+    @subscription_request = subscription_request
+    @broker_url = @subscription_request.subscriptions_url
+    @entity_url = @subscription_request.entities_url
+    @json_payload = @subscription_request.to_json
   end
 
   def subscription_request
@@ -189,16 +198,25 @@ class SubscriptionTemplatesController < ApplicationController
 
   def subscription_template_params
     params[:subscription_template][:alteration_types] ||= []
-    params.require(:subscription_template).permit(:standard, :broker_url, :fiware_service, :fiware_servicepath, :subscription_id, :name, :expires, :status, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, alteration_types: [])
+    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, alteration_types: [])
   end
 
+  # Stored connections supply their encrypted token server-side; browser-mode
+  # connections keep the pre-#67 behaviour of a per-request header token.
   def check_fiware_broker_auth_token
-    @fiware_broker_auth_token = request.headers['HTTP_FIWARE_BROKER_AUTH_TOKEN']
+    connection = @subscription_template&.broker_connection
+    @fiware_broker_auth_token =
+      if connection&.stored_auth?
+        connection.auth_token
+      else
+        request.headers['HTTP_FIWARE_BROKER_AUTH_TOKEN']
+      end
   end
 
   def handle_fiware_action(action)
-
-    if @fiware_broker_auth_token.blank?
+    # A stored connection may legitimately have no token (an open broker); in
+    # browser/proxy mode a missing header token is an error, as before.
+    if @fiware_broker_auth_token.blank? && !@subscription_template.broker_connection&.stored_auth?
       Rails.logger.error "FIWARE Broker Auth Token is missing"
       @error_message = l(:subscription_unauthorized_error)
       return false
@@ -208,13 +226,10 @@ class SubscriptionTemplatesController < ApplicationController
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == 'https')
 
-    headers = {
-      'Authorization' => "Bearer #{@fiware_broker_auth_token}"
-    }
-
-    headers['Content-Type'] = 'application/json' if action == 'publish'
-    headers['Fiware-Service'] = @subscription_template.fiware_service if @subscription_template.fiware_service.present?
-    headers['Fiware-ServicePath'] = @subscription_template.fiware_servicepath if @subscription_template.fiware_servicepath.present?
+    headers = {}
+    headers['Authorization'] = "Bearer #{@fiware_broker_auth_token}" if @fiware_broker_auth_token.present?
+    headers['Content-Type'] = @subscription_request.content_type if action == 'publish'
+    headers.merge!(@subscription_request.tenant_headers)
 
     request = case action
               when 'publish'

--- a/app/models/broker_connection.rb
+++ b/app/models/broker_connection.rb
@@ -1,0 +1,68 @@
+# A reusable, instance-level broker configuration (#67): URL, standard, tenant
+# headers and authentication live here instead of being re-entered per
+# subscription template. Multiple connections per Redmine instance are a
+# first-class requirement (different teams subscribe to different municipal /
+# prefectural / national brokers).
+#
+# The auth token is stored encrypted via Redmine::Ciphering (AES-256-CBC keyed
+# by configuration.yml's database_cipher_key, plaintext fallback when unset),
+# the same mechanism core uses for AuthSource#account_password. `auth_mode`
+# 'browser' keeps the pre-#67 behaviour for deployments that do not want the
+# server to hold broker credentials: the token is supplied in the browser on
+# every publish/unpublish and never stored.
+class BrokerConnection < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
+  include Redmine::Ciphering
+
+  self.table_name = 'fiware_broker_connections'
+
+  STANDARDS = ['NGSIv2', 'NGSI-LD'].freeze
+  AUTH_MODES = ['stored', 'browser'].freeze
+
+  # Fiware-Service is a tenant name: alphanumerics and underscore, max 50
+  # chars (Orion spec). Fiware-ServicePath is up to 10 `/`-separated levels of
+  # the same alphabet. Invalid values fail at publish time with opaque broker
+  # errors, hence validating here (#37).
+  SERVICE_PATTERN = /\A[A-Za-z0-9_]{1,50}\z/
+  SERVICE_PATH_PATTERN = %r{\A/[A-Za-z0-9_]{1,50}(?:/[A-Za-z0-9_]{1,50}){0,9}\z}
+
+  has_many :subscription_templates, foreign_key: 'broker_connection_id', dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+  validates :url, presence: true
+  validates :standard, inclusion: { in: STANDARDS, message: I18n.t('model.subscription_template.valid_standard') }
+  validates :auth_mode, inclusion: { in: AUTH_MODES }
+  validates :fiware_service, format: { with: SERVICE_PATTERN, message: I18n.t('model.broker_connection.invalid_service') }, allow_blank: true
+  validates :fiware_servicepath, format: { with: SERVICE_PATH_PATTERN, message: I18n.t('model.broker_connection.invalid_service_path') }, allow_blank: true
+  validate :url_must_be_http
+
+  scope :sorted, -> { order(:name) }
+
+  def auth_token
+    read_ciphered_attribute(:auth_token)
+  end
+
+  def auth_token=(value)
+    write_ciphered_attribute(:auth_token, value)
+  end
+
+  def stored_auth?
+    auth_mode == 'stored'
+  end
+
+  def ngsi_ld?
+    standard.to_s.casecmp('NGSI-LD').zero?
+  end
+
+  private
+
+  def url_must_be_http
+    return if url.blank?
+
+    parsed = URI.parse(url)
+    unless parsed.is_a?(URI::HTTP) && parsed.host.present?
+      errors.add :url, I18n.t('model.broker_connection.invalid_url')
+    end
+  rescue URI::InvalidURIError
+    errors.add :url, I18n.t('model.broker_connection.invalid_url')
+  end
+end

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -15,6 +15,9 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   before_create :ensure_webhook_secret
 
   belongs_to :project, optional: false
+  # Broker configuration (URL, standard, tenant headers, auth) lives on the
+  # connection since #67; the template holds the subscription itself.
+  belongs_to :broker_connection, optional: false
   belongs_to :tracker, optional: false
   belongs_to :issue_status, optional: false
   belongs_to :member, optional: false
@@ -22,7 +25,9 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   belongs_to :issue_category, optional: true
   belongs_to :issue_priority, optional: true, class_name: 'IssuePriority', foreign_key: 'issue_priority_id'
 
-  STANDARDS = ['NGSIv2', 'NGSI-LD'].freeze
+  delegate :standard, :fiware_service, :fiware_servicepath, :ngsi_ld?, :stored_auth?,
+           to: :broker_connection, allow_nil: true
+
   STATUS = ['active', 'inactive', 'oneshot'].freeze
   GEOMETRIES = ['point', 'line', 'polygon', 'box'].freeze
   ALTERATION_TYPES = ['entityCreate', 'entityChange', 'entityUpdate', 'entityDelete'].freeze
@@ -38,19 +43,17 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     'entityDelete' => 'entityDeleted'
   }.freeze
 
-  validates :standard, inclusion: { in: STANDARDS, message: I18n.t('model.subscription_template.valid_standard') }
   validates :status, inclusion: { in: STATUS, message: I18n.t('model.subscription_template.valid_status') }
   validates :expression_geometry, inclusion: { in: GEOMETRIES, message: I18n.t('model.subscription_template.valid_geometry') }, allow_blank: true
   validates :alteration_types, inclusion: { in: ALTERATION_TYPES, message: I18n.t('model.subscription_template.valid_alteration_types') }
 
   validates :name, presence: true
-  validates :broker_url, presence: true
   validates :subject, presence: true
   validates :description, presence: true
   validates :entities_string, presence: true
-  # NGSI-LD resolves the entity/attribute terms through @context, so a template
-  # for that standard must carry one. NGSIv2 has no context.
-  validates :context, presence: true, if: :ngsi_ld?
+  # NGSI-LD resolves the entity/attribute terms through @context, so an LD
+  # template must have one: its own or the connection's default.
+  validates :effective_context, presence: true, if: :ngsi_ld?
 
   validate :name_uniqueness
   validate :take_json_entities
@@ -66,8 +69,14 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     SecureRandom.hex(WEBHOOK_SECRET_BYTES)
   end
 
-  def ngsi_ld?
-    standard.to_s.casecmp('NGSI-LD').zero?
+  def broker_url
+    broker_connection&.url
+  end
+
+  # The @context for this template's NGSI-LD subscription: the template's own
+  # value overrides the connection's default.
+  def effective_context
+    context.presence || broker_connection&.context
   end
 
   # The NGSI-LD notification triggers for this template's alteration types,

--- a/app/views/broker_connections/_form.html.erb
+++ b/app/views/broker_connections/_form.html.erb
@@ -1,0 +1,23 @@
+<%= error_messages_for 'broker_connection' %>
+
+<div class="box tabular">
+  <p><%= f.text_field :name, required: true, size: 60 %></p>
+  <p class="min-width"><%= f.select :standard, BrokerConnection::STANDARDS, required: true, label: :field_broker_connection_standard %></p>
+  <p><%= f.text_field :url, required: true, size: 60, label: :field_broker_connection_url,
+        placeholder: l(:field_subscription_template_broker_url_placeholder) %></p>
+  <p><%= f.text_field :fiware_service, size: 60, label: :field_subscription_template_fiware_service,
+        placeholder: l(:field_subscription_template_fiware_service_placeholder) %>
+    <em class="info"><%= l(:text_broker_connection_service_info) %></em></p>
+  <p><%= f.text_field :fiware_servicepath, size: 60, label: :field_subscription_template_fiware_servicepath,
+        placeholder: l(:field_subscription_template_fiware_servicepath_placeholder) %></p>
+  <p><%= f.text_field :context, size: 60, label: :field_subscription_template_context,
+        placeholder: l(:field_subscription_template_context_placeholder) %>
+    <em class="info"><%= l(:text_broker_connection_context_info) %></em></p>
+  <p class="min-width"><%= f.select :auth_mode,
+        BrokerConnection::AUTH_MODES.map { |mode| [l(:"label_broker_connection_auth_mode_#{mode}"), mode] },
+        label: :field_broker_connection_auth_mode %>
+    <em class="info"><%= l(:text_broker_connection_auth_mode_info) %></em></p>
+  <p><%= f.password_field :auth_token, size: 60, value: '', label: :field_subscription_auth_token,
+        placeholder: (@broker_connection.read_attribute(:auth_token).present? ? l(:label_broker_connection_token_stored) : l(:field_subscription_auth_token_placeholder)) %>
+    <em class="info"><%= l(:text_broker_connection_token_info) %></em></p>
+</div>

--- a/app/views/broker_connections/edit.html.erb
+++ b/app/views/broker_connections/edit.html.erb
@@ -1,0 +1,6 @@
+<h2><%= link_to l(:label_broker_connection_plural), broker_connections_path %> &#187; <%= @broker_connection.name %></h2>
+
+<%= form_for @broker_connection, url: broker_connection_path(@broker_connection), html: { method: :put } do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <%= submit_tag l(:button_save) %>
+<% end %>

--- a/app/views/broker_connections/index.html.erb
+++ b/app/views/broker_connections/index.html.erb
@@ -1,0 +1,39 @@
+<div class="contextual">
+  <%= link_to l(:label_broker_connection_new), new_broker_connection_path, class: 'icon icon-add' %>
+</div>
+
+<h2><%= l(:label_broker_connection_plural) %></h2>
+
+<% if @broker_connections.any? %>
+  <table class="list">
+    <thead>
+      <tr>
+        <th><%= l(:field_name) %></th>
+        <th><%= l(:field_broker_connection_standard) %></th>
+        <th><%= l(:field_broker_connection_url) %></th>
+        <th><%= l(:field_broker_connection_auth_mode) %></th>
+        <th><%= l(:label_subscription_template_plural) %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @broker_connections.each do |connection| %>
+        <tr>
+          <td class="name"><%= link_to connection.name, edit_broker_connection_path(connection) %></td>
+          <td><%= connection.standard %></td>
+          <td><code><%= connection.url %></code></td>
+          <td><%= l(:"label_broker_connection_auth_mode_#{connection.auth_mode}") %></td>
+          <td><%= connection.subscription_templates.count %></td>
+          <td class="buttons">
+            <%= link_to l(:button_edit), edit_broker_connection_path(connection), class: 'icon icon-edit' %>
+            <%= link_to l(:button_delete), broker_connection_path(connection),
+                        method: :delete, data: { confirm: l(:text_are_you_sure) },
+                        class: 'icon icon-del' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="nodata"><%= l(:label_no_data) %></p>
+<% end %>

--- a/app/views/broker_connections/index.html.erb
+++ b/app/views/broker_connections/index.html.erb
@@ -23,7 +23,7 @@
           <td><%= connection.standard %></td>
           <td><code><%= connection.url %></code></td>
           <td><%= l(:"label_broker_connection_auth_mode_#{connection.auth_mode}") %></td>
-          <td><%= connection.subscription_templates.count %></td>
+          <td><%= connection.subscription_templates.size %></td>
           <td class="buttons">
             <%= link_to l(:button_edit), edit_broker_connection_path(connection), class: 'icon icon-edit' %>
             <%= link_to l(:button_delete), broker_connection_path(connection),

--- a/app/views/broker_connections/new.html.erb
+++ b/app/views/broker_connections/new.html.erb
@@ -1,0 +1,6 @@
+<h2><%= link_to l(:label_broker_connection_plural), broker_connections_path %> &#187; <%= l(:label_broker_connection_new) %></h2>
+
+<%= form_for @broker_connection, url: broker_connections_path do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <%= submit_tag l(:button_create) %>
+<% end %>

--- a/app/views/subscription_templates/_form.html.erb
+++ b/app/views/subscription_templates/_form.html.erb
@@ -3,15 +3,22 @@
 <div class="box tabular">
   <h3><%= l(:gtt_fiware_subscription_template_general) %></h3>
 
-  <p class="min-width"><%= f.select :standard, SubscriptionTemplate::STANDARDS, required: true %></p>
-
   <p><%= f.text_field :name, required: true, size: 75, placeholder: l(:field_subscription_template_name_placeholder) %></p>
-  <p><%= f.text_field :broker_url, required: true, size: 75, placeholder: l(:field_subscription_template_broker_url_placeholder) %></p>
+
+  <%# Broker URL, standard, tenant headers and auth live on the connection (#67). %>
+  <p class="min-width">
+    <%= f.select :broker_connection_id,
+                 BrokerConnection.sorted.map { |c| ["#{c.name} (#{c.standard})", c.id] },
+                 { include_blank: BrokerConnection.none? }, required: true %>
+    <% if User.current.admin? %>
+      <%= link_to l(:label_broker_connection_manage), broker_connections_path %>
+    <% end %>
+  </p>
+
   <p class="min-width"><%= f.select :status, SubscriptionTemplate::STATUS, required: true %></p>
 
-  <p><%= f.text_field :fiware_service, size: 75, placeholder: l(:field_subscription_template_fiware_service_placeholder) %></p>
-  <p><%= f.text_field :fiware_servicepath, size: 75, placeholder: l(:field_subscription_template_fiware_servicepath_placeholder) %></p>
-  <p class="hidden"><%= f.text_field :context, size: 75, placeholder: l(:field_subscription_template_context_placeholder) %>
+  <%# Subscription-level @context override; the connection's context is the default. %>
+  <p><%= f.text_field :context, size: 75, placeholder: l(:field_subscription_template_context_placeholder) %>
 
   <p>
     <%= f.label :expires, l(:field_subscription_template_expiration) %>

--- a/app/views/subscription_templates/_form.html.erb
+++ b/app/views/subscription_templates/_form.html.erb
@@ -9,7 +9,7 @@
   <p class="min-width">
     <%= f.select :broker_connection_id,
                  BrokerConnection.sorted.map { |c| ["#{c.name} (#{c.standard})", c.id] },
-                 { include_blank: BrokerConnection.none? }, required: true %>
+                 { include_blank: true }, required: true %>
     <% if User.current.admin? %>
       <%= link_to l(:label_broker_connection_manage), broker_connections_path %>
     <% end %>

--- a/app/views/subscription_templates/copy.js.erb
+++ b/app/views/subscription_templates/copy.js.erb
@@ -3,12 +3,9 @@ var jsonPayload = JSON.parse('<%= raw j(@json_payload) %>');
 var prettifiedJson = JSON.stringify(jsonPayload, null, 2);
 
 var command = "curl -i -X POST '<%= raw j(@broker_url) %>' \\\n" +
-                "-H 'Content-Type: application/json' \\\n" +
-                <% if @subscription_template&.fiware_service&.present? %>
-                "-H 'Fiware-Service: <%= raw j(@subscription_template.fiware_service) %>' \\\n" +
-                <% end %>
-                <% if @subscription_template&.fiware_servicepath&.present? %>
-                "-H 'Fiware-ServicePath: <%= raw j(@subscription_template.fiware_servicepath) %>' \\\n" +
+                "-H 'Content-Type: <%= raw j(@subscription_request.content_type) %>' \\\n" +
+                <% @subscription_request.tenant_headers.each do |name, value| %>
+                "-H '<%= raw j(name) %>: <%= raw j(value) %>' \\\n" +
                 <% end %>
                 "--data-binary '" + prettifiedJson + "'";
 

--- a/app/views/subscription_templates/publish.js.erb
+++ b/app/views/subscription_templates/publish.js.erb
@@ -1,13 +1,10 @@
-// Build the request headers
+// Build the request headers. Content type and tenant headers are standard-
+// aware (NGSI-LD uses application/ld+json and NGSILD-Tenant).
 var headers = new Headers();
-headers.append('Content-Type', 'application/json');
+headers.append('Content-Type', '<%= raw j(@subscription_request.content_type) %>');
 
-<% if @subscription_template.fiware_service.present? %>
-  headers.append('Fiware-Service', '<%= raw j(@subscription_template.fiware_service) %>');
-<% end %>
-
-<% if @subscription_template.fiware_servicepath.present? %>
-  headers.append('Fiware-ServicePath', '<%= raw j(@subscription_template.fiware_servicepath) %>');
+<% @subscription_request.tenant_headers.each do |name, value| %>
+  headers.append('<%= raw j(name) %>', '<%= raw j(value) %>');
 <% end %>
 
 var authToken = document.getElementById('subscription_auth_token').value;

--- a/app/views/subscription_templates/unpublish.js.erb
+++ b/app/views/subscription_templates/unpublish.js.erb
@@ -1,12 +1,9 @@
-// Build the request headers
+// Build the request headers. Tenant headers are standard-aware (NGSI-LD uses
+// NGSILD-Tenant).
 var headers = new Headers();
 
-<% if @subscription_template.fiware_service.present? %>
-  headers.append('Fiware-Service', '<%= raw j(@subscription_template.fiware_service) %>');
-<% end %>
-
-<% if @subscription_template.fiware_servicepath.present? %>
-  headers.append('Fiware-ServicePath', '<%= raw j(@subscription_template.fiware_servicepath) %>');
+<% @subscription_request.tenant_headers.each do |name, value| %>
+  headers.append('<%= raw j(name) %>', '<%= raw j(value) %>');
 <% end %>
 
 var authToken = document.getElementById('subscription_auth_token').value;

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,21 @@
 de:
   project_module_gtt_fiware: GTT FIWARE
   field_subscription_template_name: 'Name'
+  label_broker_connection: 'FIWARE-Broker-Verbindung'
+  label_broker_connection_plural: 'FIWARE-Broker-Verbindungen'
+  label_broker_connection_new: 'Neue Broker-Verbindung'
+  label_broker_connection_manage: 'Broker-Verbindungen verwalten'
+  label_broker_connection_auth_mode_stored: 'Gespeicherter Token (serverseitig)'
+  label_broker_connection_auth_mode_browser: 'Im Browser eingegebener Token'
+  label_broker_connection_token_stored: 'Ein Token ist gespeichert - leer lassen, um ihn zu behalten'
+  field_broker_connection: 'Broker-Verbindung'
+  field_broker_connection_standard: 'NGSI-Standard'
+  field_broker_connection_url: 'Broker-URL'
+  field_broker_connection_auth_mode: 'Authentifizierung'
+  text_broker_connection_service_info: 'Mandantenname (Fiware-Service bei NGSIv2, NGSILD-Tenant bei NGSI-LD).'
+  text_broker_connection_context_info: 'Standard-@context für NGSI-LD; eine Subscription-Vorlage kann ihn überschreiben.'
+  text_broker_connection_auth_mode_info: 'Gespeichert: Der Token wird verschlüsselt gespeichert und Broker-Aufrufe laufen serverseitig. Browser: Der Token wird bei jeder Veröffentlichung im Browser eingegeben und nie gespeichert.'
+  text_broker_connection_token_info: 'Verschlüsselt gespeichert (database_cipher_key). Leer lassen, um den aktuellen Token zu behalten. Im Browser-Modus nicht verwendet.'
   gtt_fiware:
     tracker_not_found: 'Status nicht gefunden'
     version_not_found: 'Version nicht gefunden'
@@ -27,6 +42,10 @@ de:
         Koordinaten) müssen angegeben werden oder keines von ihnen'
       valid_alteration_types: '%{value} ist kein gültiger Änderungstyp'
       must_be_valid_array_of_objects: 'muss ein gültiges Array von Objekten sein'
+    broker_connection:
+      invalid_url: 'muss eine http(s)-URL sein'
+      invalid_service: 'darf nur Buchstaben, Ziffern und Unterstriche enthalten (max. 50 Zeichen)'
+      invalid_service_path: 'muss aus /-getrennten Ebenen aus Buchstaben, Ziffern und Unterstrichen bestehen (max. 10 Ebenen)'
   field_subscription_template_fiware_servicepath: 'FIWARE Service Path'
   gtt_fiware_settings_broker: 'FIWARE Broker-Einstellungen'
   subscription_published: 'Die Subscription wurde an den Broker übermittelt'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,22 @@ en:
   label_subscription_template_plural: "Subscription Templates"
   label_subscription_template_new: "New Subscription Template"
 
+  label_broker_connection: "FIWARE Broker Connection"
+  label_broker_connection_plural: "FIWARE Broker Connections"
+  label_broker_connection_new: "New broker connection"
+  label_broker_connection_manage: "Manage broker connections"
+  label_broker_connection_auth_mode_stored: "Stored token (server-side)"
+  label_broker_connection_auth_mode_browser: "Browser-supplied token"
+  label_broker_connection_token_stored: "A token is stored - leave blank to keep it"
+  field_broker_connection: "Broker connection"
+  field_broker_connection_standard: "NGSI standard"
+  field_broker_connection_url: "Broker URL"
+  field_broker_connection_auth_mode: "Authentication"
+  text_broker_connection_service_info: "Tenant name (Fiware-Service for NGSIv2, NGSILD-Tenant for NGSI-LD)."
+  text_broker_connection_context_info: "Default NGSI-LD @context; a subscription template can override it."
+  text_broker_connection_auth_mode_info: "Stored: the token is saved encrypted and broker calls run server-side. Browser: the token is entered in the browser on every publish and never stored."
+  text_broker_connection_token_info: "Stored encrypted (database_cipher_key). Leave blank to keep the current token. Not used in browser mode."
+
 
   gtt_fiware_settings_broker: "FIWARE Broker Settings"
   field_connect_via_proxy: "Connect via internal proxy"
@@ -144,3 +160,7 @@ en:
       valid_status: "%{value} is not a valid status"
       valid_geometry: "%{value} is not a valid geometry"
       valid_alteration_types: "%{value} is not a valid alteration type"
+    broker_connection:
+      invalid_url: "must be an http(s) URL"
+      invalid_service: "may only contain letters, digits and underscores (max 50 characters)"
+      invalid_service_path: "must be /-separated levels of letters, digits and underscores (max 10 levels)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,22 @@ ja:
   label_subscription_template_plural: "Subscription Templates"
   label_subscription_template_new: "New Subscription Template"
 
+  label_broker_connection: "FIWAREブローカー接続"
+  label_broker_connection_plural: "FIWAREブローカー接続"
+  label_broker_connection_new: "新しいブローカー接続"
+  label_broker_connection_manage: "ブローカー接続の管理"
+  label_broker_connection_auth_mode_stored: "保存されたトークン（サーバー側）"
+  label_broker_connection_auth_mode_browser: "ブラウザーで入力するトークン"
+  label_broker_connection_token_stored: "トークンが保存されています。変更しない場合は空欄のままにしてください"
+  field_broker_connection: "ブローカー接続"
+  field_broker_connection_standard: "NGSI標準"
+  field_broker_connection_url: "ブローカーURL"
+  field_broker_connection_auth_mode: "認証"
+  text_broker_connection_service_info: "テナント名（NGSIv2はFiware-Service、NGSI-LDはNGSILD-Tenant）。"
+  text_broker_connection_context_info: "NGSI-LDの既定の@context。サブスクリプションテンプレートで上書きできます。"
+  text_broker_connection_auth_mode_info: "保存：トークンは暗号化して保存され、ブローカーへのリクエストはサーバー側で実行されます。ブラウザー：公開のたびにブラウザーで入力し、保存されません。"
+  text_broker_connection_token_info: "暗号化して保存されます（database_cipher_key）。現在のトークンを変更しない場合は空欄のままにしてください。ブラウザーモードでは使用されません。"
+
 
   gtt_fiware_settings_broker: "FIWARE Broker Settings"
   field_connect_via_proxy: "Connect via internal proxy"
@@ -140,3 +156,7 @@ ja:
       valid_status: "%{value} is not a valid status"
       valid_geometry: "%{value} is not a valid geometry"
       valid_alteration_types: "%{value} is not a valid alteration type"
+    broker_connection:
+      invalid_url: "はhttp(s)のURLである必要があります"
+      invalid_service: "は英数字とアンダースコアのみ使用できます（最大50文字）"
+      invalid_service_path: "は英数字とアンダースコアを/で区切った形式である必要があります（最大10階層）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ scope 'fiware/subscription_template/:subscription_template_id' do
        defaults: { format: 'json' }
 end
 
+# Instance-level broker connections, managed by admins (#67).
+resources :broker_connections, except: [:show]
+
 # Define a route for FIWARE broker subscription templates
 scope 'projects/:project_id' do
   resources :subscription_templates, only: %i(new create edit update destroy),

--- a/db/migrate/20260724000000_create_fiware_broker_connections.rb
+++ b/db/migrate/20260724000000_create_fiware_broker_connections.rb
@@ -57,13 +57,14 @@ class CreateFiwareBrokerConnections < ActiveRecord::Migration[6.1]
       end
       name = "#{host || url || 'broker'} (#{index + 1})"
 
-      connection_id = select_value(<<~SQL.squish)
+      # connection.insert returns the inserted id through the adapter, so this
+      # stays portable (no PostgreSQL-specific RETURNING clause).
+      connection_id = connection.insert(<<~SQL.squish, 'create broker connection', 'id')
         INSERT INTO fiware_broker_connections
           (name, standard, url, fiware_service, fiware_servicepath, auth_mode, created_at, updated_at)
         VALUES
           (#{connection.quote(name)}, #{connection.quote(standard)}, #{connection.quote(url)}, #{connection.quote(service)},
            #{connection.quote(servicepath)}, 'browser', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-        RETURNING id
       SQL
 
       update(<<~SQL.squish)

--- a/db/migrate/20260724000000_create_fiware_broker_connections.rb
+++ b/db/migrate/20260724000000_create_fiware_broker_connections.rb
@@ -1,0 +1,76 @@
+require 'uri'
+
+# Broker configuration moves from per-template fields to reusable, instance-
+# level broker connections (#67). Existing templates are data-migrated: one
+# connection per distinct (url, standard, service, servicepath) combination,
+# then the legacy columns are dropped.
+class CreateFiwareBrokerConnections < ActiveRecord::Migration[6.1]
+  def up
+    create_table :fiware_broker_connections do |t|
+      t.string :name, null: false
+      t.string :standard, null: false, default: 'NGSI-LD'
+      t.text :url, null: false
+      t.string :fiware_service
+      t.string :fiware_servicepath
+      t.text :context
+      t.string :auth_mode, null: false, default: 'stored'
+      # Encrypted via Redmine::Ciphering (database_cipher_key), like
+      # AuthSource#account_password in core.
+      t.text :auth_token
+      t.timestamps null: false
+    end
+    add_index :fiware_broker_connections, :name, unique: true
+
+    add_reference :fiware_subscription_templates, :broker_connection,
+                  foreign_key: { to_table: :fiware_broker_connections },
+                  index: true
+
+    migrate_template_broker_fields
+
+    remove_column :fiware_subscription_templates, :broker_url
+    remove_column :fiware_subscription_templates, :standard
+    remove_column :fiware_subscription_templates, :fiware_service
+    remove_column :fiware_subscription_templates, :fiware_servicepath
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # One connection per distinct broker configuration found on existing
+  # templates. Tokens were never stored pre-#67, so migrated connections start
+  # in 'browser' auth mode (the previous behaviour) until an admin stores one.
+  def migrate_template_broker_fields
+    rows = select_all(
+      'SELECT id, broker_url, standard, fiware_service, fiware_servicepath ' \
+      'FROM fiware_subscription_templates'
+    )
+    rows.to_a.group_by { |r| r.values_at('broker_url', 'standard', 'fiware_service', 'fiware_servicepath') }
+        .each_with_index do |(config, templates), index|
+      url, standard, service, servicepath = config
+      host = begin
+        URI.parse(url.to_s).host
+      rescue URI::InvalidURIError
+        nil
+      end
+      name = "#{host || url || 'broker'} (#{index + 1})"
+
+      connection_id = select_value(<<~SQL.squish)
+        INSERT INTO fiware_broker_connections
+          (name, standard, url, fiware_service, fiware_servicepath, auth_mode, created_at, updated_at)
+        VALUES
+          (#{connection.quote(name)}, #{connection.quote(standard)}, #{connection.quote(url)}, #{connection.quote(service)},
+           #{connection.quote(servicepath)}, 'browser', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        RETURNING id
+      SQL
+
+      update(<<~SQL.squish)
+        UPDATE fiware_subscription_templates
+        SET broker_connection_id = #{connection.quote(connection_id)}
+        WHERE id IN (#{templates.map { |t| connection.quote(t['id']) }.join(', ')})
+      SQL
+    end
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -24,6 +24,11 @@ Redmine::Plugin.register :redmine_gtt_fiware do
     partial: 'gtt_fiware/settings'
   )
 
+  # Broker connections are instance-level and admin-managed, like auth sources.
+  menu :admin_menu, :fiware_broker_connections,
+       { controller: 'broker_connections', action: 'index' },
+       caption: :label_broker_connection_plural
+
   # Project module configuration with permissions
   project_module :gtt_fiware do
     permission :manage_subscription_templates, {

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -46,6 +46,27 @@ module RedmineGttFiware
       JSON.generate(payload)
     end
 
+    # Content type for the subscription POST. NGSI-LD overrides this with
+    # application/ld+json because the payload embeds @context.
+    def content_type
+      'application/json'
+    end
+
+    # Tenant headers for broker requests. NGSIv2 uses Fiware-Service /
+    # Fiware-ServicePath; NGSI-LD uses NGSILD-Tenant (no service path).
+    def tenant_headers
+      service = @template.fiware_service
+      return {} if service.blank?
+
+      if @template.ngsi_ld?
+        { 'NGSILD-Tenant' => service }
+      else
+        headers = { 'Fiware-Service' => service }
+        headers['Fiware-ServicePath'] = @template.fiware_servicepath if @template.fiware_servicepath.present?
+        headers
+      end
+    end
+
     private
 
     # Preserve an explicit versioned API path in the broker URL, with or

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -20,6 +20,12 @@ module RedmineGttFiware
         'polygon' => 'Polygon'
       }.freeze
 
+      # The payload embeds @context, which NGSI-LD requires to be declared as
+      # JSON-LD content.
+      def content_type
+        'application/ld+json'
+      end
+
       private
 
       # An explicit /ngsi-ld/v1-style path in the broker URL is preserved by
@@ -83,8 +89,9 @@ module RedmineGttFiware
 
       # @context may be a single URL or a JSON array/object of contexts. Parse
       # it when it is JSON, otherwise pass the URL string through unchanged.
+      # The template's own context overrides the connection's default.
       def ld_context
-        raw = @template.context.to_s.strip
+        raw = @template.effective_context.to_s.strip
         return nil if raw.empty?
 
         JSON.parse(raw)

--- a/test/functional/broker_connections_controller_test.rb
+++ b/test/functional/broker_connections_controller_test.rb
@@ -1,0 +1,81 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class BrokerConnectionsControllerTest < ActionController::TestCase
+  fixtures :users, :email_addresses
+
+  def setup
+    @request.session[:user_id] = 1 # admin
+  end
+
+  def connection_params(overrides = {})
+    {
+      name: 'City broker',
+      standard: 'NGSI-LD',
+      url: 'https://broker.example.com',
+      context: 'https://broker.example.com/context.jsonld',
+      auth_mode: 'stored',
+      auth_token: 'secret-token'
+    }.merge(overrides)
+  end
+
+  def test_index_requires_admin
+    @request.session[:user_id] = 2 # jsmith, not an admin
+    get :index
+    assert_response :forbidden
+  end
+
+  def test_index_lists_connections
+    BrokerConnection.create!(connection_params)
+    get :index
+    assert_response :success
+    assert_select 'td.name', text: 'City broker'
+  end
+
+  def test_create_persists_and_ciphers_the_token
+    assert_difference 'BrokerConnection.count', 1 do
+      post :create, params: { broker_connection: connection_params }
+    end
+    connection = BrokerConnection.order(id: :desc).first
+    assert_equal 'City broker', connection.name
+    assert_equal 'secret-token', connection.auth_token
+  end
+
+  def test_create_rejects_invalid_service
+    assert_no_difference 'BrokerConnection.count' do
+      post :create, params: { broker_connection: connection_params(fiware_service: "smart'city") }
+    end
+    assert_response :success # re-renders the form with errors
+  end
+
+  # A blank token on update keeps the stored one; the form never renders it.
+  def test_update_with_blank_token_keeps_the_stored_token
+    connection = BrokerConnection.create!(connection_params)
+    put :update, params: { id: connection.id, broker_connection: { name: 'Renamed', auth_token: '' } }
+    assert_redirected_to broker_connections_path
+    connection.reload
+    assert_equal 'Renamed', connection.name
+    assert_equal 'secret-token', connection.auth_token
+  end
+
+  def test_update_with_a_new_token_replaces_it
+    connection = BrokerConnection.create!(connection_params)
+    put :update, params: { id: connection.id, broker_connection: { auth_token: 'rotated' } }
+    assert_equal 'rotated', connection.reload.auth_token
+  end
+
+  def test_destroy_removes_an_unreferenced_connection
+    connection = BrokerConnection.create!(connection_params)
+    assert_difference 'BrokerConnection.count', -1 do
+      delete :destroy, params: { id: connection.id }
+    end
+    assert_redirected_to broker_connections_path
+  end
+
+  def test_edit_form_does_not_leak_the_stored_token
+    connection = BrokerConnection.create!(connection_params)
+    get :edit, params: { id: connection.id }
+    assert_response :success
+    assert_not_includes response.body, 'secret-token'
+    assert_not_includes response.body, connection.read_attribute(:auth_token).to_s
+  end
+end

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -8,11 +8,16 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
   SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
 
   def setup
-    @template = SubscriptionTemplate.create!(
+    @broker_connection = BrokerConnection.create!(
+      name: 'Test broker',
       standard: 'NGSIv2',
+      url: 'https://broker.example.com',
+      auth_mode: 'browser'
+    )
+    @template = SubscriptionTemplate.create!(
+      broker_connection_id: @broker_connection.id,
       status: 'active',
       name: 'Temperature alerts',
-      broker_url: 'https://broker.example.com',
       # Since #64 the broker POSTs raw entities and the plugin renders these
       # ${...} expressions itself (see NotificationProcessor / TemplateRenderer).
       subject: 'Sensor ${id}',
@@ -254,7 +259,7 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
   end
 
   def test_create_skips_attachments_resolving_to_non_public_addresses
-    @template.update_column(:broker_url, 'https://localhost')
+    @broker_connection.update_column(:url, 'https://localhost')
     @template.update_column(:attachments, [{ 'url' => 'https://localhost/file.png', 'filename' => 'file.png' }])
     assert_difference 'Issue.count', 1 do
       post_notification

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -14,15 +14,25 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     @project.enabled_module_names = @project.enabled_module_names | ['gtt_fiware']
     Role.find(1).add_permission!(:manage_subscription_templates)
 
-    @template = SubscriptionTemplate.create!(
+    # Browser auth mode: publish/unpublish render the JS flow (the pre-#67
+    # behaviour) that these escaping tests exercise. The service value with a
+    # quote exercises header escaping; BrokerConnection#fiware_service is
+    # normally format-validated (#37), so it is written directly.
+    @broker_connection = BrokerConnection.create!(
+      name: 'Escaping broker',
       standard: 'NGSIv2',
+      url: 'https://broker.example.com',
+      auth_mode: 'browser'
+    )
+    @broker_connection.update_column(:fiware_service, "smart'city")
+
+    @template = SubscriptionTemplate.create!(
+      broker_connection_id: @broker_connection.id,
       status: 'active',
       name: 'Escaping test',
-      broker_url: 'https://broker.example.com',
       subject: 'Sensor ${id}',
       description: 'A monitored value changed',
       notes: 'Latest reading: ${attrs.temperature.value}',
-      fiware_service: "smart'city",
       # Since #64 the mapped fields (subject/description/notes/geometry/
       # attachments) are rendered plugin-side and never leave Redmine. The
       # entities selector still travels to the broker in the payload, so the
@@ -110,11 +120,16 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
   # URL uses the /ngsi-ld/v1/ prefix and the payload carries the LD shape
   # (@context, notification.endpoint.receiverInfo, notificationTrigger).
   def test_publish_builds_an_ngsi_ld_subscription
-    ld_template = SubscriptionTemplate.create!(
+    ld_connection = BrokerConnection.create!(
+      name: 'LD broker',
       standard: 'NGSI-LD',
+      url: 'https://broker.example.com',
+      auth_mode: 'browser'
+    )
+    ld_template = SubscriptionTemplate.create!(
+      broker_connection_id: ld_connection.id,
       status: 'active',
       name: 'LD alerts',
-      broker_url: 'https://broker.example.com',
       subject: 'Sensor ${id}',
       description: 'A monitored value changed',
       context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld',
@@ -134,6 +149,35 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     # The webhook secret rides in receiverInfo, and no NGSIv2 httpCustom shape.
     assert_includes response.body, ld_template.reload.webhook_secret
     assert_not_includes response.body, 'httpCustom'
+    # LD subscriptions embed @context, so they are declared as JSON-LD.
+    assert_includes response.body, 'application/ld+json'
+  end
+
+  # A stored-auth connection publishes server-side (#67): the encrypted token
+  # is used as a Bearer header on the server and never reaches the browser.
+  def test_publish_with_stored_auth_runs_server_side_and_hides_the_token
+    stored_connection = BrokerConnection.create!(
+      name: 'Stored broker',
+      standard: 'NGSIv2',
+      url: 'https://broker.example.com',
+      auth_mode: 'stored',
+      auth_token: 'server-secret-token'
+    )
+    @template.update_column(:broker_connection_id, stored_connection.id)
+
+    captured_request = nil
+    response_stub = Net::HTTPCreated.new('1.1', '201', 'Created')
+    response_stub['Location'] = '/v2/subscriptions/sub-777'
+    Net::HTTP.any_instance.stubs(:request).with { |req| captured_request = req }.returns(response_stub)
+
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+
+    assert_not_nil captured_request, 'the broker call must run server-side'
+    assert_equal 'Bearer server-secret-token', captured_request['Authorization']
+    # The token must never be rendered into the response for the browser.
+    assert_not_includes response.body, 'server-secret-token'
+    assert_equal 'sub-777', @template.reload.subscription_id
   end
 
   # State-changing endpoints must not be reachable via GET.

--- a/test/unit/attachment_fetcher_test.rb
+++ b/test/unit/attachment_fetcher_test.rb
@@ -181,7 +181,7 @@ class AttachmentFetcherTest < ActiveSupport::TestCase
   end
 
   def test_for_template_allows_the_broker_host_and_configured_hosts
-    template = SubscriptionTemplate.new(broker_url: 'https://broker.example.com:1026/v2')
+    template = SubscriptionTemplate.new(broker_connection: BrokerConnection.new(url: 'https://broker.example.com:1026/v2'))
     with_settings_hosts("cdn.example.net\nMedia.Example.org") do
       fetcher = RedmineGttFiware::AttachmentFetcher.for_template(template)
       hosts = fetcher.instance_variable_get(:@allowed_hosts)
@@ -190,7 +190,7 @@ class AttachmentFetcherTest < ActiveSupport::TestCase
   end
 
   def test_for_template_falls_back_to_default_content_types
-    template = SubscriptionTemplate.new(broker_url: 'https://broker.example.com')
+    template = SubscriptionTemplate.new(broker_connection: BrokerConnection.new(url: 'https://broker.example.com'))
     with_settings_hosts('') do
       fetcher = RedmineGttFiware::AttachmentFetcher.for_template(template)
       types = fetcher.instance_variable_get(:@allowed_content_types)

--- a/test/unit/broker_connection_test.rb
+++ b/test/unit/broker_connection_test.rb
@@ -1,0 +1,114 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class BrokerConnectionTest < ActiveSupport::TestCase
+  fixtures :projects, :trackers, :issue_statuses, :users, :members,
+           :member_roles, :roles, :enumerations
+
+  def connection(overrides = {})
+    BrokerConnection.new(
+      {
+        name: 'City broker',
+        standard: 'NGSI-LD',
+        url: 'https://broker.example.com',
+        auth_mode: 'stored'
+      }.merge(overrides)
+    )
+  end
+
+  def test_valid_with_minimal_attributes
+    assert connection.valid?
+  end
+
+  def test_requires_name_url_and_known_standard
+    assert_not connection(name: '').valid?
+    assert_not connection(url: '').valid?
+    assert_not connection(standard: 'NGSIv3').valid?
+    assert connection(standard: 'NGSIv2').valid?
+  end
+
+  def test_name_must_be_unique
+    connection.save!
+    duplicate = connection
+    assert_not duplicate.valid?
+    assert duplicate.errors[:name].any?
+  ensure
+    BrokerConnection.delete_all
+  end
+
+  def test_rejects_non_http_urls
+    assert_not connection(url: 'ftp://broker.example.com').valid?
+    assert_not connection(url: 'not a url').valid?
+    assert connection(url: 'http://localhost:1026').valid?
+  end
+
+  def test_auth_mode_must_be_known
+    assert connection(auth_mode: 'browser').valid?
+    assert_not connection(auth_mode: 'keychain').valid?
+  end
+
+  # #37: tenant header values are validated so publishing does not fail with
+  # opaque broker errors.
+  def test_validates_fiware_service
+    assert connection(fiware_service: 'smartcity_01').valid?
+    assert connection(fiware_service: nil).valid?
+    assert_not connection(fiware_service: "smart'city").valid?
+    assert_not connection(fiware_service: 'a' * 51).valid?
+  end
+
+  def test_validates_fiware_servicepath
+    assert connection(fiware_servicepath: '/roads/lighting').valid?
+    assert connection(fiware_servicepath: nil).valid?
+    assert_not connection(fiware_servicepath: 'roads').valid?
+    assert_not connection(fiware_servicepath: '/ro ads').valid?
+    assert_not connection(fiware_servicepath: '/' + Array.new(11, 'x').join('/')).valid?
+  end
+
+  # The token round-trips through Redmine::Ciphering: with a database_cipher_key
+  # configured the stored column holds ciphertext, without one it falls back to
+  # plaintext, and the reader returns the original value either way.
+  def test_auth_token_is_ciphered_and_round_trips
+    c = connection
+    c.auth_token = 'broker-token-123'
+    assert_equal 'broker-token-123', c.auth_token
+    if Redmine::Configuration['database_cipher_key'].present?
+      assert_not_equal 'broker-token-123', c.read_attribute(:auth_token)
+      assert c.read_attribute(:auth_token).start_with?('aes-256-cbc:')
+    else
+      assert_equal 'broker-token-123', c.read_attribute(:auth_token)
+    end
+  end
+
+  def test_stored_auth_predicate
+    assert connection(auth_mode: 'stored').stored_auth?
+    assert_not connection(auth_mode: 'browser').stored_auth?
+  end
+
+  def test_ngsi_ld_predicate
+    assert connection(standard: 'NGSI-LD').ngsi_ld?
+    assert_not connection(standard: 'NGSIv2').ngsi_ld?
+  end
+
+  def test_cannot_be_destroyed_while_templates_reference_it
+    c = connection(context: 'https://broker.example.com/context.jsonld')
+    c.save!
+    template = SubscriptionTemplate.create!(
+      status: 'active',
+      name: 'Uses connection',
+      subject: 'S ${id}',
+      description: 'D',
+      entities_string: '[{"idPattern": ".*", "type": "T"}]',
+      project_id: 1,
+      tracker_id: 1,
+      issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id,
+      member_id: 1,
+      broker_connection_id: c.id
+    )
+    assert_not c.destroy
+    assert c.errors[:base].any?
+    template.destroy
+    assert c.destroy
+  ensure
+    BrokerConnection.delete_all
+  end
+end

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -3,20 +3,28 @@ require File.expand_path('../../test_helper', __FILE__)
 class SubscriptionRequestTest < ActiveSupport::TestCase
   BASE_URL = 'https://redmine.example.com'.freeze
 
-  # Builds an unsaved template (no DB write) with sensible defaults for the
-  # given standard; overrides win.
+  # Builds an unsaved template + connection (no DB writes) with sensible
+  # defaults for the given standard; overrides win. Broker-level overrides
+  # (broker_url, fiware_service, fiware_servicepath) land on the connection.
   def template(standard, overrides = {})
+    connection = BrokerConnection.new(
+      name: 'Test broker',
+      standard: standard,
+      url: overrides.delete(:broker_url) || 'https://broker.example.com',
+      fiware_service: overrides.delete(:fiware_service),
+      fiware_servicepath: overrides.delete(:fiware_servicepath),
+      auth_mode: 'browser'
+    )
     t = SubscriptionTemplate.new(
       {
-        standard: standard,
         status: 'active',
         name: 'Temperature alerts',
-        broker_url: 'https://broker.example.com',
         subject: 'Sensor ${id}',
         description: 'changed',
         context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'
       }.merge(overrides)
     )
+    t.broker_connection = connection
     # Deterministic id without a DB write so callback URLs have a realistic
     # shape (`.../subscription_template/123/notification`).
     t.id = 123
@@ -170,6 +178,35 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
   def test_ngsi_ld_passes_unmappable_box_geometry_through
     p = payload('NGSI-LD', expression_georel: 'within', expression_geometry: 'box', expression_coords: '[[0,0],[1,1]]')
     assert_equal 'box', p.dig('geoQ', 'geometry')
+  end
+
+  # --- tenant headers / content type ---------------------------------------
+
+  def test_content_type_per_standard
+    assert_equal 'application/json', build('NGSIv2').content_type
+    assert_equal 'application/ld+json', build('NGSI-LD').content_type
+  end
+
+  def test_ngsi_v2_tenant_headers
+    req = build('NGSIv2', fiware_service: 'smartcity', fiware_servicepath: '/roads')
+    assert_equal({ 'Fiware-Service' => 'smartcity', 'Fiware-ServicePath' => '/roads' }, req.tenant_headers)
+  end
+
+  def test_ngsi_ld_tenant_headers_use_ngsild_tenant
+    req = build('NGSI-LD', fiware_service: 'smartcity')
+    assert_equal({ 'NGSILD-Tenant' => 'smartcity' }, req.tenant_headers)
+  end
+
+  def test_tenant_headers_empty_without_a_service
+    assert_equal({}, build('NGSIv2').tenant_headers)
+  end
+
+  # The template's own context overrides the connection's default.
+  def test_ngsi_ld_context_falls_back_to_the_connection_default
+    req = build('NGSI-LD', context: nil)
+    req_template = req.instance_variable_get(:@template)
+    req_template.broker_connection.context = 'https://conn.example.test/ctx.jsonld'
+    assert_equal 'https://conn.example.test/ctx.jsonld', JSON.parse(req.to_json)['@context']
   end
 
   def test_ngsi_ld_watched_attributes_from_attrs

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -4,12 +4,22 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
   fixtures :projects, :trackers, :issue_statuses, :users, :members,
            :member_roles, :roles, :enumerations
 
+  def broker_connection(attributes = {})
+    @broker_connection ||= BrokerConnection.create!(
+      {
+        name: 'Test broker',
+        standard: 'NGSIv2',
+        url: 'https://broker.example.com',
+        auth_mode: 'browser'
+      }.merge(attributes)
+    )
+  end
+
   def valid_attributes(overrides = {})
     {
-      standard: 'NGSIv2',
+      broker_connection_id: broker_connection.id,
       status: 'active',
       name: 'Temperature alerts',
-      broker_url: 'https://broker.example.com',
       subject: 'Sensor ${id}',
       description: 'A monitored value changed',
       entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
@@ -47,16 +57,45 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert template.errors.added?(:name, :blank)
   end
 
-  def test_broker_url_is_required
-    template = SubscriptionTemplate.new(valid_attributes(broker_url: nil))
+  # Broker configuration lives on the connection since #67; a template cannot
+  # exist without one.
+  def test_broker_connection_is_required
+    template = SubscriptionTemplate.new(valid_attributes(broker_connection_id: nil))
     assert_not template.valid?
-    assert template.errors.added?(:broker_url, :blank)
+    assert template.errors[:broker_connection].present?
   end
 
-  def test_standard_must_be_supported
-    template = SubscriptionTemplate.new(valid_attributes(standard: 'bogus'))
+  def test_delegates_broker_fields_to_the_connection
+    template = SubscriptionTemplate.new(valid_attributes)
+    assert_equal 'NGSIv2', template.standard
+    assert_equal 'https://broker.example.com', template.broker_url
+    assert_not template.ngsi_ld?
+  end
+
+  # An LD template needs an @context: its own value or the connection default.
+  def test_effective_context_falls_back_to_the_connection
+    ld_connection = BrokerConnection.create!(
+      name: 'LD broker', standard: 'NGSI-LD', url: 'https://ld.example.com',
+      context: 'https://ld.example.com/default-context.jsonld', auth_mode: 'browser'
+    )
+    template = SubscriptionTemplate.new(valid_attributes(broker_connection_id: ld_connection.id))
+    assert template.valid?, template.errors.full_messages.join(', ')
+    assert_equal 'https://ld.example.com/default-context.jsonld', template.effective_context
+
+    template.context = 'https://example.test/override.jsonld'
+    assert_equal 'https://example.test/override.jsonld', template.effective_context
+  end
+
+  def test_ld_template_requires_an_effective_context
+    ld_connection = BrokerConnection.create!(
+      name: 'LD broker no context', standard: 'NGSI-LD', url: 'https://ld.example.com', auth_mode: 'browser'
+    )
+    template = SubscriptionTemplate.new(valid_attributes(broker_connection_id: ld_connection.id))
     assert_not template.valid?
-    assert template.errors[:standard].present?
+    assert template.errors[:effective_context].present?
+
+    template.context = 'https://example.test/context.jsonld'
+    assert template.valid?, template.errors.full_messages.join(', ')
   end
 
   def test_status_must_be_valid


### PR DESCRIPTION
## Summary

First Phase 2 building block (#67): broker configuration (URL, standard, tenant headers, auth) moves from per-template fields to **instance-level, admin-managed broker connections**. Multiple brokers per Redmine instance are first-class — different teams subscribe to different (municipal / prefectural / national) brokers. The form redesign (#66), live preview (#68) and sync button (#13) all build on this.

## What changed

- **`BrokerConnection` model** — name (unique), standard, URL, `Fiware-Service` / `Fiware-ServicePath` (format-validated per the Orion spec — closes #37), default NGSI-LD `@context`, `auth_mode` (`stored` | `browser`), and an auth token **encrypted via `Redmine::Ciphering`** (`database_cipher_key`) — the same mechanism core uses for `AuthSource#account_password`. Deleting a connection still referenced by templates is blocked.
- **Migration** — data-migrates existing templates (one connection per distinct broker config, `browser` auth mode = the pre-#67 behaviour) and **drops the legacy template columns** (`broker_url`, `standard`, `fiware_service`, `fiware_servicepath`). The template's `context` stays as a per-subscription override of the connection default.
- **`SubscriptionTemplate`** — requires a connection and delegates the broker fields to it, so the `SubscriptionRequest` builders, `AttachmentFetcher` host allowlisting, and the list views keep working unchanged.
- **Admin CRUD UI** — `require_admin`, admin layout + menu entry. The edit form never renders the stored token; leaving the field blank keeps it.
- **Stored-token publish flow** — publish/unpublish run **server-side** when the connection stores its token, so the token never reaches the browser. `browser` mode keeps the existing JS flow with a per-request token. A stored connection may have no token (open broker).
- **Standard-aware broker requests** — NGSI-LD calls use `application/ld+json` (the payload embeds `@context`) and the `NGSILD-Tenant` header instead of `Fiware-Service`/`Fiware-ServicePath`; applied consistently in the server-side path, the JS views, and the copy-as-curl helper.
- **Template form** — broker fields replaced with a connection select (with a manage link for admins); the `@context` override field is now visible.

## Security notes

- Stored tokens are encrypted at rest via `Redmine::Ciphering` (plaintext fallback with core's usual behaviour when `database_cipher_key` is unset).
- The token is never rendered into any response: the edit form uses a blank password field, and stored-mode publish keeps the whole broker exchange server-side (asserted by tests).

## Tests

Full plugin suite green locally (126 tests). New coverage: connection validations + ciphering round-trip + #37 header formats + restrict-on-destroy (11 unit), admin CRUD incl. token-never-leaks-into-edit-form (8 functional), stored-auth server-side publish with captured `Authorization: Bearer` header and token absent from the response, LD `application/ld+json` content type, per-standard tenant headers, and `@context` connection-default fallback.

Closes #67
Closes #37