### PR TITLE
Admin-exposable standard fields (#69, step 2b)

### DIFF
--- a/app/controllers/broker_connections_controller.rb
+++ b/app/controllers/broker_connections_controller.rb
@@ -78,6 +78,8 @@ class BrokerConnectionsController < ApplicationController
       mapping = @broker_connection.emission_mappings.find_or_initialize_by(tracker_id: tracker_id)
       if attrs[:enabled] == '1'
         mapping.subtype = attrs[:subtype].to_s.strip
+        # The setter intersects with the catalog, so unknown keys are dropped.
+        mapping.exposed_standard_fields = Array(attrs[:fields]).map(&:to_s)
         failed << mapping unless mapping.save
       elsif mapping.persisted?
         mapping.destroy

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -38,7 +38,26 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
     %w[rdfs gttfiware inst id type location dateCreated dateModified dateObserved]
   ).map(&:downcase).freeze
 
-  serialize :exposed_attributes, coder: JSON
+  # Tolerant JSON coder: a hand-edited or corrupted column value degrades to
+  # "nothing exposed" instead of raising - the public context endpoint and
+  # every issue save iterate mappings, so a broken row must never take them
+  # down.
+  class ExposedAttributesCoder
+    def self.dump(value)
+      JSON.dump(value || {})
+    end
+
+    def self.load(value)
+      return {} if value.blank?
+
+      parsed = JSON.parse(value)
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue JSON::ParserError
+      {}
+    end
+  end
+
+  serialize :exposed_attributes, coder: ExposedAttributesCoder
 
   belongs_to :broker_connection
   belongs_to :tracker

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -10,13 +10,35 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   # CamelCase by convention (WorkOrder, RoadDamageReport), not enforced.
   SUBTYPE_PATTERN = /\A[A-Za-z][A-Za-z0-9]*\z/
 
+  # The standard issue fields an admin may expose per mapping (#69, step 2b),
+  # keyed by their published vocabulary term. Values name the Redmine field
+  # label so the UI needs no locale keys of its own. assignee is listed last
+  # and defaults off like everything else - publishing person names to a
+  # shared broker is an explicit admin decision.
+  STANDARD_FIELDS = {
+    'description' => :field_description,
+    'priority' => :field_priority,
+    'category' => :field_category,
+    'targetVersion' => :field_fixed_version,
+    'startDate' => :field_start_date,
+    'dueDate' => :field_due_date,
+    'estimatedTime' => :field_estimated_hours,
+    'percentDone' => :field_done_ratio,
+    'parent' => :field_parent_issue,
+    'assignee' => :field_assigned_to
+  }.freeze
+
   # Terms a subtype must not shadow in the published context (#69, step 2):
-  # the core vocabulary, the context's prefixes, and the NGSI-LD/core-context
-  # terms every entity relies on. Compared case-insensitively.
+  # the core vocabulary, the exposable standard terms, the context's prefixes,
+  # and the NGSI-LD/core-context terms every entity relies on. Compared
+  # case-insensitively.
   RESERVED_SUBTYPES = (
     RedmineGttFiware::InstanceContext::CORE_TERMS +
+    STANDARD_FIELDS.keys +
     %w[rdfs gttfiware inst id type location dateCreated dateModified dateObserved]
   ).map(&:downcase).freeze
+
+  serialize :exposed_attributes, coder: JSON
 
   belongs_to :broker_connection
   belongs_to :tracker
@@ -27,6 +49,19 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   validates :tracker_id, uniqueness: { scope: :broker_connection_id }
   # Emission is NGSI-LD only in v1 (the entity payload is JSON-LD).
   validate :connection_must_be_ngsi_ld
+
+  # The exposed standard fields, always a cleaned subset of the catalog -
+  # unknown keys (a stale UI, a hand-edited row) are dropped on read and
+  # write, so IssueEntity can trust every entry.
+  def exposed_standard_fields
+    Array((exposed_attributes || {})['standard']) & STANDARD_FIELDS.keys
+  end
+
+  def exposed_standard_fields=(fields)
+    self.exposed_attributes = (exposed_attributes || {}).merge(
+      'standard' => Array(fields).map(&:to_s) & STANDARD_FIELDS.keys
+    )
+  end
 
   # Default subtype suggestion for a tracker: its name as a JSON-LD term when
   # that yields something usable, the generic suggestion otherwise (tracker

