### PR TITLE
Make the release verification repeatable: fake broker, seeder, checklist

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -28,6 +28,9 @@ development) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang
 ## Tools and Utilities
 
 - [FIWARE Broker Scripts](broker_scripts.md)
+- [Release Verification](release_verification.md) — pre-release checks beyond
+  the automated suite: auth mode drill against a fake broker, real broker
+  round trips for both NGSI standards
 
 ## Reference
 

--- a/doc/release_verification.md
+++ b/doc/release_verification.md
@@ -1,0 +1,128 @@
+# Release Verification
+
+Manual-but-scripted checks to run before tagging a release, on top of the
+automated test suite. Each layer catches what the previous one cannot; the
+whole pass takes roughly half an hour. First run: 2026-07-28/29 for v3.0
+(results recorded on [issue #16](https://github.com/gtt-project/redmine_gtt_fiware/issues/16)).
+
+## Layer 0 — automated suite (CI)
+
+The GitHub Actions matrix (Redmine/RedMica 6.0–7.0 x Ruby 3.3–4.0) must be
+green on the release commit. It covers models, controllers, builders and the
+form's DOM contract, but executes **no client-side JavaScript** and talks to
+**no real broker** — that is what the layers below are for.
+
+## Layer 1 — auth mode drill (fake broker)
+
+Verifies the three connection auth modes end to end through the real UI,
+including the browser-mode JavaScript and CORS. Uses
+[`scripts/fake_broker.py`](scripts/fake_broker.py), a dependency-free
+header-echo broker: it logs every request as a JSON line, answers subscription
+POSTs with `201` + `Location`, and speaks CORS.
+
+1. Start it on the same container network as Redmine, with the port also
+   published to the host (browser mode calls it from your browser):
+
+   ```bash
+   podman run -d --name fakebroker --network <redmine-network> -p 9999:9999 \
+     -v $(pwd)/plugins/redmine_gtt_fiware/doc/scripts/fake_broker.py:/srv/broker.py:ro \
+     docker.io/library/python:3-alpine python /srv/broker.py
+   ```
+
+   > Hostname rule: brokers reject URL hosts containing underscores
+   > (`400 invalid custom /url/` from Orion), so reach Redmine and the fake
+   > broker via underscore-free network aliases.
+
+2. Seed one connection + template per mode (idempotent):
+
+   ```bash
+   VERIFY_PROJECT=<project-identifier> bundle exec rails runner \
+     plugins/redmine_gtt_fiware/doc/scripts/seed_verification.rb
+   ```
+
+3. Open the project's FIWARE settings tab and drill each template. For the
+   relayed and browser templates, first type any token (e.g. `relay-me-123`)
+   into the token box; the stored template publishes with its stored token
+   directly.
+
+4. Compare `podman logs fakebroker` against this table — the **user-agent and
+   origin tell you which side made the call**, which is the whole point:
+
+   | Action | Expected request at the broker |
+   | --- | --- |
+   | stored publish | `POST` with `Authorization: Bearer stored-secret-789`, Ruby user-agent, no Origin |
+   | relayed publish | `POST` with `Authorization: Bearer <typed token>`, Ruby user-agent (server relays; token not stored) |
+   | browser publish | `OPTIONS` preflight, then `POST` **from the browser** (browser user-agent + `Origin` header) with `X-Api-Key: <typed token>` — the custom token header (#99) |
+   | each unpublish | matching `DELETE` with the same auth header from the same side |
+
+   Also check in Redmine: each publish stores a `fake-sub-N` subscription id
+   (browser mode reports it back through a PATCH), each unpublish clears it to
+   blank, and the page never displays a stored token.
+
+## Layer 2 — real broker round trip (NGSIv2, local Orion)
+
+Verifies the actual subscription payloads, `q` filter enforcement, notification
+delivery, webhook authentication and issue creation against a real broker.
+
+```bash
+podman run -d --name orion-mongo --network <redmine-network> docker.io/library/mongo:5.0
+podman run -d --name orion-v2 --network <redmine-network> -p 1026:1026 \
+  docker.io/fiware/orion:3.12.0 -dbURI mongodb://orion-mongo
+```
+
+1. Create an NGSIv2 connection to `http://orion-v2:1026` (stored mode, no
+   token — an open broker also verifies the token-less stored path).
+2. Create a template with a query filter (e.g. `severity>3`) and geometry
+   "Entity location", then publish it. The notification callback URL must be
+   reachable **from the Orion container** (see #101: the URL is built from the
+   publishing request's host, so publish from a host/alias Orion can resolve).
+3. Three-phase filter test — create an entity below the threshold, update it
+   to the boundary, then past it:
+
+   ```bash
+   curl -s http://localhost:1026/v2/entities -H 'Content-Type: application/json' -d \
+     '{"id":"urn:verify:1","type":"<entity type>","severity":{"type":"Number","value":2},
+       "location":{"type":"geo:json","value":{"type":"Point","coordinates":[139.69,35.69]}}}'
+   curl -s http://localhost:1026/v2/entities/urn:verify:1/attrs -X PATCH \
+     -H 'Content-Type: application/json' -d '{"severity":{"type":"Number","value":5}}'
+   ```
+
+   Expected: **no issue** for the below-threshold phases, **exactly one issue**
+   after crossing it — with the subject/description rendered, the author set to
+   the template's member, and the point geometry on the map. `GET
+   /v2/subscriptions` shows `timesSent: 1`.
+4. Exercise the Synchronize and Unpublish buttons; after unpublish the broker's
+   subscription list is empty and the local subscription id is cleared.
+
+## Layer 3 — NGSI-LD round trip (real LD broker)
+
+Same shape as layer 2 against an NGSI-LD broker (hosted or local). Watch for:
+
+- `NGSILD-Tenant` header (no service path in LD), `application/ld+json`,
+  `@context` in the payload
+- `notification.endpoint.receiverInfo` **must** arrive as real HTTP headers —
+  the webhook-secret authentication depends on it
+- notifications may carry `String`/`Number` attribute types and `Relationship`
+  values under `value` instead of `object`; issues must still render
+- broker callbacks need a publicly reachable Redmine URL (a
+  `cloudflared tunnel --url http://127.0.0.1:3000` quick tunnel works; Rails
+  host authorization must allow the tunnel host in development)
+- **known upstream gap:** some brokers accept `q`/`geoQ` on subscriptions but
+  do not apply them to notifications — run the layer 2 three-phase test here
+  too and record the result
+
+## Cleanup
+
+```bash
+podman rm -f fakebroker orion-v2 orion-mongo
+```
+
+Delete the `Verification broker (...)` connections and `Verification: ... mode`
+templates from the UI (or rerun the seeder next time — it is idempotent).
+
+## Future automation
+
+The natural promotion path is browser-driven system tests (Capybara/headless
+Chrome, as Redmine core uses) for layer 1, and a scripted layer 2 harness.
+Tracked with the JavaScript test setup in
+[#106](https://github.com/gtt-project/redmine_gtt_fiware/issues/106).

--- a/doc/scripts/fake_broker.py
+++ b/doc/scripts/fake_broker.py
@@ -10,7 +10,7 @@ Usage (any container runtime; the port must be reachable both by the Redmine
 server for stored/relayed mode and by the operator's browser for browser mode):
 
     podman run -d --name fakebroker --network <redmine-network> -p 9999:9999 \
-      -v $(pwd)/fake_broker.py:/srv/broker.py:ro \
+      -v $(pwd)/plugins/redmine_gtt_fiware/doc/scripts/fake_broker.py:/srv/broker.py:ro \
       docker.io/library/python:3-alpine python /srv/broker.py
 
     podman logs fakebroker        # the request log
@@ -53,7 +53,12 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
-        self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        # A malformed Content-Length must not crash the verification server.
+        try:
+            length = int(self.headers.get('Content-Length', 0))
+        except (TypeError, ValueError):
+            length = 0
+        self.rfile.read(length)
         self._log()
         Handler.counter += 1
         self.send_response(201)

--- a/doc/scripts/fake_broker.py
+++ b/doc/scripts/fake_broker.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Header-echo fake FIWARE broker for verifying the plugin's auth modes.
+
+Logs every request (method, path, headers) as a JSON line to stdout, answers
+subscription POSTs with 201 + a Location header, and speaks enough CORS for a
+cross-origin browser-mode fetch (including exposing Location, which
+publish.js.erb reads). No state, no dependencies beyond the standard library.
+
+Usage (any container runtime; the port must be reachable both by the Redmine
+server for stored/relayed mode and by the operator's browser for browser mode):
+
+    podman run -d --name fakebroker --network <redmine-network> -p 9999:9999 \
+      -v $(pwd)/fake_broker.py:/srv/broker.py:ro \
+      docker.io/library/python:3-alpine python /srv/broker.py
+
+    podman logs fakebroker        # the request log
+
+Environment:
+    PORT        listen port (default 9999)
+    BROKER_LOG  optional file to append the JSON lines to as well
+"""
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    counter = 0
+
+    def _cors(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+        # Authorization is excluded from the '*' wildcard, so list explicitly.
+        self.send_header('Access-Control-Allow-Headers',
+                         'Authorization, Content-Type, X-Api-Key, X-Auth-Token, '
+                         'Fiware-Service, Fiware-ServicePath, NGSILD-Tenant')
+        self.send_header('Access-Control-Expose-Headers', 'Location')
+
+    def _log(self):
+        line = json.dumps({'method': self.command, 'path': self.path,
+                           'headers': dict(self.headers)})
+        print(line, flush=True)
+        log_file = os.environ.get('BROKER_LOG')
+        if log_file:
+            with open(log_file, 'a') as f:
+                f.write(line + '\n')
+
+    def do_OPTIONS(self):
+        self._log()
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        self._log()
+        Handler.counter += 1
+        self.send_response(201)
+        self._cors()
+        self.send_header('Location', '/v2/subscriptions/fake-sub-%d' % Handler.counter)
+        self.end_headers()
+
+    def do_DELETE(self):
+        self._log()
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_GET(self):
+        self._log()
+        body = json.dumps({'status': 'active'}).encode()
+        self.send_response(200)
+        self._cors()
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '9999'))
+    print('fake broker listening on :%d' % port, file=sys.stderr, flush=True)
+    HTTPServer(('0.0.0.0', port), Handler).serve_forever()

--- a/doc/scripts/seed_verification.rb
+++ b/doc/scripts/seed_verification.rb
@@ -1,0 +1,80 @@
+# Seeds one broker connection and one subscription template per auth mode
+# (stored / relayed / browser), all pointing at the fake_broker.py echo broker,
+# for the manual auth-mode drill in doc/release_verification.md.
+#
+# Idempotent: reruns update the same records (matched by name).
+#
+# Usage, from the Redmine root:
+#
+#   VERIFY_PROJECT=<identifier> bundle exec rails runner \
+#     plugins/redmine_gtt_fiware/doc/scripts/seed_verification.rb
+#
+# Environment:
+#   VERIFY_PROJECT              project identifier (required; the GTT FIWARE
+#                               module must be enabled and the project must
+#                               have at least one member and tracker)
+#   FAKE_BROKER_SERVER_URL      broker URL as reachable FROM THE REDMINE SERVER
+#                               (default http://fakebroker:9999 -- container
+#                               network alias; hostnames must not contain
+#                               underscores, brokers reject them in URLs)
+#   FAKE_BROKER_BROWSER_URL     broker URL as reachable FROM THE BROWSER
+#                               (default http://localhost:9999)
+#   VERIFY_MEMBER_LOGIN         login of the member to author issues as
+#                               (default: the project's first member)
+
+project = Project.find_by!(identifier: ENV.fetch('VERIFY_PROJECT'))
+server_url = ENV.fetch('FAKE_BROKER_SERVER_URL', 'http://fakebroker:9999')
+browser_url = ENV.fetch('FAKE_BROKER_BROWSER_URL', 'http://localhost:9999')
+
+member =
+  if ENV['VERIFY_MEMBER_LOGIN'].present?
+    project.members.joins(:user).find_by!(users: { login: ENV['VERIFY_MEMBER_LOGIN'] })
+  else
+    project.members.joins(:user).first or raise 'project has no members'
+  end
+tracker = project.trackers.first or raise 'project has no trackers'
+
+connections = {
+  'stored' => { name: 'Verification broker (stored)', url: server_url,
+                auth_token: 'stored-secret-789' },
+  # 'proxied' is the internal name for the UI's "relayed" mode.
+  'proxied' => { name: 'Verification broker (relayed)', url: server_url },
+  # A custom token header on the browser connection also exercises the
+  # connection-configurable token header (#99) in the browser-mode JS.
+  'browser' => { name: 'Verification broker (browser)', url: browser_url,
+                 token_header: 'X-Api-Key' }
+}
+
+connections.each do |auth_mode, attrs|
+  connection = BrokerConnection.find_or_initialize_by(name: attrs[:name])
+  connection.assign_attributes(
+    standard: 'NGSIv2',
+    auth_mode: auth_mode,
+    url: attrs[:url],
+    token_header: attrs[:token_header],
+    auth_token: attrs[:auth_token]
+  )
+  connection.save!
+
+  template = SubscriptionTemplate.find_or_initialize_by(
+    name: "Verification: #{auth_mode} mode", project_id: project.id
+  )
+  template.assign_attributes(
+    broker_connection: connection,
+    status: 'active',
+    tracker_id: tracker.id,
+    member_id: member.id,
+    issue_status_id: IssueStatus.sorted.first.id,
+    issue_priority_id: IssuePriority.default&.id || IssuePriority.first.id,
+    subject: '${type} ${id} (verification)',
+    description: 'Auth mode drill against the fake broker; safe to delete.',
+    entities_string: '[{"type": "VerificationEntity", "idPattern": ".*"}]',
+    geometry_string: 'null'
+  )
+  template.save!
+  puts "#{template.name}: template ##{template.id} -> #{connection.name} (#{connection.url})"
+end
+
+puts "Done. Drill: open the project's FIWARE settings tab, type a token into"
+puts 'the token box, publish/unpublish each template, and compare the broker'
+puts 'log against the expected-results table in doc/release_verification.md.'


### PR DESCRIPTION
The live checks that verified v3.0 — the auth mode drill, the Orion v2 round trip with the `q` filter three-phase test, and the NGSI-LD round trip (#16) — were ad-hoc: scripts in a session scratchpad, one-off runner commands. This makes them repeatable by anyone, any time:

## What's included

- **`doc/scripts/fake_broker.py`** — dependency-free header-echo broker: logs every request as a JSON line to stdout (`podman logs fakebroker`), answers subscription POSTs with `201` + `Location`, and speaks CORS including the exposed `Location` header that browser-mode JS reads. This is what makes the *relayed* and *browser* auth modes testable without a real authenticated broker.
- **`doc/scripts/seed_verification.rb`** — idempotent seeder (rails runner): one connection + template per auth mode, pointed at the fake broker; the browser connection carries `token_header: X-Api-Key` so the drill also covers #99's custom-header JS.
- **`doc/release_verification.md`** — the layered checklist:
  - Layer 0: the CI matrix (what it covers, and explicitly what it cannot — client-side JS, real brokers)
  - Layer 1: auth mode drill with an **expected-results table** (the user-agent/Origin at the broker tells you which side made each call)
  - Layer 2: real NGSIv2 round trip (local Orion) incl. the three-phase `q` filter test and sync/unpublish
  - Layer 3: NGSI-LD round trip with the gotchas from the first run (`receiverInfo` must arrive as headers, tunnel + host authorization, notification attribute shapes, the upstream `q`/`geoQ` gap)
  - linked from `doc/index.md`

## Verified

- Seeder runs and is idempotent (same records on rerun)
- A stored-mode publish through the real UI against the checked-in fake broker reproduces the expected log line (`Authorization: Bearer stored-secret-789`, Ruby user-agent)
- The full drill this codifies ran on 2026-07-29 and found a real bug (#107)

Future automation (Capybara system tests for layer 1) stays tracked in #106.