### PR TITLE
Self-published instance context (#69, step 2a)

### DIFF
--- a/app/controllers/fiware_contexts_controller.rb
+++ b/app/controllers/fiware_contexts_controller.rb
@@ -1,0 +1,32 @@
+# Serves the instance's self-published JSON-LD context (#69, step 2) at
+# GET /fiware/context.jsonld.
+#
+# Deliberately public: brokers dereference @context at ingestion and schema
+# consumers must be able to read it without credentials, exactly like any
+# published JSON-LD context on the web. It discloses only what the admin
+# configured for publication (subtype names; exposed attribute terms later),
+# never issue data.
+class FiwareContextsController < ApplicationController
+  # See SubscriptionIssuesController: the explicit declaration keeps the
+  # framework-default forgery protection visible to static analysis.
+  protect_from_forgery with: :exception
+
+  skip_before_action :check_if_login_required, only: [:show]
+
+  def show
+    context = RedmineGttFiware::InstanceContext.new(base_url)
+    # Contexts are fetched by brokers on every ingestion; let them cache.
+    expires_in 5.minutes, public: true
+    render json: context.to_h, content_type: 'application/ld+json'
+  end
+
+  private
+
+  # The configured public host wins (same semantics as the callback URLs,
+  # #101); the request host is the fallback so the document stays coherent
+  # when dereferenced locally on an unconfigured instance.
+  def base_url
+    host = Setting.host_name.to_s.strip
+    host.present? ? "#{Setting.protocol}://#{host}" : request.base_url
+  end
+end

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -10,11 +10,20 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   # CamelCase by convention (WorkOrder, RoadDamageReport), not enforced.
   SUBTYPE_PATTERN = /\A[A-Za-z][A-Za-z0-9]*\z/
 
+  # Terms a subtype must not shadow in the published context (#69, step 2):
+  # the core vocabulary, the context's prefixes, and the NGSI-LD/core-context
+  # terms every entity relies on. Compared case-insensitively.
+  RESERVED_SUBTYPES = (
+    RedmineGttFiware::InstanceContext::CORE_TERMS +
+    %w[rdfs gttfiware inst id type location dateCreated dateModified dateObserved]
+  ).map(&:downcase).freeze
+
   belongs_to :broker_connection
   belongs_to :tracker
 
   validates :subtype, presence: true,
                       format: { with: SUBTYPE_PATTERN, message: I18n.t('model.emission_mapping.invalid_subtype') }
+  validate :subtype_must_not_shadow_reserved_terms
   validates :tracker_id, uniqueness: { scope: :broker_connection_id }
   # Emission is NGSI-LD only in v1 (the entity payload is JSON-LD).
   validate :connection_must_be_ngsi_ld
@@ -33,5 +42,11 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
     return if broker_connection.nil? || broker_connection.ngsi_ld?
 
     errors.add :broker_connection, I18n.t('model.emission_mapping.connection_not_ngsi_ld')
+  end
+
+  def subtype_must_not_shadow_reserved_terms
+    return unless RESERVED_SUBTYPES.include?(subtype.to_s.downcase)
+
+    errors.add :subtype, I18n.t('model.emission_mapping.reserved_subtype')
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -61,6 +61,7 @@ de:
       invalid_token_header: 'muss ein gültiger HTTP-Header-Name sein'
     emission_mapping:
       invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
+      reserved_subtype: 'ist ein reservierter Vokabular-Term und kann nicht als Subtyp verwendet werden'
       connection_not_ngsi_ld: 'Ticket-Übertragung erfordert eine NGSI-LD-Verbindung'
   field_subscription_template_fiware_servicepath: 'FIWARE Service Path'
   gtt_fiware_settings_broker: 'FIWARE-Einstellungen'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,4 +227,5 @@ en:
       invalid_token_header: "must be a valid HTTP header name"
     emission_mapping:
       invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
+      reserved_subtype: "is a reserved vocabulary term and cannot be used as a subtype"
       connection_not_ngsi_ld: "issue emission requires an NGSI-LD connection"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -223,4 +223,5 @@ ja:
       invalid_token_header: "は有効なHTTPヘッダー名である必要があります"
     emission_mapping:
       invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
+      reserved_subtype: "は予約済みの語彙タームのためサブタイプとして使用できません"
       connection_not_ngsi_ld: "チケット送信にはNGSI-LD接続が必要です"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ end
 # Instance-level broker connections, managed by admins (#67).
 resources :broker_connections, except: [:show]
 
+# The instance's self-published JSON-LD context (#69, step 2): core terms
+# plus the configured emission subtypes. Public - brokers dereference it at
+# ingestion and consumers read the schema from it.
+get 'fiware/context.jsonld', to: 'fiware_contexts#show', format: false
+
 # Define a route for FIWARE broker subscription templates
 scope 'projects/:project_id' do
   resources :subscription_templates, only: %i(new create edit update destroy),

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -41,7 +41,10 @@ module RedmineGttFiware
       CORE_TERMS.each { |term| terms[term] = "gttfiware:#{term}" }
       # refersTo points at another entity, so it expands as an IRI, not a string.
       terms['refersTo'] = { '@id' => 'gttfiware:refersTo', '@type' => '@id' }
-      subtypes.each_key { |subtype| terms[subtype] = "inst:#{subtype}" }
+      # Validation rejects reserved subtype names (EmissionMapping); the skip
+      # is defense in depth for pre-validation rows, so a stray subtype can
+      # never shadow a core term or prefix in the published document.
+      subtypes.each_key { |subtype| terms[subtype] = "inst:#{subtype}" unless terms.key?(subtype) }
       terms
     end
 
@@ -54,7 +57,7 @@ module RedmineGttFiware
           '@id' => "inst:#{subtype}",
           '@type' => 'rdfs:Class',
           'rdfs:subClassOf' => { '@id' => 'gttfiware:Issue' },
-          'rdfs:label' => "#{subtype} (tracker: #{tracker_names.sort.join(', ')})"
+          'rdfs:label' => "#{subtype} (tracker: #{tracker_names.uniq.sort.join(', ')})"
         }
       end
     end

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -1,0 +1,68 @@
+module RedmineGttFiware
+  # Generates the instance's self-published JSON-LD context (#69, step 2):
+  # the core Issue vocabulary terms plus one class per configured emission
+  # subtype, each declared rdfs:subClassOf the core Issue. Consumers who
+  # dereference one URL learn the instance's full schema; the @graph is
+  # ignored by @context processing and speaks to RDF tooling.
+  class InstanceContext
+    # The published core vocabulary namespace. The core terms are frozen (see
+    # IssueEntity): renaming any of them is a breaking change for every
+    # consumer of every instance.
+    CORE_NAMESPACE = 'https://gtt-project.org/ns/fiware#'.freeze
+    CORE_TERMS = %w[Issue title status statusLabel subtype source refersTo].freeze
+    RDFS = 'http://www.w3.org/2000/01/rdf-schema#'.freeze
+
+    # base_url: the instance's public base (Setting.host_name-derived, with
+    # the request base as fallback for the serving controller only).
+    def initialize(base_url)
+      @base_url = base_url.to_s.chomp('/')
+    end
+
+    def to_h
+      {
+        '@context' => context_terms,
+        '@graph' => subtype_classes
+      }
+    end
+
+    # Where instance-defined terms (subtypes, later attributes) live.
+    def vocab_namespace
+      "#{@base_url}/fiware/vocab#"
+    end
+
+    private
+
+    def context_terms
+      terms = {
+        'rdfs' => RDFS,
+        'gttfiware' => CORE_NAMESPACE,
+        'inst' => vocab_namespace
+      }
+      CORE_TERMS.each { |term| terms[term] = "gttfiware:#{term}" }
+      # refersTo points at another entity, so it expands as an IRI, not a string.
+      terms['refersTo'] = { '@id' => 'gttfiware:refersTo', '@type' => '@id' }
+      subtypes.each_key { |subtype| terms[subtype] = "inst:#{subtype}" }
+      terms
+    end
+
+    # One class declaration per distinct configured subtype, anchored to the
+    # core Issue. The label names the mapped trackers so a human reading the
+    # schema can see what feeds each subtype.
+    def subtype_classes
+      subtypes.map do |subtype, tracker_names|
+        {
+          '@id' => "inst:#{subtype}",
+          '@type' => 'rdfs:Class',
+          'rdfs:subClassOf' => { '@id' => 'gttfiware:Issue' },
+          'rdfs:label' => "#{subtype} (tracker: #{tracker_names.sort.join(', ')})"
+        }
+      end
+    end
+
+    def subtypes
+      @subtypes ||= EmissionMapping.includes(:tracker).each_with_object({}) do |mapping, result|
+        (result[mapping.subtype] ||= []) << mapping.tracker.name
+      end
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -28,12 +28,12 @@ module RedmineGttFiware
         'statusLabel' => property(@issue.status.name),
         'subtype' => property(@mapping.subtype),
         'dateCreated' => datetime_property(@issue.created_on),
