### PR TITLE
Store nil, not '', when browser-mode unpublish clears the subscription id

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -66,7 +66,9 @@ class SubscriptionTemplatesController < ApplicationController
 
   def update_subscription_id
     @subscription_template = find_subscription_template
-    @subscription_template.update(subscription_id: params[:subscription_id])
+    # presence: browser-mode unpublish PATCHes an empty string; store nil so a
+    # cleared subscription looks the same regardless of which mode cleared it.
+    @subscription_template.update(subscription_id: params[:subscription_id].presence)
 
     @subscription_templates = subscription_template_scope
     respond_to do |format|

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -65,9 +65,10 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def update_subscription_id
-    @subscription_template = find_subscription_template
-    # presence: browser-mode unpublish PATCHes an empty string; store nil so a
-    # cleared subscription looks the same regardless of which mode cleared it.
+    # @subscription_template is loaded by the find_subscription_template
+    # before_action. presence: browser-mode unpublish PATCHes an empty string;
+    # store nil so a cleared subscription looks the same regardless of which
+    # mode cleared it.
     @subscription_template.update(subscription_id: params[:subscription_id].presence)
 
     @subscription_templates = subscription_template_scope

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -324,6 +324,19 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal I18n.t(:subscription_unauthorized_error), flash[:error]
   end
 
+  # Browser-mode publish/unpublish report the broker-assigned id back through
+  # this action; an empty value (unpublish) must store nil, not '', so a
+  # cleared subscription looks the same regardless of which mode cleared it.
+  def test_update_subscription_id_sets_and_clears
+    patch :update_subscription_id, params: { project_id: @project.id, id: @template.id, subscription_id: 'sub-42' }, xhr: true
+    assert_response :success
+    assert_equal 'sub-42', @template.reload.subscription_id
+
+    patch :update_subscription_id, params: { project_id: @project.id, id: @template.id, subscription_id: '' }, xhr: true
+    assert_response :success
+    assert_nil @template.reload.subscription_id
+  end
+
   # --- transport modes and throttling (#95) ----------------------------------
 
   # 'proxied': the token is typed in the browser and sent as a header, but the


### PR DESCRIPTION
Found while live-testing the **relayed (proxied)** and **browser** auth modes end-to-end — the two modes whose client-side halves had never run for real (functional tests cover the server side, but not the token box, the header-attaching list JS, or browser mode's cross-origin fetch).

## The live test (header-echo fake broker, real UI clicks)

| Step | Result |
| --- | --- |
| Relayed publish (token typed in box) | broker received `Authorization: Bearer <typed>` from **user-agent Ruby** — server relays, token never stored |
| Browser publish (`token_header: X-Api-Key`) | CORS preflight + `POST` straight **from Chrome** (Origin header) carrying `x-api-key: <typed>` — also live-proves #100's custom-header JS |
| Both | broker `Location` id stored locally (browser mode via the `update_subscription_id` PATCH) |
| Relayed unpublish | `DELETE` with Bearer header from the server, local id → `nil` |
| Browser unpublish | preflight + `DELETE` with `x-api-key` from the browser, local id → **`''`** ← the finding |

## The fix

`update_subscription_id` stored the raw param, so browser-mode unpublish (which PATCHes an empty value) left `''` where every server-side path leaves `nil`. Reads agree today (`present?` everywhere), but the two cleared states should not differ at the database level — a future `WHERE subscription_id IS NULL` would silently miss browser-cleared rows.

The action now stores `params[:subscription_id].presence`. New functional test covers set and clear (the action previously had no test at all).

## Testing

Full suite: **170 runs, 625 assertions, 0 failures**.