--- a/app/views/broker_connections/_form.html.erb
+++ b/app/views/broker_connections/_form.html.erb
@@ -52,6 +52,20 @@
                            mapping&.subtype || EmissionMapping.suggested_subtype(tracker),
                            size: 30, id: "emission_mapping_subtype_#{tracker.id}" %>
         <em class="info"><%= l(:field_emission_subtype_hint) %></em>
+        <%# Admin-exposable standard fields (#69, step 2b). Everything beyond
+            the frozen core defaults to unexposed; assignee doubly so - it
+            publishes a person's name to a shared broker. %>
+        <span class="gtt-fiware-exposure" style="display: block; margin-top: 2px; font-size: 0.92em;">
+          <%= l(:label_emission_exposed_fields) %>:
+          <% EmissionMapping::STANDARD_FIELDS.each do |term, field_label| %>
+            <label style="margin-right: 8px; font-weight: normal;">
+              <%= check_box_tag "emission_mappings[#{tracker.id}][fields][]", term,
+                                mapping&.exposed_standard_fields&.include?(term),
+                                id: "emission_mapping_field_#{tracker.id}_#{term}" %>
+              <%= l(field_label) %>
+            </label>
+          <% end %>
+        </span>
       </p>
     <% end %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -71,6 +71,7 @@ de:
   label_emission_mappings: 'Ticket-Übertragung'
   text_emission_mappings_info: 'Tickets der angehakten Tracker werden als NGSI-LD-Issue-Entitäten mit dem angegebenen Subtyp an diesen Broker übertragen, aus Projekten mit aktiviertem Modul Ticket-Übertragung. Erfordert die Instanz-Kennung in den Plugin-Einstellungen.'
   field_emission_subtype_hint: 'Subtyp (JSON-LD-Term, z. B. WorkOrder)'
+  label_emission_exposed_fields: 'Veröffentlichte Attribute'
   gtt_fiware_settings_emission: 'Ticket-Übertragung'
   field_fiware_instance_id: 'Instanz-Kennung'
   text_fiware_instance_id_info: 'Buchstaben, Ziffern, Bindestrich und Unterstrich. Teil jeder übertragenen Entitäts-ID (urn:ngsi-ld:Issue:redmine:<instanz>:<ticket>). Ohne Wert bleibt die Übertragung aus; eine spätere Änderung vergibt allen übertragenen Entitäten neue IDs.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   label_emission_mappings: "Issue Emission"
   text_emission_mappings_info: "Issues of the checked trackers are emitted to this broker as NGSI-LD Issue entities with the given subtype, from projects that enable the Issue Emission module. Requires the instance identifier in the plugin settings."
   field_emission_subtype_hint: "Subtype (a JSON-LD term, e.g. WorkOrder)"
+  label_emission_exposed_fields: "Published attributes"
   gtt_fiware_settings_emission: "Issue Emission"
   field_fiware_instance_id: "Instance identifier"
   text_fiware_instance_id_info: "Letters, digits, hyphen and underscore. Becomes part of every emitted entity id (urn:ngsi-ld:Issue:redmine:<instance>:<issue>). Emission stays off while blank; changing it later re-identifies every emitted entity."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -44,6 +44,7 @@ ja:
   label_emission_mappings: "チケット送信"
   text_emission_mappings_info: "チェックしたトラッカーのチケットは、指定したサブタイプ付きのNGSI-LD Issueエンティティとしてこのブローカーへ送信されます（チケット送信モジュールを有効にしたプロジェクトのみ）。プラグイン設定のインスタンス識別子が必要です。"
   field_emission_subtype_hint: "サブタイプ（JSON-LDターム、例：WorkOrder）"
+  label_emission_exposed_fields: "公開する属性"
   gtt_fiware_settings_emission: "チケット送信"
   field_fiware_instance_id: "インスタンス識別子"
   text_fiware_instance_id_info: "英数字、ハイフン、アンダースコアのみ。送信されるすべてのエンティティID（urn:ngsi-ld:Issue:redmine:<instance>:<issue>）に含まれます。空欄の間は送信されません。後から変更するとすべての送信済みエンティティのIDが変わります。"

