### PR TITLE
Clone picker rows from an inert template prototype; harden JSON edge validation

### DIFF
--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -163,8 +163,13 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   # Parsable JSON is not enough: the subscription builders and the form's
   # structured picker both expect an array of entity objects, so '{}' or
   # '[1]' must fail validation here instead of breaking publish later.
+  # Blank input is left to the presence validation (one error, and no
+  # TypeError from JSON.parse(nil)); to_s keeps a stray non-string writer
+  # value on the graceful rescue path instead of raising.
   def take_json_entities
-    parsed = JSON.parse(entities_string)
+    return if entities_string.blank?
+
+    parsed = JSON.parse(entities_string.to_s)
     unless parsed.is_a?(Array) && parsed.any? && parsed.all? { |e| e.is_a?(Hash) }
       errors.add :entities_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
       return
@@ -189,7 +194,7 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   def take_json_attachments
     return if attachments_string.blank?
 
-    parsed = JSON.parse(attachments_string)
+    parsed = JSON.parse(attachments_string.to_s)
     if parsed.nil?
       self.attachments = nil
       return

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -160,8 +160,16 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     self.notify_on_metadata_change = true if notify_on_metadata_change.nil?
   end
 
+  # Parsable JSON is not enough: the subscription builders and the form's
+  # structured picker both expect an array of entity objects, so '{}' or
+  # '[1]' must fail validation here instead of breaking publish later.
   def take_json_entities
-    self.entities = JSON.parse(entities_string)
+    parsed = JSON.parse(entities_string)
+    unless parsed.is_a?(Array) && parsed.any? && parsed.all? { |e| e.is_a?(Hash) }
+      errors.add :entities_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
+      return
+    end
+    self.entities = parsed
   rescue JSON::ParserError
     errors.add :entities_string, I18n.t(:error_invalid_json)
   end
@@ -174,10 +182,23 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     errors.add :geometry_string, I18n.t(:error_invalid_json)
   end
 
+  # 'null' (from the picker with no rows) clears the stored attachments; any
+  # other value must be an array of attachment objects -- a parsable but
+  # wrong-shaped value ('{}', '[1]') previously slipped through validation
+  # and broke the picker and the download step downstream.
   def take_json_attachments
     return if attachments_string.blank?
 
-    self.attachments = JSON.parse(attachments_string)
+    parsed = JSON.parse(attachments_string)
+    if parsed.nil?
+      self.attachments = nil
+      return
+    end
+    unless parsed.is_a?(Array) && parsed.all? { |a| a.is_a?(Hash) }
+      errors.add :attachments_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
+      return
+    end
+    self.attachments = parsed
   rescue JSON::ParserError
     errors.add :attachments_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
   end

--- a/app/views/subscription_templates/_attachment_row.html.erb
+++ b/app/views/subscription_templates/_attachment_row.html.erb
@@ -1,0 +1,10 @@
+<%# One attachment picker row (#66). Rendered once per stored attachment and
+    once inside the picker's <template> prototype, which the add link clones
+    -- so adding still works when every row has been removed. %>
+<span class="gtt-fiware-attachment-row" style="display: block; margin-bottom: 4px;">
+  <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" placeholder="https://example.com/photo.jpg" size="35" />
+  <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" placeholder="photo-${id}.jpg" size="20" />
+  <input type="text" class="js-attachment-description" value="<%= attachment['description'] %>" placeholder="<%= l(:field_description) %>" size="20" />
+  <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
+  <a href="#" class="js-attachment-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
+</span>

--- a/app/views/subscription_templates/_entity_row.html.erb
+++ b/app/views/subscription_templates/_entity_row.html.erb
@@ -1,0 +1,13 @@
+<%# One structured entity picker row (#66). Rendered once per stored entity
+    and once inside the picker's <template> prototype, which the add link
+    clones -- so adding still works when every row has been removed. %>
+<span class="gtt-fiware-entity-row" style="display: block; margin-bottom: 4px;">
+  <input type="text" class="js-entity-type" value="<%= entity['type'] %>" placeholder="<%= l(:field_subscription_template_entity_type_placeholder) %>" size="25" />
+  <select class="js-entity-match-kind">
+    <option value="idPattern" <%= 'selected' if entity.key?('idPattern') || !entity.key?('id') %>><%= l(:label_entity_match_pattern) %></option>
+    <option value="id" <%= 'selected' if entity.key?('id') %>><%= l(:label_entity_match_id) %></option>
+  </select>
+  <input type="text" class="js-entity-match-value" value="<%= entity['idPattern'] || entity['id'] %>" size="25" />
+  <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
+  <a href="#" class="js-entity-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
+</span>