-        'dateModified' => datetime_property(@issue.updated_on),
-        '@context' => CORE_CONTEXT
+        'dateModified' => datetime_property(@issue.updated_on)
       }
       entity['source'] = property(source_url) if source_url
       entity['location'] = geo_property if geometry?
       entity['refersTo'] = relationship(@issue.fiware_entity) if refers_to?
+      entity['@context'] = entity_context
       entity
     end
 
@@ -94,6 +94,18 @@ module RedmineGttFiware
       return nil if host.blank?
 
       "#{Setting.protocol}://#{host}/issues/#{@issue.id}"
+    end
+
+    # Brokers dereference @context at ingestion, so the instance's published
+    # context (#69, step 2) is referenced only when the instance has a public
+    # identity (Setting.host_name) a broker can actually reach; an
+    # unconfigured instance emits with the core context alone and its terms
+    # expand into the default vocabulary.
+    def entity_context
+      host = Setting.host_name.to_s.strip
+      return CORE_CONTEXT if host.blank?
+
+      ["#{Setting.protocol}://#{host}/fiware/context.jsonld", CORE_CONTEXT]
     end
   end
 end

--- a/test/functional/fiware_contexts_controller_test.rb
+++ b/test/functional/fiware_contexts_controller_test.rb
@@ -49,6 +49,32 @@ class FiwareContextsControllerTest < ActionController::TestCase
     assert_includes work_order['rdfs:label'], Tracker.find(2).name
   end
 
