### PR TITLE
Build broker callback URLs from Setting.host_name (#101)

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -181,7 +181,7 @@ class SubscriptionTemplatesController < ApplicationController
     end
 
     template = SubscriptionTemplate.new(broker_connection: connection)
-    request_builder = RedmineGttFiware::SubscriptionRequest.build(template, base_url: request.base_url)
+    request_builder = RedmineGttFiware::SubscriptionRequest.build(template, base_url: callback_base_url)
     uri = URI(request_builder.entities_url)
     uri.query = URI.encode_www_form(type: entity_type, limit: 1)
 
@@ -353,9 +353,20 @@ class SubscriptionTemplatesController < ApplicationController
   def subscription_request
     RedmineGttFiware::SubscriptionRequest.build(
       @subscription_template,
-      base_url: request.base_url,
+      base_url: callback_base_url,
       throttling: @subscription_template.effective_throttling
     )
+  end
+
+  # Base URL the broker calls back on (#101). The publishing admin's request
+  # host is frequently not broker-reachable (localhost in development, an
+  # internal name behind a reverse proxy), so the configured canonical host
+  # wins: Setting.protocol + Setting.host_name, exactly what core uses for
+  # links in notification emails (host_name may carry a sub-URI path).
+  # An unconfigured host_name keeps the previous request-based behaviour.
+  def callback_base_url
+    host = Setting.host_name.to_s.strip
+    host.present? ? "#{Setting.protocol}://#{host}" : request.base_url
   end
 
   def new_path

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -96,12 +96,15 @@ module RedmineGttFiware
       URI(@template.broker_url)
     end
 
+    # Plain appends, not URI.join with an absolute path: joining "/fiware/..."
+    # discards any path in the base, which breaks sub-URI deployments
+    # (Setting.host_name may legitimately be "example.com/redmine", #101).
     def callback_url
-      URI.join(@base_url, "/fiware/subscription_template/#{@template.id}/notification").to_s
+      "#{@base_url.to_s.chomp('/')}/fiware/subscription_template/#{@template.id}/notification"
     end
 
     def registration_url
-      URI.join(@base_url, "/fiware/subscription_template/#{@template.id}/registration/").to_s
+      "#{@base_url.to_s.chomp('/')}/fiware/subscription_template/#{@template.id}/registration/"
     end
   end
 end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -324,6 +324,30 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal I18n.t(:subscription_unauthorized_error), flash[:error]
   end
 
+  # The broker calls back on the configured canonical host (#101): the
+  # publishing admin's request host (localhost, an internal proxy name) is
+  # frequently not broker-reachable, so Setting.host_name + Setting.protocol
+  # win, exactly like core's notification email links.
+  def test_publish_builds_callback_urls_from_the_configured_host_name
+    with_settings host_name: 'redmine.public.example', protocol: 'https' do
+      post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+      assert_response :success
+      assert_includes response.body,
+                      "https://redmine.public.example/fiware/subscription_template/#{@template.id}/notification"
+      assert_not_includes response.body, 'test.host'
+    end
+  end
+
+  # An unconfigured host name keeps the previous request-based behaviour.
+  def test_publish_falls_back_to_the_request_host_without_a_host_name
+    with_settings host_name: '' do
+      post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+      assert_response :success
+      assert_includes response.body,
+                      "http://test.host/fiware/subscription_template/#{@template.id}/notification"
+    end
+  end
+
   # Browser-mode publish/unpublish report the broker-assigned id back through
   # this action; an empty value (unpublish) must store nil, not '', so a
   # cleared subscription looks the same regardless of which mode cleared it.

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -96,6 +96,25 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_equal 'active', p['status']
   end
 
+  # Setting.host_name may carry a sub-URI path ("example.com/redmine"); the
+  # callback URLs must keep it instead of joining it away (#101).
+  def test_callback_urls_preserve_a_sub_uri_base
+    builder = RedmineGttFiware::SubscriptionRequest.build(
+      template('NGSIv2'), base_url: 'https://example.com/redmine', throttling: 3
+    )
+    http_custom = JSON.parse(builder.to_json).dig('notification', 'httpCustom')
+    assert_equal 'https://example.com/redmine/fiware/subscription_template/123/notification',
+                 http_custom['url']
+
+    # A trailing slash on the base must not produce a double slash.
+    builder = RedmineGttFiware::SubscriptionRequest.build(
+      template('NGSIv2'), base_url: 'https://example.com/redmine/', throttling: 3
+    )
+    http_custom = JSON.parse(builder.to_json).dig('notification', 'httpCustom')
+    assert_equal 'https://example.com/redmine/fiware/subscription_template/123/notification',
+                 http_custom['url']
+  end
+
   def test_ngsi_v2_notification_carries_only_callback_and_headers_no_templating
     http_custom = payload('NGSIv2').dig('notification', 'httpCustom')
     assert_equal 'https://redmine.example.com/fiware/subscription_template/123/notification', http_custom['url']


### PR DESCRIPTION
Closes #101.

Callback URLs (notification endpoint, registration URL) were built from `request.base_url` at publish time — the host the *admin's browser* used, which is frequently not a host the *broker* can reach (localhost in development, internal names behind reverse proxies; both variants bit us during the #16 verification).

## Change

- `callback_base_url` in the controller: `Setting.protocol` + `Setting.host_name` when configured — exactly what core uses for links in notification emails — with fallback to `request.base_url` when `host_name` is blank (preserves behaviour for unconfigured instances). Both builder call sites (publish/copy/sync via `prepare_payload`, live preview) go through it.
- **Latent sub-URI bug fixed in the builder**: `URI.join(base, "/fiware/...")` discards any path in the base, so a `host_name` like `example.com/redmine` (the setting legitimately carries a sub-URI path) would have lost its prefix. The callback/registration URLs are now plain appends and preserve the sub-URI, with trailing-slash normalization.

## Testing

- Functional: configured host name wins over the request host (payload carries `https://redmine.public.example/...`, `test.host` absent); blank host name falls back to the request host
- Unit: sub-URI base preserved in the callback URL, with and without trailing slash
- Full suite: **173 runs, 635 assertions, 0 failures**