--- a/app/views/subscription_templates/_form_basics.html.erb
+++ b/app/views/subscription_templates/_form_basics.html.erb
@@ -34,18 +34,12 @@
     <%= content_tag :label, l(:field_subscription_template_entities) %>
     <span id="gtt-fiware-entity-rows" <%= 'style=display:none;'.html_safe unless entities_pickerable %>>
       <% entity_rows.each do |entity| %>
-        <span class="gtt-fiware-entity-row" style="display: block; margin-bottom: 4px;">
-          <input type="text" class="js-entity-type" value="<%= entity['type'] %>" placeholder="<%= l(:field_subscription_template_entity_type_placeholder) %>" size="25" />
-          <select class="js-entity-match-kind">
-            <option value="idPattern" <%= 'selected' if entity.key?('idPattern') || !entity.key?('id') %>><%= l(:label_entity_match_pattern) %></option>
-            <option value="id" <%= 'selected' if entity.key?('id') %>><%= l(:label_entity_match_id) %></option>
-          </select>
-          <input type="text" class="js-entity-match-value" value="<%= entity['idPattern'] || entity['id'] %>" size="25" />
-          <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
-          <a href="#" class="js-entity-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
-        </span>
+        <%= render 'entity_row', entity: entity %>
       <% end %>
       <a href="#" id="gtt-fiware-entity-add"><%= l(:label_entity_filter_add) %></a>
+      <%# Inert prototype the add link clones; independent of existing rows,
+          so adding works again after the last row was removed. %>
+      <template id="gtt-fiware-entity-prototype"><%= render 'entity_row', entity: { 'type' => '', 'idPattern' => '.*' } %></template>
     </span>
     <a href="#" class="js-json-toggle" data-target="entities" style="font-size: 0.9em;"><%= l(:label_edit_as_json) %></a>
   </p>

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -43,15 +43,12 @@
     <%= content_tag :label, l(:field_subscription_template_attachments) %>
     <span id="gtt-fiware-attachment-rows" <%= 'style=display:none;'.html_safe unless attachments_pickerable %>>
       <% attachment_rows.each do |attachment| %>
-        <span class="gtt-fiware-attachment-row" style="display: block; margin-bottom: 4px;">
-          <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" placeholder="https://example.com/photo.jpg" size="35" />
-          <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" placeholder="photo-${id}.jpg" size="20" />
-          <input type="text" class="js-attachment-description" value="<%= attachment['description'] %>" placeholder="<%= l(:field_description) %>" size="20" />
-          <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
-          <a href="#" class="js-attachment-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
-        </span>
+        <%= render 'attachment_row', attachment: attachment %>
       <% end %>
       <a href="#" id="gtt-fiware-attachment-add"><%= l(:label_attachment_template_add) %></a>
+      <%# Inert prototype the add link clones; independent of existing rows,
+          so adding works again after the last row was removed. %>
+      <template id="gtt-fiware-attachment-prototype"><%= render 'attachment_row', attachment: {} %></template>
     </span>
     <a href="#" class="js-json-toggle" data-target="attachments" style="font-size: 0.9em;"><%= l(:label_edit_as_json) %></a>
   </p>

--- a/app/views/subscription_templates/_form_script.html.erb
+++ b/app/views/subscription_templates/_form_script.html.erb
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // --- row add/remove ----------------------------------------------------
 