+  # Defense in depth for pre-validation rows: a stray reserved subtype must
+  # never shadow a core term or prefix in the published document.
+  def test_reserved_subtype_rows_cannot_shadow_core_terms
+    legacy = EmissionMapping.new(broker_connection: @connection, tracker: Tracker.find(1), subtype: 'Issue')
+    legacy.save!(validate: false)
+
+    get :show
+    body = JSON.parse(response.body)
+    assert_equal 'gttfiware:Issue', body['@context']['Issue'], 'the core term must win'
+  end
+
+  # The same tracker mapped to the same subtype on several connections must
+  # not repeat in the class label.
+  def test_subtype_labels_dedupe_tracker_names
+    other = BrokerConnection.create!(
+      name: 'Second broker', standard: 'NGSI-LD',
+      url: 'https://other.example.com', auth_mode: 'stored'
+    )
+    EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(1), subtype: 'WorkOrder')
+    EmissionMapping.create!(broker_connection: other, tracker: Tracker.find(1), subtype: 'WorkOrder')
+
+    get :show
+    label = JSON.parse(response.body)['@graph'].first['rdfs:label']
+    assert_equal 1, label.scan(Tracker.find(1).name).size
+  end
+
   # The configured public host defines the instance namespace (#101
   # semantics); the request host is only the local fallback.
   def test_instance_namespace_follows_the_configured_host

--- a/test/functional/fiware_contexts_controller_test.rb
+++ b/test/functional/fiware_contexts_controller_test.rb
@@ -1,0 +1,67 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class FiwareContextsControllerTest < ActionController::TestCase
+  fixtures :projects, :trackers
+
+  def setup
+    @connection = BrokerConnection.create!(
+      name: 'Context broker', standard: 'NGSI-LD',
+      url: 'https://broker.example.com', auth_mode: 'stored'
+    )
+  end
+
+  # Brokers dereference @context at ingestion; the document must be readable
+  # without any session or credential.
+  def test_context_is_public
+    @request.session[:user_id] = nil
+    with_settings login_required: '1' do
+      get :show
+      assert_response :success
+      assert_equal 'application/ld+json', response.media_type
+    end
+  end
+
+  def test_context_carries_the_core_terms
+    get :show
+    context = JSON.parse(response.body)['@context']
+    RedmineGttFiware::InstanceContext::CORE_TERMS.each do |term|
+      assert context.key?(term), "core term #{term} must be defined"
+    end
+    # refersTo expands as an IRI, not a string.
+    assert_equal '@id', context.dig('refersTo', '@type')
+  end
+
+  def test_subtypes_are_declared_subclasses_of_issue
+    EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(1), subtype: 'WorkOrder')
+    EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(2), subtype: 'WorkOrder')
+    EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(3), subtype: 'Incident')
+
+    get :show
+    body = JSON.parse(response.body)
+    assert_equal 'inst:WorkOrder', body['@context']['WorkOrder']
+
+    classes = body['@graph'].index_by { |node| node['@id'] }
+    assert_equal 2, classes.size, 'one class per distinct subtype'
+    work_order = classes['inst:WorkOrder']
+    assert_equal 'gttfiware:Issue', work_order.dig('rdfs:subClassOf', '@id')
+    # The label names every mapped tracker.
+    assert_includes work_order['rdfs:label'], Tracker.find(1).name
+    assert_includes work_order['rdfs:label'], Tracker.find(2).name
+  end
+
+  # The configured public host defines the instance namespace (#101
+  # semantics); the request host is only the local fallback.
+  def test_instance_namespace_follows_the_configured_host
+    with_settings host_name: 'redmine.public.example', protocol: 'https' do
+      get :show
+      body = JSON.parse(response.body)
+      assert_equal 'https://redmine.public.example/fiware/vocab#', body['@context']['inst']
+    end
+
+    with_settings host_name: '' do
+      get :show
+      body = JSON.parse(response.body)
+      assert_equal 'http://test.host/fiware/vocab#', body['@context']['inst']
+    end
+  end
+end

