### PR TITLE
Admin-exposable custom fields (#69, step 2c)

### DIFF
--- a/app/controllers/broker_connections_controller.rb
+++ b/app/controllers/broker_connections_controller.rb
@@ -80,6 +80,11 @@ class BrokerConnectionsController < ApplicationController
         mapping.subtype = attrs[:subtype].to_s.strip
         # The setter intersects with the catalog, so unknown keys are dropped.
         mapping.exposed_standard_fields = Array(attrs[:fields]).map(&:to_s)
+        custom = {}
+        (attrs[:custom] || {}).each do |cf_id, cf_attrs|
+          custom[cf_id] = cf_attrs[:term].to_s.strip if cf_attrs[:enabled] == '1'
+        end
+        mapping.exposed_custom_fields = custom
         failed << mapping unless mapping.save
       elsif mapping.persisted?
         mapping.destroy

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -144,8 +144,14 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
     return unless raw.is_a?(Hash)
 
     terms = raw.values.map(&:to_s)
+    # One inst: IRI must not be published as both a class (subtype) and a
+    # property (custom term), so custom terms may not shadow any configured
+    # subtype - this mapping's or another's.
+    subtype_terms = ([subtype] + EmissionMapping.where.not(id: id).distinct.pluck(:subtype))
+                    .compact.map(&:downcase)
     terms.each do |term|
-      if !term.match?(SUBTYPE_PATTERN) || RESERVED_SUBTYPES.include?(term.downcase)
+      if !term.match?(SUBTYPE_PATTERN) || RESERVED_SUBTYPES.include?(term.downcase) ||
+         subtype_terms.include?(term.downcase)
         errors.add :base, I18n.t('model.emission_mapping.invalid_custom_term', term: term)
       end
     end

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -35,7 +35,7 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   RESERVED_SUBTYPES = (
     RedmineGttFiware::InstanceContext::CORE_TERMS +
     STANDARD_FIELDS.keys +
-    %w[rdfs gttfiware inst id type location dateCreated dateModified dateObserved]
+    %w[rdf rdfs gttfiware inst id type location dateCreated dateModified dateObserved]
   ).map(&:downcase).freeze
 
   # Tolerant JSON coder: a hand-edited or corrupted column value degrades to
@@ -65,6 +65,7 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   validates :subtype, presence: true,
                       format: { with: SUBTYPE_PATTERN, message: I18n.t('model.emission_mapping.invalid_subtype') }
   validate :subtype_must_not_shadow_reserved_terms
+  validate :custom_terms_must_be_valid
   validates :tracker_id, uniqueness: { scope: :broker_connection_id }
   # Emission is NGSI-LD only in v1 (the entity payload is JSON-LD).
   validate :connection_must_be_ngsi_ld
@@ -80,6 +81,38 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
     self.exposed_attributes = (exposed_attributes || {}).merge(
       'standard' => Array(fields).map(&:to_s) & STANDARD_FIELDS.keys
     )
+  end
+
+  # The exposed custom fields (#69, step 2c): {custom field id => term}.
+  # Terms are instance vocabulary (inst: namespace), lowerCamel by
+  # convention. Validation reports bad terms; the reader additionally drops
+  # anything invalid, so IssueEntity and the context can trust every entry.
+  def exposed_custom_fields
+    raw = (exposed_attributes || {})['custom']
+    return {} unless raw.is_a?(Hash)
+
+    raw.each_with_object({}) do |(cf_id, term), result|
+      term = term.to_s
+      next unless term.match?(SUBTYPE_PATTERN)
+      next if RESERVED_SUBTYPES.include?(term.downcase)
+
+      result[cf_id.to_i] = term
+    end
+  end
+
+  def exposed_custom_fields=(fields)
+    cleaned = {}
+    (fields || {}).each { |cf_id, term| cleaned[cf_id.to_s] = term.to_s }
+    self.exposed_attributes = (exposed_attributes || {}).merge('custom' => cleaned)
+  end
+
+  # Default term suggestion for a custom field: its name as a lowerCamel
+  # JSON-LD term when usable, an id-based fallback otherwise (custom field
+  # names are free text, often non-ASCII).
+  def self.suggested_custom_term(custom_field)
+    words = custom_field.name.to_s.gsub(/[^A-Za-z0-9]+/, ' ').split
+    term = ([words.first.to_s.downcase] + words.drop(1).map(&:capitalize)).join
+    term.match?(SUBTYPE_PATTERN) ? term : "customField#{custom_field.id}"
   end
 
   # Default subtype suggestion for a tracker: its name as a JSON-LD term when
@@ -102,5 +135,22 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
     return unless RESERVED_SUBTYPES.include?(subtype.to_s.downcase)
 
     errors.add :subtype, I18n.t('model.emission_mapping.reserved_subtype')
+  end
+
+  # An admin's typo in a custom term must surface as an error, not silently
+  # vanish through the reader's defensive filter.
+  def custom_terms_must_be_valid
+    raw = (exposed_attributes || {})['custom']
+    return unless raw.is_a?(Hash)
+
+    terms = raw.values.map(&:to_s)
+    terms.each do |term|
+      if !term.match?(SUBTYPE_PATTERN) || RESERVED_SUBTYPES.include?(term.downcase)
+        errors.add :base, I18n.t('model.emission_mapping.invalid_custom_term', term: term)
+      end
+    end
+    return if terms.uniq.length == terms.length
+
+    errors.add :base, I18n.t('model.emission_mapping.duplicate_custom_term')
   end
 end

--- a/app/views/broker_connections/_form.html.erb
+++ b/app/views/broker_connections/_form.html.erb
@@ -66,6 +66,24 @@
             </label>
           <% end %>
         </span>
+        <%# Custom-field exposure (#69, step 2c): each exposed field gets an
+            admin-named instance vocabulary term (lowerCamel by convention). %>
+        <% if tracker.custom_fields.any? %>
+          <span class="gtt-fiware-exposure" style="display: block; margin-top: 2px; font-size: 0.92em;">
+            <%= l(:label_emission_exposed_custom_fields) %>:
+            <% tracker.custom_fields.sorted.each do |custom_field| %>
+              <label style="margin-right: 4px; font-weight: normal;">
+                <%= check_box_tag "emission_mappings[#{tracker.id}][custom][#{custom_field.id}][enabled]", '1',
+                                  mapping&.exposed_custom_fields&.key?(custom_field.id),
+                                  id: "emission_mapping_custom_#{tracker.id}_#{custom_field.id}" %>
+                <%= custom_field.name %>
+              </label>
+              <%= text_field_tag "emission_mappings[#{tracker.id}][custom][#{custom_field.id}][term]",
+                                 mapping&.exposed_custom_fields&.[](custom_field.id) || EmissionMapping.suggested_custom_term(custom_field),
+                                 size: 18, id: "emission_mapping_custom_term_#{tracker.id}_#{custom_field.id}" %>
+            <% end %>
+          </span>
+        <% end %>
       </p>
     <% end %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -62,6 +62,8 @@ de:
     emission_mapping:
       invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
       reserved_subtype: 'ist ein reservierter Vokabular-Term und kann nicht als Subtyp verwendet werden'
+      invalid_custom_term: 'Term %{term} muss ein nicht reservierter JSON-LD-Term sein (Buchstaben und Ziffern, beginnend mit einem Buchstaben)'
+      duplicate_custom_term: 'Terme benutzerdefinierter Felder müssen innerhalb einer Zuordnung eindeutig sein'
       connection_not_ngsi_ld: 'Ticket-Übertragung erfordert eine NGSI-LD-Verbindung'
   field_subscription_template_fiware_servicepath: 'FIWARE Service Path'
   gtt_fiware_settings_broker: 'FIWARE-Einstellungen'
@@ -72,6 +74,7 @@ de:
   text_emission_mappings_info: 'Tickets der angehakten Tracker werden als NGSI-LD-Issue-Entitäten mit dem angegebenen Subtyp an diesen Broker übertragen, aus Projekten mit aktiviertem Modul Ticket-Übertragung. Erfordert die Instanz-Kennung in den Plugin-Einstellungen.'
   field_emission_subtype_hint: 'Subtyp (JSON-LD-Term, z. B. WorkOrder)'
   label_emission_exposed_fields: 'Veröffentlichte Attribute'
+  label_emission_exposed_custom_fields: 'Veröffentlichte benutzerdefinierte Felder'
   gtt_fiware_settings_emission: 'Ticket-Übertragung'
   field_fiware_instance_id: 'Instanz-Kennung'
   text_fiware_instance_id_info: 'Buchstaben, Ziffern, Bindestrich und Unterstrich. Teil jeder übertragenen Entitäts-ID (urn:ngsi-ld:Issue:redmine:<instanz>:<ticket>). Ohne Wert bleibt die Übertragung aus; eine spätere Änderung vergibt allen übertragenen Entitäten neue IDs.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
   text_emission_mappings_info: "Issues of the checked trackers are emitted to this broker as NGSI-LD Issue entities with the given subtype, from projects that enable the Issue Emission module. Requires the instance identifier in the plugin settings."
   field_emission_subtype_hint: "Subtype (a JSON-LD term, e.g. WorkOrder)"
   label_emission_exposed_fields: "Published attributes"
+  label_emission_exposed_custom_fields: "Published custom fields"
   gtt_fiware_settings_emission: "Issue Emission"
   field_fiware_instance_id: "Instance identifier"
   text_fiware_instance_id_info: "Letters, digits, hyphen and underscore. Becomes part of every emitted entity id (urn:ngsi-ld:Issue:redmine:<instance>:<issue>). Emission stays off while blank; changing it later re-identifies every emitted entity."
@@ -229,4 +230,6 @@ en:
     emission_mapping:
       invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
       reserved_subtype: "is a reserved vocabulary term and cannot be used as a subtype"
+      invalid_custom_term: "custom field term %{term} must be a non-reserved JSON-LD term (letters and digits, starting with a letter)"
+      duplicate_custom_term: "custom field terms must be unique within a mapping"
       connection_not_ngsi_ld: "issue emission requires an NGSI-LD connection"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,6 +45,7 @@ ja:
   text_emission_mappings_info: "チェックしたトラッカーのチケットは、指定したサブタイプ付きのNGSI-LD Issueエンティティとしてこのブローカーへ送信されます（チケット送信モジュールを有効にしたプロジェクトのみ）。プラグイン設定のインスタンス識別子が必要です。"
   field_emission_subtype_hint: "サブタイプ（JSON-LDターム、例：WorkOrder）"
   label_emission_exposed_fields: "公開する属性"
+  label_emission_exposed_custom_fields: "公開するカスタムフィールド"
   gtt_fiware_settings_emission: "チケット送信"
   field_fiware_instance_id: "インスタンス識別子"
   text_fiware_instance_id_info: "英数字、ハイフン、アンダースコアのみ。送信されるすべてのエンティティID（urn:ngsi-ld:Issue:redmine:<instance>:<issue>）に含まれます。空欄の間は送信されません。後から変更するとすべての送信済みエンティティのIDが変わります。"
@@ -225,4 +226,6 @@ ja:
     emission_mapping:
       invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
       reserved_subtype: "は予約済みの語彙タームのためサブタイプとして使用できません"
+      invalid_custom_term: "カスタムフィールドのターム %{term} は予約されていないJSON-LDタームである必要があります（英字で始まる英数字のみ）"
+      duplicate_custom_term: "カスタムフィールドのタームはマッピング内で一意である必要があります"
       connection_not_ngsi_ld: "チケット送信にはNGSI-LD接続が必要です"

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -93,13 +93,22 @@ module RedmineGttFiware
       end
     end
 
+    # term => source field names, custom fields batch-loaded in one query.
+    # A term colliding with a subtype is skipped: one inst: IRI must not be
+    # published as both a class and a property (validation rejects new
+    # collisions; this covers pre-validation rows).
     def custom_terms
-      @custom_terms ||= EmissionMapping.find_each.each_with_object({}) do |mapping, result|
-        mapping.exposed_custom_fields.each do |cf_id, term|
-          custom_field = IssueCustomField.find_by(id: cf_id)
-          next unless custom_field
+      @custom_terms ||= begin
+        exposures = EmissionMapping.all.map(&:exposed_custom_fields)
+        custom_fields = IssueCustomField.where(id: exposures.flat_map(&:keys).uniq).index_by(&:id)
+        exposures.each_with_object({}) do |exposed, result|
+          exposed.each do |cf_id, term|
+            custom_field = custom_fields[cf_id]
+            next unless custom_field
+            next if subtypes.key?(term)
 
-          (result[term] ||= []) << custom_field.name
+            (result[term] ||= []) << custom_field.name
+          end
         end
       end
     end

--- a/lib/redmine_gtt_fiware/instance_context.rb
+++ b/lib/redmine_gtt_fiware/instance_context.rb
@@ -16,6 +16,7 @@ module RedmineGttFiware
     STANDARD_TERMS = %w[description priority category targetVersion startDate
                         dueDate estimatedTime percentDone parent assignee].freeze
     RDFS = 'http://www.w3.org/2000/01/rdf-schema#'.freeze
+    RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'.freeze
 
     # base_url: the instance's public base (Setting.host_name-derived, with
     # the request base as fallback for the serving controller only).
@@ -26,7 +27,7 @@ module RedmineGttFiware
     def to_h
       {
         '@context' => context_terms,
-        '@graph' => subtype_classes
+        '@graph' => subtype_classes + custom_field_properties
       }
     end
 
@@ -42,6 +43,7 @@ module RedmineGttFiware
 
     def context_terms
       terms = {
+        'rdf' => RDF,
         'rdfs' => RDFS,
         'gttfiware' => CORE_NAMESPACE,
         'inst' => vocab_namespace
@@ -51,10 +53,11 @@ module RedmineGttFiware
       # not strings.
       terms['refersTo'] = { '@id' => 'gttfiware:refersTo', '@type' => '@id' }
       terms['parent'] = { '@id' => 'gttfiware:parent', '@type' => '@id' }
-      # Validation rejects reserved subtype names (EmissionMapping); the skip
-      # is defense in depth for pre-validation rows, so a stray subtype can
-      # never shadow a core term or prefix in the published document.
+      # Validation rejects reserved subtype and custom terms (EmissionMapping);
+      # the skip is defense in depth for pre-validation rows, so a stray term
+      # can never shadow a core term or prefix in the published document.
       subtypes.each_key { |subtype| terms[subtype] = "inst:#{subtype}" unless terms.key?(subtype) }
+      custom_terms.each_key { |term| terms[term] = "inst:#{term}" unless terms.key?(term) }
       terms
     end
 
@@ -72,9 +75,32 @@ module RedmineGttFiware
       end
     end
 
+    # One property declaration per distinct exposed custom-field term (#69,
+    # step 2c), labeled with the source field so schema readers can trace it.
+    def custom_field_properties
+      custom_terms.map do |term, field_names|
+        {
+          '@id' => "inst:#{term}",
+          '@type' => 'rdf:Property',
+          'rdfs:label' => "#{term} (custom field: #{field_names.uniq.sort.join(', ')})"
+        }
+      end
+    end
+
     def subtypes
       @subtypes ||= EmissionMapping.includes(:tracker).each_with_object({}) do |mapping, result|
         (result[mapping.subtype] ||= []) << mapping.tracker.name
+      end
+    end
+
+    def custom_terms
+      @custom_terms ||= EmissionMapping.find_each.each_with_object({}) do |mapping, result|
+        mapping.exposed_custom_fields.each do |cf_id, term|
+          custom_field = IssueCustomField.find_by(id: cf_id)
+          next unless custom_field
+
+          (result[term] ||= []) << custom_field.name
+        end
       end
     end
   end

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -34,6 +34,7 @@ module RedmineGttFiware
       entity['location'] = geo_property if geometry?
       entity['refersTo'] = relationship(@issue.fiware_entity) if refers_to?
       entity.merge!(exposed_properties)
+      entity.merge!(exposed_custom_properties)
       entity['@context'] = entity_context
       entity
     end
@@ -92,6 +93,38 @@ module RedmineGttFiware
     # decision (the checkbox defaults off like everything else).
     def exposed_assignee
       property(@issue.assigned_to.name) if @issue.assigned_to
+    end
+
+    # The admin-exposed custom fields (#69, step 2c), typed by field format;
+    # blank values are absent from the entity like everything else.
+    def exposed_custom_properties
+      @mapping.exposed_custom_fields.each_with_object({}) do |(cf_id, term), result|
+        custom_field = IssueCustomField.find_by(id: cf_id)
+        next unless custom_field
+
+        value = custom_property(custom_field)
+        result[term] = value if value
+      end
+    end
+
+    def custom_property(custom_field)
+      raw = @issue.custom_field_value(custom_field)
+      raw = raw.reject(&:blank?) if raw.is_a?(Array)
+      return nil if raw.blank? && raw != false
+
+      case custom_field.field_format
+      when 'int' then property(raw.to_i)
+      when 'float' then property(raw.to_f)
+      when 'bool' then property(raw == '1' || raw == true)
+      when 'date'
+        begin
+          date_property(Date.parse(raw.to_s))
+        rescue ArgumentError, TypeError
+          nil
+        end
+      else
+        property(raw.is_a?(Array) ? raw.map(&:to_s) : raw.to_s)
+      end
     end
 
     def property(value)

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -98,8 +98,10 @@ module RedmineGttFiware
     # The admin-exposed custom fields (#69, step 2c), typed by field format;
     # blank values are absent from the entity like everything else.
     def exposed_custom_properties
-      @mapping.exposed_custom_fields.each_with_object({}) do |(cf_id, term), result|
-        custom_field = IssueCustomField.find_by(id: cf_id)
+      exposed = @mapping.exposed_custom_fields
+      custom_fields = IssueCustomField.where(id: exposed.keys).index_by(&:id)
+      exposed.each_with_object({}) do |(cf_id, term), result|
+        custom_field = custom_fields[cf_id]
         next unless custom_field
 
         value = custom_property(custom_field)

--- a/test/functional/fiware_contexts_controller_test.rb
+++ b/test/functional/fiware_contexts_controller_test.rb
@@ -87,6 +87,23 @@ class FiwareContextsControllerTest < ActionController::TestCase
     assert_equal 1, label.scan(Tracker.find(1).name).size
   end
 
+  # Exposed custom-field terms are published as instance vocabulary with a
+  # labeled property node (#69, step 2c).
+  def test_custom_field_terms_are_published
+    custom_field = IssueCustomField.create!(name: 'Road surface', field_format: 'string',
+                                            is_for_all: true, trackers: Tracker.all)
+    mapping = EmissionMapping.create!(broker_connection: @connection, tracker: Tracker.find(1), subtype: 'WorkOrder')
+    mapping.exposed_custom_fields = { custom_field.id => 'roadSurface' }
+    mapping.save!
+
+    get :show
+    body = JSON.parse(response.body)
+    assert_equal 'inst:roadSurface', body['@context']['roadSurface']
+    node = body['@graph'].detect { |n| n['@id'] == 'inst:roadSurface' }
+    assert_equal 'rdf:Property', node['@type']
+    assert_includes node['rdfs:label'], 'Road surface'
+  end
+
   # The configured public host defines the instance namespace (#101
   # semantics); the request host is only the local fallback.
   def test_instance_namespace_follows_the_configured_host

--- a/test/unit/emission_mapping_test.rb
+++ b/test/unit/emission_mapping_test.rb
@@ -99,6 +99,20 @@ class EmissionMappingTest < ActiveSupport::TestCase
     end
   end
 
+  # One inst: IRI must not be both a class and a property: custom terms may
+  # not shadow any configured subtype, own mapping or another's.
+  def test_custom_terms_must_not_shadow_subtypes
+    conn = connection
+    mapping = EmissionMapping.new(broker_connection: conn, tracker: Tracker.first, subtype: 'WorkOrder')
+    mapping.exposed_custom_fields = { 5 => 'workorder' }
+    assert_not mapping.valid?
+
+    EmissionMapping.create!(broker_connection: conn, tracker: Tracker.first, subtype: 'Incident')
+    other = EmissionMapping.new(broker_connection: conn, tracker: Tracker.all.second, subtype: 'WorkOrder')
+    other.exposed_custom_fields = { 5 => 'incident' }
+    assert_not other.valid?
+  end
+
   def test_duplicate_custom_terms_are_rejected
     mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
     mapping.exposed_custom_fields = { 5 => 'roadSurface', 7 => 'roadSurface' }

--- a/test/unit/emission_mapping_test.rb
+++ b/test/unit/emission_mapping_test.rb
@@ -78,6 +78,40 @@ class EmissionMappingTest < ActiveSupport::TestCase
     assert_equal [], mapping.reload.exposed_standard_fields
   end
 
+  # --- custom field exposure (#69, step 2c) ----------------------------------
+
+  def test_exposed_custom_fields_round_trip
+    mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
+    mapping.exposed_custom_fields = { 5 => 'roadSurface', '7' => 'severityScore' }
+    assert mapping.valid?
+    assert_equal({ 5 => 'roadSurface', 7 => 'severityScore' }, mapping.exposed_custom_fields)
+  end
+
+  # An admin's typo must surface as an error, not vanish through the
+  # reader's defensive filter.
+  def test_invalid_custom_terms_are_validation_errors
+    mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
+    ['road surface', 'title', 'rdf', '9lives'].each do |bad|
+      mapping.exposed_custom_fields = { 5 => bad }
+      assert_not mapping.valid?, "#{bad.inspect} must be rejected"
+      # ... and the reader drops it regardless.
+      assert_equal({}, mapping.exposed_custom_fields)
+    end
+  end
+
+  def test_duplicate_custom_terms_are_rejected
+    mapping = EmissionMapping.new(broker_connection: connection, tracker: Tracker.first, subtype: 'WorkOrder')
+    mapping.exposed_custom_fields = { 5 => 'roadSurface', 7 => 'roadSurface' }
+    assert_not mapping.valid?
+  end
+
+  def test_suggested_custom_term
+    assert_equal 'reportedVia', EmissionMapping.suggested_custom_term(IssueCustomField.new(name: 'Reported via'))
+    assert_equal 'onSiteVerified', EmissionMapping.suggested_custom_term(IssueCustomField.new(name: 'On-site verified'))
+    fallback = EmissionMapping.suggested_custom_term(IssueCustomField.new(name: '調査日').tap { |cf| cf.id = 42 })
+    assert_equal 'customField42', fallback
+  end
+
   # The exposure catalog and the published vocabulary must not drift apart.
   def test_standard_fields_match_the_published_terms
     assert_equal RedmineGttFiware::InstanceContext::STANDARD_TERMS.sort,

--- a/test/unit/issue_entity_test.rb
+++ b/test/unit/issue_entity_test.rb
@@ -149,6 +149,50 @@ class IssueEntityTest < ActiveSupport::TestCase
     assert_equal "urn:ngsi-ld:Issue:redmine:test-town:#{parent.id}", e.dig('parent', 'object')
   end
 
+  # --- exposed custom fields (#69, step 2c) ----------------------------------
+
+  def custom_field(format, name)
+    IssueCustomField.create!(name: name, field_format: format, is_for_all: true,
+                             trackers: Tracker.all)
+  end
+
+  def test_exposed_custom_fields_are_typed_by_format
+    string_cf = custom_field('string', 'Road surface')
+    bool_cf = custom_field('bool', 'On-site verified')
+    int_cf = custom_field('int', 'Severity score')
+    date_cf = custom_field('date', 'Inspection date')
+    @mapping.exposed_custom_fields = {
+      string_cf.id => 'roadSurface', bool_cf.id => 'onSiteVerified',
+      int_cf.id => 'severityScore', date_cf.id => 'inspectionDate'
+    }
+    @mapping.save!
+    @issue.custom_field_values = {
+      string_cf.id => 'gravel', bool_cf.id => '0',
+      int_cf.id => '4', date_cf.id => '2026-07-30'
+    }
+
+    e = entity
+    assert_equal 'gravel', e.dig('roadSurface', 'value')
+    assert_equal false, e.dig('onSiteVerified', 'value')
+    assert_equal 4, e.dig('severityScore', 'value')
+    assert_equal({ '@type' => 'Date', '@value' => '2026-07-30' }, e.dig('inspectionDate', 'value'))
+  end
+
+  def test_blank_custom_values_are_omitted
+    string_cf = custom_field('string', 'Road surface')
+    @mapping.exposed_custom_fields = { string_cf.id => 'roadSurface' }
+    @mapping.save!
+    @issue.custom_field_values = { string_cf.id => '' }
+
+    assert_nil entity['roadSurface']
+  end
+
+  def test_deleted_custom_fields_are_skipped
+    @mapping.exposed_custom_fields = { 99_999 => 'ghostField' }
+    @mapping.save!
+    assert_nil entity['ghostField']
+  end
+
   def test_source_omitted_without_a_configured_host
     with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' }, host_name: '' do
       e = RedmineGttFiware::IssueEntity.new(@issue, @mapping).to_h


### PR DESCRIPTION
Refs #69 — the final slice of design step 2, on top of #113.

## What's in

- **Per-mapping custom-field exposure**: each tracker row lists its custom fields with a checkbox and an **admin-named term** (lowerCamel suggested from the field name — `Reported via` → `reportedVia`; id-based fallback for non-ASCII names like `調査日` → `customField42`).
- **Storage** reuses the JSON `exposed_attributes` column (`{"custom": {"<cf id>": "<term>"}}`) — no migration. Validation surfaces typos, reserved terms and in-mapping duplicates as errors (an admin's typo must not silently vanish); the reader *additionally* drops anything invalid, so the entity serializer and context generator trust every entry.
- **Emission**: values typed by field format — `int`/`float`/`bool` (including `false`), `date` as a typed `Date` value, strings and multi-value lists as-is. Blank values and deleted custom fields are absent from the entity.
- **Vocabulary**: exposed terms are published under the **instance namespace** (`inst:` — unlike the standard fields, these genuinely differ per instance) with `rdf:Property` nodes labeled by the source field name, so schema readers can trace every term to its origin. Term shadowing of core vocabulary is impossible (validation + generator skip).

## Testing

- Mapping: round trip, typo/reserved/duplicate validation, suggested terms incl. the non-ASCII fallback
- Entity: per-format typing (incl. `bool` false), blank omission, deleted-field skip
- Context: term mapping + labeled property node
- Full suite: **225 runs, 817 assertions, 0 failures**

With this, design step 2 is complete: the instance publishes a full self-describing schema (core terms, subtypes as `Issue` subclasses, standard terms, custom-field terms) and emits entities that reference it.