-  function wireRowContainer(containerId, addId, rowClass) {
+  function wireRowContainer(containerId, addId, rowClass, prototypeId) {
     var container = document.getElementById(containerId);
     if (!container) { return; }
     container.addEventListener('click', function(e) {
@@ -116,17 +116,17 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       if (e.target.closest('#' + addId)) {
         e.preventDefault();
-        var rows = container.querySelectorAll('.' + rowClass);
-        var template = rows[rows.length - 1];
-        if (!template) { return; }
-        var clone = template.cloneNode(true);
-        clone.querySelectorAll('input').forEach(function(input) { input.value = ''; });
+        // Clone the inert <template> prototype, not an existing row: cloning
+        // the last row broke as soon as every row had been removed.
+        var prototype = document.getElementById(prototypeId);
+        if (!prototype) { return; }
+        var clone = prototype.content.firstElementChild.cloneNode(true);
         container.insertBefore(clone, document.getElementById(addId));
       }
     });
   }
-  wireRowContainer('gtt-fiware-entity-rows', 'gtt-fiware-entity-add', 'gtt-fiware-entity-row');
-  wireRowContainer('gtt-fiware-attachment-rows', 'gtt-fiware-attachment-add', 'gtt-fiware-attachment-row');
+  wireRowContainer('gtt-fiware-entity-rows', 'gtt-fiware-entity-add', 'gtt-fiware-entity-row', 'gtt-fiware-entity-prototype');
+  wireRowContainer('gtt-fiware-attachment-rows', 'gtt-fiware-attachment-add', 'gtt-fiware-attachment-row', 'gtt-fiware-attachment-prototype');
 
   document.querySelectorAll('.js-json-toggle').forEach(function(link) {
     link.addEventListener('click', function(e) {

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -246,10 +246,13 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     # The status select must carry this id or the LD oneshot toggle in
     # _form_script silently no-ops (id/required belong in html_options).
     assert_select 'select#gtt-fiware-status-select'
-    # One blank starter row each: the add links clone the last row, so with
-    # zero rows they would silently do nothing.
-    assert_select 'span.gtt-fiware-entity-row', 1
-    assert_select 'span.gtt-fiware-attachment-row', 1
+    # One blank starter row each, plus one row inside each picker's inert
+    # <template> prototype -- the add link clones the prototype, so adding
+    # must keep working after every visible row has been removed.
+    assert_select 'span.gtt-fiware-entity-row', 2
+    assert_select 'span.gtt-fiware-attachment-row', 2
+    assert_select 'template#gtt-fiware-entity-prototype span.gtt-fiware-entity-row', 1
+    assert_select 'template#gtt-fiware-attachment-prototype span.gtt-fiware-attachment-row', 1
     # Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0.
     assert_select 'a.js-entity-remove svg'
     assert_select 'a.js-attachment-remove svg'

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -152,6 +152,79 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert template.errors[:entities_string].present?
   end
 
+  # Parsable JSON with the wrong shape must fail validation too: the
+  # subscription builders expect a non-empty array of entity objects.
+  def test_entities_string_must_be_a_non_empty_array_of_objects
+    ['{}', '[]', '[1, 2]', '"TemperatureSensor"', '[{"type": "X"}, "y"]'].each do |bad|
+      template = SubscriptionTemplate.new(valid_attributes(entities_string: bad))
+      assert_not template.valid?, "#{bad.inspect} must be rejected"
+      assert template.errors[:entities_string].present?
+    end
+  end
+
+  def test_entities_string_accepts_id_and_id_pattern_entries
+    good = '[{"type": "RoadDamage", "idPattern": ".*"}, {"type": "RoadDamage", "id": "urn:x"}]'
+    template = SubscriptionTemplate.new(valid_attributes(entities_string: good))
+    assert template.valid?
+    assert_equal 2, template.entities.size
+  end
+
+  # 'null' is what the picker serializes with no rows: it clears the stored
+  # attachments instead of failing validation.
+  def test_attachments_string_null_clears_attachments
+    # reload: the just-created instance carries alteration_types in its
+    # serialized (before_save) form, which would fail revalidation.
+    template = SubscriptionTemplate.create!(
+      valid_attributes(attachments_string: '[{"url": "https://example.com/a.jpg"}]')
+    ).reload
+    assert_equal 1, template.attachments.size
+
+    template.attachments_string = 'null'
+    assert template.valid?
+    template.save!
+    assert_nil template.reload.attachments
+  end
+
+  def test_attachments_string_must_be_an_array_of_objects
+    ['not json', '{}', '[1]', '"https://example.com/a.jpg"', '[{"url": "x"}, 5]'].each do |bad|
+      template = SubscriptionTemplate.new(valid_attributes(attachments_string: bad))
+      assert_not template.valid?, "#{bad.inspect} must be rejected"
+      assert template.errors[:attachments_string].present?
+    end
+  end
+
+  def test_attachments_string_accepts_an_array_of_objects
+    template = SubscriptionTemplate.new(
+      valid_attributes(attachments_string: '[{"url": "https://example.com/a.jpg", "filename": "a-${id}.jpg"}]')
+    )
+    assert template.valid?
+    assert_equal 'a-${id}.jpg', template.attachments.first['filename']
+  end
+
+  # geometry_string stays free-form JSON: "${location}" (a string template),
+  # a GeoJSON object and 'null' (clear) are all legitimate values.
+  def test_geometry_string_accepts_template_geojson_and_null
+    ['"${location}"', '{"type": "Point", "coordinates": [1, 2]}', 'null'].each do |good|
+      template = SubscriptionTemplate.new(valid_attributes(geometry_string: good))
+      assert template.valid?, "#{good.inspect} must be accepted"
+    end
+    template = SubscriptionTemplate.new(valid_attributes(geometry_string: '{not json'))
+    assert_not template.valid?
+    assert template.errors[:geometry_string].present?
+  end
+
+  def test_attrs_must_be_a_json_array_of_strings
+    ['["temperature", "humidity"]', '', nil].each do |good|
+      template = SubscriptionTemplate.new(valid_attributes(attrs: good))
+      assert template.valid?, "#{good.inspect} must be accepted"
+    end
+    ['[1]', '"temperature"', '{"a": 1}', 'not json'].each do |bad|
+      template = SubscriptionTemplate.new(valid_attributes(attrs: bad))
+      assert_not template.valid?, "#{bad.inspect} must be rejected"
+      assert template.errors[:attrs].present?
+    end
+  end
+
   def test_name_is_unique_within_project
     SubscriptionTemplate.create!(valid_attributes)
     duplicate = SubscriptionTemplate.new(valid_attributes)

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -152,6 +152,17 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert template.errors[:entities_string].present?
   end
 
+  # Blank input is the presence validation's job: exactly one error, and no
+  # TypeError from JSON.parse(nil).
+  def test_blank_entities_string_reports_presence_only
+    ['', nil].each do |blank|
+      template = SubscriptionTemplate.new(valid_attributes(entities_string: blank))
+      template.entities = nil
+      assert_not template.valid?
+      assert_equal 1, template.errors[:entities_string].size, "#{blank.inspect} must add exactly one error"
+    end
+  end
+
   # Parsable JSON with the wrong shape must fail validation too: the
   # subscription builders expect a non-empty array of entity objects.
   def test_entities_string_must_be_a_non_empty_array_of_objects


### PR DESCRIPTION
## The bug (follow-up to #104)

Row deletion works since #104 — but delete **every** row and the add link dies: it cloned the *last existing row*, and with zero rows there was nothing to clone. Second failure of the clone-a-sibling approach (the first was "Add attachment" with zero initial rows), so this removes the pattern instead of patching it again:

- each picker now renders an inert **`<template>` prototype**; the add link clones that, fully independent of the visible rows
- the row markup moved into `_entity_row` / `_attachment_row` partials, shared by stored rows and prototypes — one source of truth
- side effect: new rows arrive prefilled like the starter row (`.*` pattern) instead of as a cleared clone

Browser-verified: remove all → add works, both pickers.

## Edge-case hardening + tests

The form's serialization contract had validation gaps: `take_json_entities` / `take_json_attachments` only rejected *unparsable* JSON, so parsable-but-wrong shapes (`{}`, `[1, 2]`, `"string"`) passed validation and would break the subscription builders or the picker downstream.

- `entities_string` must now be a **non-empty array of objects**
- `attachments_string` must be an **array of objects**; `null` (the picker's no-rows value) still clears
- `geometry_string` deliberately stays free-form (`"${location}"` templates, GeoJSON objects, `null` are all legitimate)

New unit tests pin every accepted/rejected shape for `entities_string`, `attachments_string`, `geometry_string` and `attrs`, plus the `null`-clears-attachments round trip. Functional tests pin the prototype contract (one row inside each `<template>`), so a picker that loses its prototype fails CI instead of failing users.

## Testing

Full suite: **168 runs, 617 assertions, 0 failures** (was 161 — 7 new tests).