--- a/db/migrate/20260730100000_add_exposed_attributes_to_emission_mappings.rb
+++ b/db/migrate/20260730100000_add_exposed_attributes_to_emission_mappings.rb
@@ -1,0 +1,9 @@
+# Admin-exposable attributes per emission mapping (#69, step 2b): which of
+# the issue's standard fields are published as entity properties. Stored as
+# JSON ({"standard": [...]}) so step 2c can add custom fields without another
+# migration. Default: nothing beyond the frozen core is exposed.
+class AddExposedAttributesToEmissionMappings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fiware_emission_mappings, :exposed_attributes, :text
+  end
+end

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -10,6 +10,11 @@ module RedmineGttFiware
     # consumer of every instance.
     CORE_NAMESPACE = 'https://gtt-project.org/ns/fiware#'.freeze
     CORE_TERMS = %w[Issue title status statusLabel subtype source refersTo].freeze
+    # The admin-exposable standard field terms (#69, step 2b). Published for
+    # every instance whether exposed or not: exposure gates what an instance
+    # emits, the vocabulary defines what the words mean.
+    STANDARD_TERMS = %w[description priority category targetVersion startDate
+                        dueDate estimatedTime percentDone parent assignee].freeze
     RDFS = 'http://www.w3.org/2000/01/rdf-schema#'.freeze
 
     # base_url: the instance's public base (Setting.host_name-derived, with
@@ -38,9 +43,11 @@ module RedmineGttFiware
         'gttfiware' => CORE_NAMESPACE,
         'inst' => vocab_namespace
       }
-      CORE_TERMS.each { |term| terms[term] = "gttfiware:#{term}" }
-      # refersTo points at another entity, so it expands as an IRI, not a string.
+      (CORE_TERMS + STANDARD_TERMS).each { |term| terms[term] = "gttfiware:#{term}" }
+      # Relationship terms point at other entities, so they expand as IRIs,
+      # not strings.
       terms['refersTo'] = { '@id' => 'gttfiware:refersTo', '@type' => '@id' }
+      terms['parent'] = { '@id' => 'gttfiware:parent', '@type' => '@id' }
       # Validation rejects reserved subtype names (EmissionMapping); the skip
       # is defense in depth for pre-validation rows, so a stray subtype can
       # never shadow a core term or prefix in the published document.

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -30,7 +30,10 @@ module RedmineGttFiware
       }
     end
 
-    # Where instance-defined terms (subtypes, later attributes) live.
+    # Where instance-defined terms live: the subtypes now, the custom-field
+    # terms of step 2c later. The standard field terms deliberately do NOT
+    # live here - they mean the same on every instance, so they belong to the
+    # shared namespace (see STANDARD_TERMS).
     def vocab_namespace
       "#{@base_url}/fiware/vocab#"
     end

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -33,14 +33,74 @@ module RedmineGttFiware
       entity['source'] = property(source_url) if source_url
       entity['location'] = geo_property if geometry?
       entity['refersTo'] = relationship(@issue.fiware_entity) if refers_to?
+      entity.merge!(exposed_properties)
       entity['@context'] = entity_context
       entity
     end
 
     private
 
+    # The admin-exposed standard fields (#69, step 2b): each renderer returns
+    # the NGSI-LD attribute or nil when the issue has no value, so absent
+    # data is absent from the entity instead of null-valued.
+    def exposed_properties
+      @mapping.exposed_standard_fields.each_with_object({}) do |field, result|
+        value = send("exposed_#{field.underscore}")
+        result[field] = value if value
+      end
+    end
+
+    def exposed_description
+      property(@issue.description) if @issue.description.present?
+    end
+
+    def exposed_priority
+      property(@issue.priority.name) if @issue.priority
+    end
+
+    def exposed_category
+      property(@issue.category.name) if @issue.category
+    end
+
+    def exposed_target_version
+      property(@issue.fixed_version.name) if @issue.fixed_version
+    end
+
+    def exposed_start_date
+      date_property(@issue.start_date) if @issue.start_date
+    end
+
+    def exposed_due_date
+      date_property(@issue.due_date) if @issue.due_date
+    end
+
+    def exposed_estimated_time
+      property(@issue.estimated_hours) if @issue.estimated_hours
+    end
+
+    def exposed_percent_done
+      property(@issue.done_ratio.to_i)
+    end
+
+    # A Relationship to the parent issue's URN - resolvable when the parent
+    # is emitted too, and still a truthful stable identifier when not.
+    def exposed_parent
+      relationship(self.class.urn(@issue.parent)) if @issue.parent
+    end
+
+    # Publishing person names to a shared broker is an explicit admin
+    # decision (the checkbox defaults off like everything else).
+    def exposed_assignee
+      property(@issue.assigned_to.name) if @issue.assigned_to
+    end
+
     def property(value)
       { 'type' => 'Property', 'value' => value }