--- a/test/unit/emission_mapping_test.rb
+++ b/test/unit/emission_mapping_test.rb
@@ -43,6 +43,16 @@ class EmissionMappingTest < ActiveSupport::TestCase
     assert mapping.errors[:broker_connection].present?
   end
 
+  # A subtype must not shadow core vocabulary terms or context prefixes in
+  # the published document (#69 step 2), whatever the casing.
+  def test_subtype_must_not_shadow_reserved_terms
+    %w[Issue issue rdfs gttfiware inst location dateCreated type].each do |reserved|
+      mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: reserved)
+      assert_not mapping.valid?, "#{reserved.inspect} must be rejected"
+      assert mapping.errors[:subtype].present?
+    end
+  end
+
   # Tracker names are free text, often non-ASCII; the suggestion must always
   # be a usable term.
   def test_suggested_subtype

--- a/test/unit/issue_entity_test.rb
+++ b/test/unit/issue_entity_test.rb
@@ -32,7 +32,19 @@ class IssueEntityTest < ActiveSupport::TestCase
     assert_equal 'WorkOrder', e.dig('subtype', 'value')
     assert_equal "https://redmine.example.com/issues/#{@issue.id}", e.dig('source', 'value')
     assert_equal 'DateTime', e.dig('dateCreated', 'value', '@type')
-    assert_equal RedmineGttFiware::IssueEntity::CORE_CONTEXT, e['@context']
+    # With a public host the entity references the instance's published
+    # context ahead of the core one, so subtype terms expand properly.
+    assert_equal ['https://redmine.example.com/fiware/context.jsonld',
+                  RedmineGttFiware::IssueEntity::CORE_CONTEXT], e['@context']
+  end
+
+  # Brokers dereference @context at ingestion: an instance without a public
+  # identity must not point them at an unreachable URL.
+  def test_context_is_core_only_without_a_configured_host
+    with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' }, host_name: '' do
+      e = RedmineGttFiware::IssueEntity.new(@issue, @mapping).to_h
+      assert_equal RedmineGttFiware::IssueEntity::CORE_CONTEXT, e['@context']
+    end
   end
 
   def test_status_normalizes_to_closed_for_closed_statuses


### PR DESCRIPTION
Refs #69 — first slice of design step 2 (the self-published instance schema). Follow-ups: standard-field exposure (2b), custom fields (2c).

## What's in

- **`GET /fiware/context.jsonld`** — the instance's generated JSON-LD context:
  - the frozen **core vocabulary terms** under `https://gtt-project.org/ns/fiware#` (`Issue`, `title`, `status`, `statusLabel`, `subtype`, `source`, `refersTo` — the latter typed `@id` so it expands as an IRI)
  - one **class per distinct configured subtype** in the `@graph`, declared `rdfs:subClassOf` the core `Issue`, labeled with the mapped trackers — `@context` processors ignore the graph; RDF tooling gets the subclass axioms
  - the **instance namespace** `<base>/fiware/vocab#`, where steps 2b/2c's exposed attribute terms will live
- **Deliberately public** (no login), like any published JSON-LD context: brokers dereference `@context` at ingestion, consumers read the schema from it. It discloses only what the admin configured for publication (subtype names), never issue data. 5-minute public cache.
- **Emitted entities now reference the instance context** ahead of the core one — but **only when `Setting.host_name` is configured** (#101 semantics): brokers fetch `@context` at ingestion, so an instance without a public identity must not hand them an unreachable URL; it emits with the core context alone.
- The instance namespace follows the configured host with request-host fallback for local dereferencing.

## Live check

```json
{
  "@context": { "...": "...", "RoadDamageReport": "inst:RoadDamageReport" },
  "@graph": [{
    "@id": "inst:RoadDamageReport",
    "@type": "rdfs:Class",
    "rdfs:subClassOf": { "@id": "gttfiware:Issue" },
    "rdfs:label": "RoadDamageReport (tracker: Task)"
  }]
}
```

served as `application/ld+json` from the dev instance with its configured mapping.

## Testing

- Controller: public even with login required, media type, core terms incl. the `@id`-typed `refersTo`, subtype dedup + subclass declarations + tracker labels, namespace follows the configured host
- Entity: instance context referenced with a public host, core-only without
- Full suite: **206 runs, 744 assertions, 0 failures**

## Note

`https://gtt-project.org/ns/fiware#` does not resolve yet — publishing the core vocabulary document on the website is a small follow-up task (tracked when 2b freezes the attribute terms).