### PR TITLE
Bump plugin version to 3.0.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '2.1.0'
+  version '3.0.0'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Version bump for the v3.0.0 release (roadmap #71 phases 1+2; live verification recorded on #16). Tag and release notes follow once merged.