### PR TITLE
feat: subscription sync button (#13)

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -8,8 +8,8 @@ class SubscriptionTemplatesController < ApplicationController
   before_action :get_issue_statuses, only: [:new, :create, :edit, :update]
   before_action :get_issue_priorities, only: [:new, :create, :edit, :update]
   before_action :get_issue_categories, only: [:new, :create, :edit, :update]
-  before_action :find_subscription_template, only: [:edit, :update, :destroy, :copy, :publish, :unpublish, :update_subscription_id]
-  before_action :check_fiware_broker_auth_token, only: [:publish, :unpublish]
+  before_action :find_subscription_template, only: [:edit, :update, :destroy, :copy, :publish, :unpublish, :sync, :update_subscription_id]
+  before_action :check_fiware_broker_auth_token, only: [:publish, :unpublish, :sync]
 
   # set_subscription_id is the broker/tooling registration callback, a JSON API
   # endpoint authenticated by API key. accept_api_auth enables key auth, and
@@ -106,6 +106,26 @@ class SubscriptionTemplatesController < ApplicationController
     handle_publish_unpublish('unpublish', l(:subscription_unpublished), 'unpublish')
   end
 
+  # Reconciles local state with the broker (#13). Always runs server-side:
+  # 404 from the broker clears the stored subscription id (the subscription is
+  # gone, e.g. a oneshot fired or it expired and was purged); 200 updates the
+  # local status from the broker's. The auth token comes from the stored
+  # connection or, in browser/proxy mode, the request header.
+  def sync
+    @subscription_request = subscription_request
+    @sync_message =
+      if @subscription_template.subscription_id.blank?
+        l(:subscription_sync_no_subscription)
+      else
+        perform_sync
+      end
+
+    @subscription_templates = subscription_template_scope
+    respond_to do |format|
+      format.js { render 'sync' }
+    end
+  end
+
   private
 
   # js_template is the template basename (e.g. 'publish'); Rails resolves it
@@ -125,6 +145,61 @@ class SubscriptionTemplatesController < ApplicationController
         format.js { render js_template }
       end
     end
+  end
+
+  # Queries the broker for the template's subscription and reconciles local
+  # state. Returns the user-facing message.
+  def perform_sync
+    response = fetch_remote_subscription
+    case response
+    when Net::HTTPNotFound
+      @subscription_template.update(subscription_id: nil)
+      l(:subscription_sync_removed)
+    when Net::HTTPSuccess
+      apply_remote_status(JSON.parse(response.body))
+      l(:subscription_synced)
+    else
+      Rails.logger.error "FIWARE broker sync failed: #{response.code} #{response.message}"
+      l(:subscription_sync_error)
+    end
+  rescue JSON::ParserError
+    Rails.logger.error 'FIWARE broker sync returned an unparsable body'
+    l(:subscription_sync_error)
+  rescue StandardError => e
+    Rails.logger.error "Error syncing subscription: #{e.message}"
+    l(:subscription_sync_error)
+  end
+
+  def fetch_remote_subscription
+    uri = URI(@subscription_request.subscription_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+
+    headers = {}
+    headers['Authorization'] = "Bearer #{@fiware_broker_auth_token}" if @fiware_broker_auth_token.present?
+    headers.merge!(@subscription_request.tenant_headers)
+    http.request(Net::HTTP::Get.new(uri.path, headers))
+  end
+
+  # Maps the broker's reported subscription state onto the local status.
+  # NGSIv2 reports status active/inactive/oneshot/expired/failed ('failed'
+  # means the last notification failed but the subscription is still active);
+  # NGSI-LD reports status active/paused/expired plus isActive.
+  def apply_remote_status(subscription)
+    remote = subscription['status'].to_s
+    if remote.empty? && @subscription_template.ngsi_ld?
+      remote = subscription['isActive'] == false ? 'paused' : 'active'
+    end
+
+    normalized =
+      case remote
+      when 'active', 'inactive', 'oneshot' then remote
+      when 'failed' then 'active'
+      when 'paused', 'expired' then 'inactive'
+      end
+    return if normalized.nil? || normalized == @subscription_template.status
+
+    @subscription_template.update(status: normalized)
   end
 
   # The broker call runs server-side when the proxy setting is on OR the

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -148,7 +148,8 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   # Queries the broker for the template's subscription and reconciles local
-  # state. Returns the user-facing message.
+  # state. Returns the user-facing message. A 200 whose status the plugin
+  # cannot interpret is reported as an error, not a successful sync.
   def perform_sync
     response = fetch_remote_subscription
     case response
@@ -156,8 +157,12 @@ class SubscriptionTemplatesController < ApplicationController
       @subscription_template.update(subscription_id: nil)
       l(:subscription_sync_removed)
     when Net::HTTPSuccess
-      apply_remote_status(JSON.parse(response.body))
-      l(:subscription_synced)
+      if apply_remote_status(JSON.parse(response.body))
+        l(:subscription_synced)
+      else
+        Rails.logger.error 'FIWARE broker sync: unrecognized subscription status in response'
+        l(:subscription_sync_error)
+      end
     else
       Rails.logger.error "FIWARE broker sync failed: #{response.code} #{response.message}"
       l(:subscription_sync_error)
@@ -178,16 +183,19 @@ class SubscriptionTemplatesController < ApplicationController
     headers = {}
     headers['Authorization'] = "Bearer #{@fiware_broker_auth_token}" if @fiware_broker_auth_token.present?
     headers.merge!(@subscription_request.tenant_headers)
-    http.request(Net::HTTP::Get.new(uri.path, headers))
+    # request_uri keeps any query string and never yields an empty path.
+    http.request(Net::HTTP::Get.new(uri.request_uri, headers))
   end
 
   # Maps the broker's reported subscription state onto the local status.
   # NGSIv2 reports status active/inactive/oneshot/expired/failed ('failed'
   # means the last notification failed but the subscription is still active);
-  # NGSI-LD reports status active/paused/expired plus isActive.
+  # NGSI-LD reports status active/paused/expired plus isActive. Returns the
+  # recognized status, or nil when the response carries none the plugin
+  # understands (the caller reports that as an error).
   def apply_remote_status(subscription)
     remote = subscription['status'].to_s
-    if remote.empty? && @subscription_template.ngsi_ld?
+    if remote.empty? && @subscription_template.ngsi_ld? && subscription.key?('isActive')
       remote = subscription['isActive'] == false ? 'paused' : 'active'
     end
 
@@ -197,9 +205,10 @@ class SubscriptionTemplatesController < ApplicationController
       when 'failed' then 'active'
       when 'paused', 'expired' then 'inactive'
       end
-    return if normalized.nil? || normalized == @subscription_template.status
+    return nil if normalized.nil?
 
-    @subscription_template.update(status: normalized)
+    @subscription_template.update(status: normalized) unless normalized == @subscription_template.status
+    normalized
   end
 
   # The broker call runs server-side when the proxy setting is on OR the

--- a/app/views/subscription_templates/_subscription_template.html.erb
+++ b/app/views/subscription_templates/_subscription_template.html.erb
@@ -23,6 +23,8 @@
   </td>
   <td>
     <% if subscription_template.subscription_id.present? %>
+      <%= link_to sprite_icon('fiware-sync', l(:link_to_sync), :plugin => :redmine_gtt_fiware), sync_project_subscription_template_path(@project, subscription_template),
+          method: :post, remote: true, class: 'icon icon-reload', title: l(:link_to_sync_hint) %>
       <%= link_to sprite_icon('fiware-unpublish', l(:link_to_unpublish), :plugin => :redmine_gtt_fiware), unpublish_project_subscription_template_path(@project, subscription_template),
           method: :post, remote: true, class: 'icon icon-shared' %>
     <% else %>

--- a/app/views/subscription_templates/sync.js.erb
+++ b/app/views/subscription_templates/sync.js.erb
@@ -1,0 +1,8 @@
+// Refresh the subscription template list with the reconciled state and show
+// the outcome. Runs via rails-ujs regardless of the proxy setting (the sync
+// broker call itself always happens server-side).
+var subscriptionTemplateList = document.getElementById('subscriptionTemplateList');
+if (subscriptionTemplateList) {
+  subscriptionTemplateList.innerHTML = '<%= raw j(render partial: 'subscription_templates/subscription_template', collection: @subscription_templates, as: :subscription_template) %>';
+}
+showNotification("<%= raw j(@sync_message) %>");

--- a/assets/images/icons.svg
+++ b/assets/images/icons.svg
@@ -13,6 +13,10 @@
       <path d="M16 19h6"/>
       <path d="M19 16v6"/>
     </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--fiware-sync">
+      <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"/>
+      <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4"/>
+    </symbol>
     <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--fiware-unpublish">
       <path d="M9 15l6 -6"/>
       <path d="M11 6l.463 -.536a5 5 0 1 1 7.071 7.072l-.534 .464"/>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -121,6 +121,12 @@ de:
   field_subscription_template_description: 'Beschreibung'
   label_gtt_fiware: 'FIWARE'
   link_to_unpublish: 'Aufheben'
+  link_to_sync: 'Synchronisieren'
+  link_to_sync_hint: 'Die Subscription beim Broker abfragen und den lokalen Status aktualisieren'
+  subscription_synced: 'Die Subscription wurde mit dem Broker synchronisiert'
+  subscription_sync_removed: 'Die Subscription existiert nicht mehr beim Broker; die gespeicherte Subscription-ID wurde entfernt'
+  subscription_sync_no_subscription: 'Diese Vorlage hat keine veröffentlichte Subscription zum Synchronisieren'
+  subscription_sync_error: 'Der Broker konnte nicht abgefragt werden. Prüfen Sie den Autorisierungstoken und versuchen Sie es erneut.'
   field_subscription_template_comment: 'Anmerkung'
   subscription_published_error: 'Es gab ein Problem bei der Übertragung der Subscription
     an den Broker'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,12 @@ en:
     the broker"
 
   link_to_unpublish: "Unpublish"
+  link_to_sync: "Synchronize"
+  link_to_sync_hint: "Check the subscription on the broker and update the local status"
+  subscription_synced: "Subscription synchronized with the broker"
+  subscription_sync_removed: "The subscription no longer exists on the broker; the stored subscription ID was cleared"
+  subscription_sync_no_subscription: "This template has no published subscription to synchronize"
+  subscription_sync_error: "Could not query the broker to synchronize the subscription. Check the authorization token and try again."
   link_to_unpublish_hint: "Unpublish subscription to broker"
   subscription_unpublished: "Subscription unpublished from broker"
   subscription_unpublished_warning: "The subscription could not be removed from the

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,6 +120,12 @@ ja:
     the broker"
 
   link_to_unpublish: "Unpublish"
+  link_to_sync: "同期"
+  link_to_sync_hint: "ブローカー上のサブスクリプションを確認し、ローカルの状態を更新します"
+  subscription_synced: "サブスクリプションをブローカーと同期しました"
+  subscription_sync_removed: "サブスクリプションはブローカーに存在しないため、保存されていたサブスクリプションIDを削除しました"
+  subscription_sync_no_subscription: "このテンプレートには同期する公開済みサブスクリプションがありません"
+  subscription_sync_error: "ブローカーに接続できず、サブスクリプションを同期できませんでした。認証トークンを確認して再試行してください。"
   link_to_unpublish_hint: "Unpublish subscription to broker"
   subscription_unpublished: "Subscription unpublished from broker"
   subscription_unpublished_warning: "ブローカーからサブスクリプションを削除できませんでした。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ scope 'projects/:project_id' do
       # stored subscription id), so they are POST, not GET.
       post :publish
       post :unpublish
+      # sync reconciles local state with the broker (#13): it may clear the
+      # stored subscription id or update the status, so it is POST too.
+      post :sync
       patch :update_subscription_id
     end
   end

--- a/init.rb
+++ b/init.rb
@@ -32,7 +32,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   # Project module configuration with permissions
   project_module :gtt_fiware do
     permission :manage_subscription_templates, {
-      subscription_templates: %i( new edit update create destroy copy publish unpublish update_subscription_id set_subscription_id),
+      subscription_templates: %i( new edit update create destroy copy publish unpublish sync update_subscription_id set_subscription_id),
       projects: %i( manage_subscription_templates )
     }, require: :member
   end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -238,6 +238,18 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal 'inactive', @template.reload.status
   end
 
+  # A 200 whose status the plugin cannot interpret must be reported as an
+  # error, not a successful sync.
+  def test_sync_reports_an_error_for_an_unrecognized_status
+    @template.update_columns(subscription_id: 'sub-1', status: 'active')
+    stub_broker_get(broker_json_response('status' => 'hibernating'))
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_equal 'active', @template.reload.status
+    assert_includes response.body, 'Could not query the broker'
+  end
+
   def test_sync_keeps_state_and_reports_an_error_when_the_broker_fails
     @template.update_columns(subscription_id: 'sub-1', status: 'active')
     stub_broker_get(Net::HTTPUnauthorized.new('1.1', '401', 'Unauthorized'))
@@ -267,19 +279,17 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
   end
 
   # State-changing endpoints must not be reachable via GET.
-  def test_publish_and_unpublish_are_post_only
-    assert_routing(
-      { method: 'post', path: "/projects/#{@project.id}/subscription_templates/#{@template.id}/publish" },
-      { controller: 'subscription_templates', action: 'publish', project_id: @project.id.to_s, id: @template.id.to_s }
-    )
-    assert_routing(
-      { method: 'post', path: "/projects/#{@project.id}/subscription_templates/#{@template.id}/unpublish" },
-      { controller: 'subscription_templates', action: 'unpublish', project_id: @project.id.to_s, id: @template.id.to_s }
-    )
-    assert_raises(ActionController::RoutingError) do
-      Rails.application.routes.recognize_path(
-        "/projects/#{@project.id}/subscription_templates/#{@template.id}/publish", method: :get
+  def test_publish_unpublish_and_sync_are_post_only
+    %w[publish unpublish sync].each do |action|
+      assert_routing(
+        { method: 'post', path: "/projects/#{@project.id}/subscription_templates/#{@template.id}/#{action}" },
+        { controller: 'subscription_templates', action: action, project_id: @project.id.to_s, id: @template.id.to_s }
       )
+      assert_raises(ActionController::RoutingError, "#{action} must not be reachable via GET") do
+        Rails.application.routes.recognize_path(
+          "/projects/#{@project.id}/subscription_templates/#{@template.id}/#{action}", method: :get
+        )
+      end
     end
   end
 

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -180,6 +180,92 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal 'sub-777', @template.reload.subscription_id
   end
 
+  # --- sync (#13) -----------------------------------------------------------
+
+  def stub_broker_get(response)
+    Net::HTTP.any_instance.stubs(:request).returns(response)
+  end
+
+  def broker_json_response(body)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.stubs(:body).returns(body.to_json)
+    response
+  end
+
+  # The subscription is gone on the broker (e.g. a oneshot fired): sync clears
+  # the stored subscription id so the template shows as unpublished again.
+  def test_sync_clears_the_subscription_id_when_the_broker_returns_404
+    @template.update_column(:subscription_id, 'sub-1')
+    stub_broker_get(Net::HTTPNotFound.new('1.1', '404', 'Not Found'))
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_nil @template.reload.subscription_id
+  end
+
+  def test_sync_updates_the_local_status_from_the_broker
+    @template.update_columns(subscription_id: 'sub-1', status: 'active')
+    stub_broker_get(broker_json_response('status' => 'inactive'))
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_equal 'inactive', @template.reload.status
+  end
+
+  # NGSIv2 'failed' means the last notification failed but the subscription is
+  # still active; 'expired' means it is no longer firing.
+  def test_sync_maps_broker_statuses
+    @template.update_columns(subscription_id: 'sub-1', status: 'inactive')
+    stub_broker_get(broker_json_response('status' => 'failed'))
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_equal 'active', @template.reload.status
+
+    stub_broker_get(broker_json_response('status' => 'expired'))
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_equal 'inactive', @template.reload.status
+  end
+
+  # An NGSI-LD broker without a status field reports isActive.
+  def test_sync_uses_is_active_for_ngsi_ld
+    ld_connection = BrokerConnection.create!(
+      name: 'LD sync broker', standard: 'NGSI-LD', url: 'https://broker.example.com',
+      context: 'https://broker.example.com/ctx.jsonld', auth_mode: 'browser'
+    )
+    @template.update_columns(broker_connection_id: ld_connection.id, subscription_id: 'urn:sub:1', status: 'active')
+    stub_broker_get(broker_json_response('isActive' => false))
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_equal 'inactive', @template.reload.status
+  end
+
+  def test_sync_keeps_state_and_reports_an_error_when_the_broker_fails
+    @template.update_columns(subscription_id: 'sub-1', status: 'active')
+    stub_broker_get(Net::HTTPUnauthorized.new('1.1', '401', 'Unauthorized'))
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_equal 'sub-1', @template.reload.subscription_id
+    assert_equal 'active', @template.status
+    assert_includes response.body, 'Could not query the broker'
+  end
+
+  def test_sync_uses_the_stored_token_server_side
+    stored_connection = BrokerConnection.create!(
+      name: 'Stored sync broker', standard: 'NGSIv2', url: 'https://broker.example.com',
+      auth_mode: 'stored', auth_token: 'sync-secret'
+    )
+    @template.update_columns(broker_connection_id: stored_connection.id, subscription_id: 'sub-1')
+
+    captured_request = nil
+    response = broker_json_response('status' => 'active')
+    Net::HTTP.any_instance.stubs(:request).with { |req| captured_request = req }.returns(response)
+
+    post :sync, params: { project_id: @project.id, id: @template.id }, xhr: true, format: :js
+    assert_response :success
+    assert_equal 'Bearer sync-secret', captured_request['Authorization']
+    assert_not_includes response.body, 'sync-secret'
+  end
+
   # State-changing endpoints must not be reachable via GET.
   def test_publish_and_unpublish_are_post_only
     assert_routing(


### PR DESCRIPTION
## Summary

Phase 2, second item (#13): a per-template **Synchronize** action that queries the broker for the published subscription and reconciles local plugin state — Redmine records can drift, e.g. when a `oneshot` subscription fired or a subscription expired and was purged.

## Behaviour

| Broker response | Local effect |
| --- | --- |
| `404` | Stored subscription id is cleared; the template shows as unpublished again |
| `200`, NGSIv2 `status` `active` / `inactive` / `oneshot` | Local status updated to match |
| `200`, NGSIv2 `status` `failed` | Local status `active` (failed = last notification failed, subscription still live) |
| `200`, NGSIv2/LD `status` `expired` / `paused` | Local status `inactive` |
| `200`, NGSI-LD without `status` | `isActive` fallback |
| Error (unreachable, 401, unparsable body) | Local state untouched; warning shown |

## Design notes

- The broker call always runs **server-side**; the token comes from the stored connection (#67) or, in browser/proxy mode, the per-request header. A stored token is never rendered into the response (asserted by a test).
- POST-only (it changes state), gated by the existing `manage_subscription_templates` permission.
- The response is a small JS view that refreshes the template list and shows the outcome regardless of the `connect_via_proxy` setting.
- Tenant headers are standard-aware (`NGSILD-Tenant` for LD) via the `SubscriptionRequest` builder.
- New `fiware-sync` sprite icon (Tabler refresh), EN/JA/DE strings.

## Tests

Full plugin suite green locally (132 tests). 6 new functional tests with a stubbed broker: 404 clears the id, status mapping (including `failed` and `expired`), NGSI-LD `isActive`, error keeps state, stored token used server-side and never leaked.

Closes #13