+    end
+
+    def date_property(date)
+      { 'type' => 'Property',
+        'value' => { '@type' => 'Date', '@value' => date.iso8601 } }
     end
 
     def datetime_property(time)

--- a/test/functional/fiware_contexts_controller_test.rb
+++ b/test/functional/fiware_contexts_controller_test.rb
@@ -31,6 +31,18 @@ class FiwareContextsControllerTest < ActionController::TestCase
     assert_equal '@id', context.dig('refersTo', '@type')
   end
 
+  # The exposable standard terms are published for every instance: exposure
+  # gates what is emitted, the vocabulary defines what the words mean.
+  def test_context_carries_the_standard_terms
+    get :show
+    context = JSON.parse(response.body)['@context']
+    RedmineGttFiware::InstanceContext::STANDARD_TERMS.each do |term|
+      assert context.key?(term), "standard term #{term} must be defined"
+    end
+    # parent is a Relationship, so it expands as an IRI.
+    assert_equal '@id', context.dig('parent', '@type')
+  end
+
   def test_subtypes_are_declared_subclasses_of_issue
     EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(1), subtype: 'WorkOrder')
     EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(2), subtype: 'WorkOrder')

--- a/test/unit/emission_mapping_test.rb
+++ b/test/unit/emission_mapping_test.rb
@@ -53,6 +53,26 @@ class EmissionMappingTest < ActiveSupport::TestCase
     end
   end
 
+  # The exposure accessors trust nothing: unknown keys are dropped on read
+  # and write, so IssueEntity can dispatch on every entry.
+  def test_exposed_standard_fields_are_cleaned_against_the_catalog
+    mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
+    mapping.exposed_standard_fields = ['priority', 'no_such_field', 'assignee']
+    assert_equal %w[priority assignee], mapping.exposed_standard_fields
+
+    mapping.exposed_attributes = { 'standard' => ['dueDate', 'bogus'] }
+    assert_equal %w[dueDate], mapping.exposed_standard_fields
+
+    mapping.exposed_attributes = nil
+    assert_equal [], mapping.exposed_standard_fields
+  end
+
+  # The exposure catalog and the published vocabulary must not drift apart.
+  def test_standard_fields_match_the_published_terms
+    assert_equal RedmineGttFiware::InstanceContext::STANDARD_TERMS.sort,
+                 EmissionMapping::STANDARD_FIELDS.keys.sort
+  end
+
   # Tracker names are free text, often non-ASCII; the suggestion must always
   # be a usable term.
   def test_suggested_subtype

--- a/test/unit/emission_mapping_test.rb
+++ b/test/unit/emission_mapping_test.rb
@@ -67,6 +67,17 @@ class EmissionMappingTest < ActiveSupport::TestCase
     assert_equal [], mapping.exposed_standard_fields
   end
 
