### PR TITLE
fix: broker connections admin menu item icon

### DIFF
--- a/assets/images/icons.svg
+++ b/assets/images/icons.svg
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg" class="icon--sprite">
   <defs>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--cloud-data-connection">
+      <path d="M5 9.897c0 -1.714 1.46 -3.104 3.26 -3.104c.275 -1.22 1.255 -2.215 2.572 -2.611c1.317 -.397 2.77 -.134 3.811 .69c1.042 .822 1.514 2.08 1.239 3.3h.693a2.42 2.42 0 0 1 2.425 2.414a2.42 2.42 0 0 1 -2.425 2.414h-8.315c-1.8 0 -3.26 -1.39 -3.26 -3.103"/>
+      <path d="M12 13v3"/>
+      <path d="M10 18a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"/>
+      <path d="M14 18h7"/>
+      <path d="M3 18h7"/>
+    </symbol>
     <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--fiware-clipboard">
       <path d="M9 5h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h3m9 -9v-5a2 2 0 0 0 -2 -2h-2"/>
       <path d="M13 17v-1a1 1 0 0 1 1 -1h1m3 0h1a1 1 0 0 1 1 1v1m0 3v1a1 1 0 0 1 -1 1h-1m-3 0h-1a1 1 0 0 1 -1 -1v-1"/>

--- a/init.rb
+++ b/init.rb
@@ -24,10 +24,15 @@ Redmine::Plugin.register :redmine_gtt_fiware do
     partial: 'gtt_fiware/settings'
   )
 
-  # Broker connections are instance-level and admin-managed, like auth sources.
+  # Broker connections are instance-level and admin-managed, like auth sources
+  # (which is also why they reuse core's server-authentication icon). The :icon
+  # and matching :html class are both required for the admin menu item to
+  # render its sprite icon, exactly as core's own admin_menu items do.
   menu :admin_menu, :fiware_broker_connections,
        { controller: 'broker_connections', action: 'index' },
-       caption: :label_broker_connection_plural
+       caption: :label_broker_connection_plural,
+       icon: 'server-authentication',
+       html: { class: 'icon icon-server-authentication' }
 
   # Project module configuration with permissions
   project_module :gtt_fiware do

--- a/init.rb
+++ b/init.rb
@@ -24,15 +24,16 @@ Redmine::Plugin.register :redmine_gtt_fiware do
     partial: 'gtt_fiware/settings'
   )
 
-  # Broker connections are instance-level and admin-managed, like auth sources
-  # (which is also why they reuse core's server-authentication icon). The :icon
-  # and matching :html class are both required for the admin menu item to
+  # Broker connections are instance-level and admin-managed. The :icon (with
+  # :plugin, so it resolves from this plugin's own sprite rather than core's)
+  # and the matching :html class are both required for the admin menu item to
   # render its sprite icon, exactly as core's own admin_menu items do.
   menu :admin_menu, :fiware_broker_connections,
        { controller: 'broker_connections', action: 'index' },
        caption: :label_broker_connection_plural,
-       icon: 'server-authentication',
-       html: { class: 'icon icon-server-authentication' }
+       icon: 'cloud-data-connection',
+       plugin: :redmine_gtt_fiware,
+       html: { class: 'icon icon-cloud-data-connection' }
 
   # Project module configuration with permissions
   project_module :gtt_fiware do


### PR DESCRIPTION
## Summary

The **FIWARE Broker Connections** admin menu item (added in #67) rendered without an icon, unlike every other item in the Administration menu.

Core's `admin_menu` items each carry both an `:icon` (sprite name) and a matching `:html => { class: 'icon icon-<name>' }`; the plugin's registration had neither. This adds them, using a dedicated **`cloud-data-connection`** glyph (Tabler outline) shipped in the plugin's own sprite. The admin-menu renderer passes `:plugin` through to `sprite_icon`, so the icon resolves from the plugin sprite (`plugin_assets/redmine_gtt_fiware/icons.svg`) rather than core's.

(An earlier revision reused core's `server-authentication` icon, but that collided visually with LDAP authentication — a broker connection deserves its own distinct glyph.)

## Verification

Verified live in the dev container (chrome-devtools): after a restart to reload `init.rb`, the item renders the 18×18 `cloud-data-connection` icon, resolving from `plugin_assets/redmine_gtt_fiware/icons-*.svg#icon--cloud-data-connection`, distinct from LDAP authentication. No behaviour change beyond the menu icon; no test added (boot-time menu registration + static sprite asset, verified visually).