+  # A hand-edited or corrupted column value degrades to "nothing exposed"
+  # instead of raising - the public context endpoint iterates every mapping.
+  def test_corrupted_exposed_attributes_degrade_to_empty
+    mapping = EmissionMapping.create!(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
+    mapping.update_column(:exposed_attributes, 'not json {')
+    assert_equal [], mapping.reload.exposed_standard_fields
+
+    mapping.update_column(:exposed_attributes, '["an", "array"]')
+    assert_equal [], mapping.reload.exposed_standard_fields
+  end
+
   # The exposure catalog and the published vocabulary must not drift apart.
   def test_standard_fields_match_the_published_terms
     assert_equal RedmineGttFiware::InstanceContext::STANDARD_TERMS.sort,

--- a/test/unit/issue_entity_test.rb
+++ b/test/unit/issue_entity_test.rb
@@ -93,6 +93,62 @@ class IssueEntityTest < ActiveSupport::TestCase
     assert_nil entity['refersTo']
   end
 
+  # --- exposed standard fields (#69, step 2b) --------------------------------
+
+  # Nothing beyond the frozen core is emitted unless the admin exposed it.
+  def test_no_standard_fields_without_exposure
+    @issue.priority = IssuePriority.first
+    e = entity
+    assert_nil e['priority']
+    assert_nil e['description']
+    assert_nil e['assignee']
+  end
+
+  def test_exposed_fields_are_emitted
+    @mapping.exposed_standard_fields = %w[priority percentDone startDate assignee parent]
+    @mapping.save!
+    @issue.start_date = Date.new(2026, 7, 30)
+    @issue.assigned_to = User.active.first
+    @issue.done_ratio = 40
+
+    e = entity
+    assert_equal @issue.priority.name, e.dig('priority', 'value')
+    assert_equal 40, e.dig('percentDone', 'value')
+    assert_equal({ '@type' => 'Date', '@value' => '2026-07-30' }, e.dig('startDate', 'value'))
+    assert_equal User.active.first.name, e.dig('assignee', 'value')
+    # priority exposed but description not: exposure is per field.
+    assert_nil e['description']
+  end
+
+  # Absent data is absent from the entity, not null-valued (fixture issue 1
+  # carries a category, so it is cleared explicitly).
+  def test_exposed_fields_without_values_are_omitted
+    @mapping.exposed_standard_fields = %w[category targetVersion dueDate assignee]
+    @mapping.save!
+    @issue.category = nil
+    @issue.fixed_version = nil
+    @issue.due_date = nil
+    @issue.assigned_to = nil
+    e = entity
+    assert_nil e['category']
+    assert_nil e['targetVersion']
+    assert_nil e['dueDate']
+    assert_nil e['assignee']
+  end
+
+  def test_exposed_parent_is_a_relationship_to_the_parent_urn
+    @mapping.exposed_standard_fields = %w[parent]
+    @mapping.save!
+    # parent reads the persisted hierarchy; stubbing keeps the test free of
+    # nested-set writes (and of emission side effects on save).
+    parent = Issue.find(2)
+    @issue.stubs(:parent).returns(parent)
+
+    e = entity
+    assert_equal 'Relationship', e.dig('parent', 'type')
+    assert_equal "urn:ngsi-ld:Issue:redmine:test-town:#{parent.id}", e.dig('parent', 'object')
+  end
+
   def test_source_omitted_without_a_configured_host
     with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' }, host_name: '' do
       e = RedmineGttFiware::IssueEntity.new(@issue, @mapping).to_h


### PR DESCRIPTION
Refs #69 — second slice of design step 2, on top of #112. Remaining: custom fields (2c).

## What's in

- **Per-mapping "Published attributes" checkboxes** for the standard issue fields (the tracker field list from the design): `description`, `priority`, `category`, `targetVersion`, `startDate`, `dueDate`, `estimatedTime`, `percentDone`, `parent`, `assignee`. **Everything defaults to unexposed** — the frozen core stays the only unconditional surface; `assignee` carries the explicit-privacy-decision framing from the design.
- **Storage**: a JSON `exposed_attributes` column (`{"standard": [...]}`), extensible for 2c's custom fields without another migration. The accessors intersect with the catalog on read *and* write, so stale or hand-edited rows can never smuggle unknown keys into the dispatch.
- **Emission**: one renderer per exposed field; absent data is absent from the entity (never `null`-valued). `parent` emits as a **Relationship to the parent issue's URN** (resolvable when the parent is emitted too, still a truthful stable identifier when not); dates are typed `Date` values.
- **Vocabulary**: the standard terms are published in the instance context for every instance — exposure gates what an instance *emits*, the vocabulary defines what the words *mean*. `parent` is `@id`-typed. The reserved-subtype validation covers the new terms, and a test pins the exposure catalog and the published term list against drifting apart.
- The UI reuses core field labels (`field_priority`, …) — zero new per-field locale keys.

## Testing

- Entity: unexposed fields absent, exposed fields rendered (values, typed dates, parent URN relationship, assignee), absent-data omission (with the fixture's own category explicitly cleared)
- Mapping: catalog intersection on both accessors, nil handling, term-list drift pin
- Context: standard terms present, `parent` `@id`-typed
- Full suite: **216 runs, 791 assertions, 0 failures**