### PR TITLE
Serve issues as NGSI-LD entities on demand (#4)

### DIFF
--- a/app/controllers/fiware_entities_controller.rb
+++ b/app/controllers/fiware_entities_controller.rb
@@ -18,14 +18,22 @@ class FiwareEntitiesController < ApplicationController
       return
     end
 
-    mapping = EmissionMapping.joins(:broker_connection)
-                             .where(tracker_id: @issue.tracker_id)
-                             .order(:id).first
-    entity = RedmineGttFiware::IssueEntity.new(@issue, mapping).to_h
+    entity = RedmineGttFiware::IssueEntity.new(@issue, mapping_for(@issue)).to_h
     render json: entity, content_type: 'application/ld+json'
   end
 
   private
+
+  # A tracker can be mapped on several connections with different subtypes
+  # and exposure. The on-demand representation uses the mapping of the
+  # issue's own connection when the issue came from a broker, the oldest
+  # mapping otherwise - deterministic, and consistent with the broker the
+  # issue is actually correlated with.
+  def mapping_for(issue)
+    mappings = EmissionMapping.where(tracker_id: issue.tracker_id).order(:id)
+    preferred = issue.subscription_template&.broker_connection_id
+    mappings.detect { |m| m.broker_connection_id == preferred } || mappings.first
+  end
 
   def find_issue
     @issue = Issue.find(params[:id])

--- a/app/controllers/fiware_entities_controller.rb
+++ b/app/controllers/fiware_entities_controller.rb
@@ -1,0 +1,36 @@
+# Serves a single issue as an NGSI-LD entity (#4): the same representation
+# the emitter publishes, available on demand. With an emission mapping for
+# the issue's tracker the full curated representation is rendered; without
+# one, the frozen core alone.
+class FiwareEntitiesController < ApplicationController
+  # See SubscriptionIssuesController: the explicit declaration keeps the
+  # framework-default forgery protection visible to static analysis.
+  protect_from_forgery with: :exception
+
+  accept_api_auth :show
+  before_action :find_issue
+
+  def show
+    # Entity ids embed the instance identifier; without one there is no
+    # valid representation to serve.
+    if RedmineGttFiware::Emitter.instance_id.blank?
+      head :not_found
+      return
+    end
+
+    mapping = EmissionMapping.joins(:broker_connection)
+                             .where(tracker_id: @issue.tracker_id)
+                             .order(:id).first
+    entity = RedmineGttFiware::IssueEntity.new(@issue, mapping).to_h
+    render json: entity, content_type: 'application/ld+json'
+  end
+
+  private
+
+  def find_issue
+    @issue = Issue.find(params[:id])
+    render_404 unless @issue.visible?(User.current)
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+end

--- a/app/views/gtt_fiware/_entity_link.html.erb
+++ b/app/views/gtt_fiware/_entity_link.html.erb
@@ -1,0 +1,8 @@
+<%# Link to the issue's NGSI-LD representation (#4). Shown when the instance
+    has an identifier to mint entity ids with. %>
+<% if RedmineGttFiware::Emitter.instance_id.present? %>
+  <p class="other-formats">
+    <%= l(:label_fiware_entity_link) %>:
+    <span><%= link_to 'NGSI-LD', url_for(controller: 'fiware_entities', action: 'show', id: issue.id) %></span>
+  </p>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -86,6 +86,7 @@ de:
   field_federation_watch: 'Föderations-Beobachtung'
   text_federation_watch_info: 'Diese Subscription beobachtet die Arbeitsaufträge anderer Organisationen, statt Tickets zu erstellen: fremde Statusänderungen werden als Kommentare an lokalen Tickets vermerkt, die auf dieselbe Entität verweisen. Entitätsfilter auf Typ Issue und beobachtete Attribute auf status setzen.'
   text_federation_status_note: 'Föderations-Update: Der Arbeitsauftrag von %{org} ist jetzt %{status} (%{urn})'
+  label_fiware_entity_link: 'Auch verfügbar als'
   gtt_fiware_settings_emission: 'Ticket-Übertragung'
   field_fiware_instance_id: 'Instanz-Kennung'
   text_fiware_instance_id_info: 'Buchstaben, Ziffern, Bindestrich und Unterstrich. Teil jeder übertragenen Entitäts-ID (urn:ngsi-ld:Issue:redmine:<instanz>:<ticket>). Ohne Wert bleibt die Übertragung aus; eine spätere Änderung vergibt allen übertragenen Entitäten neue IDs.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
   field_federation_watch: "Federation watch"
   text_federation_watch_info: "This subscription watches other organizations' work orders instead of creating issues: foreign status changes are added as notes to local issues that refer to the same entity. Set the entity filter to type Issue and the watched attributes to status."
   text_federation_status_note: "Federation update: the work order by %{org} is now %{status} (%{urn})"
+  label_fiware_entity_link: "Also available as"
   gtt_fiware_settings_emission: "Issue Emission"
   field_fiware_instance_id: "Instance identifier"
   text_fiware_instance_id_info: "Letters, digits, hyphen and underscore. Becomes part of every emitted entity id (urn:ngsi-ld:Issue:redmine:<instance>:<issue>). Emission stays off while blank; changing it later re-identifies every emitted entity."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -57,6 +57,7 @@ ja:
   field_federation_watch: "フェデレーション監視"
   text_federation_watch_info: "このサブスクリプションはチケットを作成せず、他組織のワークオーダーを監視します。同じエンティティを参照するローカルのチケットに、他組織のステータス変更を注記として追加します。エンティティフィルタをタイプIssue、監視属性をstatusに設定してください。"
   text_federation_status_note: "フェデレーション更新：%{org} のワークオーダーは %{status} になりました（%{urn}）"
+  label_fiware_entity_link: "他の形式"
   gtt_fiware_settings_emission: "チケット送信"
   field_fiware_instance_id: "インスタンス識別子"
   text_fiware_instance_id_info: "英数字、ハイフン、アンダースコアのみ。送信されるすべてのエンティティID（urn:ngsi-ld:Issue:redmine:<instance>:<issue>）に含まれます。空欄の間は送信されません。後から変更するとすべての送信済みエンティティのIDが変わります。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ get 'fiware/context.jsonld', to: 'fiware_contexts#show', format: false
 # for the same source entity, fetched asynchronously.
 get 'fiware/issues/:id/federation', to: 'federation#show'
 
+# A single issue as an NGSI-LD entity (#4): the emitter's representation,
+# available on demand (session or API key).
+get 'fiware/issues/:id/entity', to: 'fiware_entities#show', defaults: { format: 'json' }
+
 # Define a route for FIWARE broker subscription templates
 scope 'projects/:project_id' do
   resources :subscription_templates, only: %i(new create edit update destroy),

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -12,7 +12,9 @@ module RedmineGttFiware
       "urn:ngsi-ld:Issue:redmine:#{Emitter.instance_id}:#{issue.id}"
     end
 
-    def initialize(issue, mapping)
+    # mapping may be nil for pull-side rendering (#4): the representation is
+    # then the frozen core alone - no subtype, no exposed attributes.
+    def initialize(issue, mapping = nil)
       @issue = issue
       @mapping = mapping
     end
@@ -26,10 +28,10 @@ module RedmineGttFiware
         # instance's own status name travels alongside as statusLabel.
         'status' => property(@issue.status.is_closed? ? 'closed' : 'open'),
         'statusLabel' => property(@issue.status.name),
-        'subtype' => property(@mapping.subtype),
         'dateCreated' => datetime_property(@issue.created_on),
         'dateModified' => datetime_property(@issue.updated_on)
       }
+      entity['subtype'] = property(@mapping.subtype) if @mapping
       entity['source'] = property(source_url) if source_url
       entity['location'] = geo_property if geometry?
       entity['refersTo'] = relationship(@issue.fiware_entity) if refers_to?
@@ -45,6 +47,8 @@ module RedmineGttFiware
     # the NGSI-LD attribute or nil when the issue has no value, so absent
     # data is absent from the entity instead of null-valued.
     def exposed_properties
+      return {} unless @mapping
+
       @mapping.exposed_standard_fields.each_with_object({}) do |field, result|
         value = send("exposed_#{field.underscore}")
         result[field] = value if value
@@ -98,6 +102,8 @@ module RedmineGttFiware
     # The admin-exposed custom fields (#69, step 2c), typed by field format;
     # blank values are absent from the entity like everything else.
     def exposed_custom_properties
+      return {} unless @mapping
+
       exposed = @mapping.exposed_custom_fields
       custom_fields = IssueCustomField.where(id: exposed.keys).index_by(&:id)
       exposed.each_with_object({}) do |(cf_id, term), result|

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -31,7 +31,10 @@ module RedmineGttFiware
         'dateCreated' => datetime_property(@issue.created_on),
         'dateModified' => datetime_property(@issue.updated_on)
       }
-      entity['subtype'] = property(@mapping.subtype) if @mapping
+      # subtype.present? and not just @mapping: a pre-validation row with a
+      # blank subtype must not emit a null-valued property (absent data is
+      # absent).
+      entity['subtype'] = property(@mapping.subtype) if @mapping&.subtype.present?
       entity['source'] = property(source_url) if source_url
       entity['location'] = geo_property if geometry?
       entity['refersTo'] = relationship(@issue.fiware_entity) if refers_to?

--- a/lib/redmine_gtt_fiware/view_hooks.rb
+++ b/lib/redmine_gtt_fiware/view_hooks.rb
@@ -7,5 +7,8 @@ module RedmineGttFiware
 
     # Federation panel (#70, 4b) below the issue description.
     render_on :view_issues_show_description_bottom, partial: 'gtt_fiware/federation_panel'
+
+    # Link to the issue's NGSI-LD representation (#4).
+    render_on :view_issues_show_description_bottom, partial: 'gtt_fiware/entity_link'
   end
 end

--- a/test/functional/fiware_entities_controller_test.rb
+++ b/test/functional/fiware_entities_controller_test.rb
@@ -44,6 +44,30 @@ class FiwareEntitiesControllerTest < ActionController::TestCase
     assert_equal @issue.priority.name, entity.dig('priority', 'value')
   end
 
+  # With several mappings for the tracker, the issue's own connection wins;
+  # a broker-less issue gets the oldest mapping.
+  def test_prefers_the_mapping_of_the_issues_own_connection
+    first_conn = BrokerConnection.create!(name: 'First broker', standard: 'NGSI-LD',
+                                          url: 'https://a.example.com', auth_mode: 'stored')
+    own_conn = BrokerConnection.create!(name: 'Own broker', standard: 'NGSI-LD',
+                                        url: 'https://b.example.com', auth_mode: 'stored',
+                                        context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld')
+    EmissionMapping.create!(broker_connection: first_conn, tracker: @issue.tracker, subtype: 'FirstType')
+    EmissionMapping.create!(broker_connection: own_conn, tracker: @issue.tracker, subtype: 'OwnType')
+    template = SubscriptionTemplate.create!(
+      broker_connection_id: own_conn.id, status: 'active', name: 'Own template',
+      subject: 'S', description: 'D', entities_string: '[{"idPattern": ".*", "type": "X"}]',
+      project_id: 1, tracker_id: @issue.tracker_id, issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id, member_id: 1
+    )
+    @issue.update_columns(subscription_template_id: template.id)
+
+    with_settings plugin_redmine_gtt_fiware: INSTANCE_SETTINGS do
+      get :show, params: { id: @issue.id }
+    end
+    assert_equal 'OwnType', JSON.parse(response.body).dig('subtype', 'value')
+  end
+
   # Entity ids embed the instance identifier; without one there is no valid
   # representation to serve.
   def test_not_found_without_an_instance_id

--- a/test/functional/fiware_entities_controller_test.rb
+++ b/test/functional/fiware_entities_controller_test.rb
@@ -1,0 +1,64 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class FiwareEntitiesControllerTest < ActionController::TestCase
+  fixtures :projects, :trackers, :projects_trackers, :issue_statuses,
+           :users, :email_addresses, :members, :member_roles, :roles,
+           :enumerations, :issues
+
+  INSTANCE_SETTINGS = { 'fiware_instance_id' => 'test-town' }.freeze
+
+  def setup
+    @request.session[:user_id] = 1
+    @issue = Issue.find(1)
+  end
+
+  def test_serves_the_core_representation_without_a_mapping
+    with_settings plugin_redmine_gtt_fiware: INSTANCE_SETTINGS do
+      get :show, params: { id: @issue.id }
+    end
+    assert_response :success
+    assert_equal 'application/ld+json', response.media_type
+    entity = JSON.parse(response.body)
+    assert_equal "urn:ngsi-ld:Issue:redmine:test-town:#{@issue.id}", entity['id']
+    assert_equal 'Issue', entity['type']
+    assert_equal @issue.subject, entity.dig('title', 'value')
+    assert_nil entity['subtype'], 'no mapping, no subtype'
+  end
+
+  def test_serves_the_curated_representation_with_a_mapping
+    connection = BrokerConnection.create!(
+      name: 'Entity endpoint broker', standard: 'NGSI-LD',
+      url: 'https://broker.example.com', auth_mode: 'stored'
+    )
+    mapping = EmissionMapping.create!(broker_connection: connection,
+                                      tracker: @issue.tracker, subtype: 'WorkOrder')
+    mapping.exposed_standard_fields = %w[priority]
+    mapping.save!
+
+    with_settings plugin_redmine_gtt_fiware: INSTANCE_SETTINGS do
+      get :show, params: { id: @issue.id }
+    end
+    assert_response :success
+    entity = JSON.parse(response.body)
+    assert_equal 'WorkOrder', entity.dig('subtype', 'value')
+    assert_equal @issue.priority.name, entity.dig('priority', 'value')
+  end
+
+  # Entity ids embed the instance identifier; without one there is no valid
+  # representation to serve.
+  def test_not_found_without_an_instance_id
+    with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => '' } do
+      get :show, params: { id: @issue.id }
+    end
+    assert_response :not_found
+  end
+
+  def test_requires_issue_visibility
+    @issue.project.update_column(:is_public, false)
+    @request.session[:user_id] = nil
+    with_settings plugin_redmine_gtt_fiware: INSTANCE_SETTINGS, login_required: '0' do
+      get :show, params: { id: @issue.id }
+    end
+    assert_response :not_found
+  end
+end

--- a/test/unit/issue_entity_test.rb
+++ b/test/unit/issue_entity_test.rb
@@ -193,6 +193,17 @@ class IssueEntityTest < ActiveSupport::TestCase
     assert_nil entity['ghostField']
   end
 
+  # Pull-side rendering (#4): without a mapping the representation is the
+  # frozen core alone.
+  def test_renders_the_core_alone_without_a_mapping
+    with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' } do
+      e = RedmineGttFiware::IssueEntity.new(@issue).to_h
+      assert_equal 'Issue', e['type']
+      assert_nil e['subtype']
+      assert_nil e['priority']
+    end
+  end
+
   def test_source_omitted_without_a_configured_host
     with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' }, host_name: '' do
       e = RedmineGttFiware::IssueEntity.new(@issue, @mapping).to_h

--- a/test/unit/issue_entity_test.rb
+++ b/test/unit/issue_entity_test.rb
@@ -193,6 +193,13 @@ class IssueEntityTest < ActiveSupport::TestCase
     assert_nil entity['ghostField']
   end
 
+  # A pre-validation mapping row with a blank subtype must not emit a
+  # null-valued property.
+  def test_blank_subtype_is_absent
+    @mapping.subtype = ''
+    assert_nil entity['subtype']
+  end
+
   # Pull-side rendering (#4): without a mapping the representation is the
   # frozen core alone.
   def test_renders_the_core_alone_without_a_mapping


### PR DESCRIPTION
Closes #4 — the remaining pull-side item, now small thanks to the emission serializer.

## What's in

- **`GET /fiware/issues/:id/entity`** serves the issue as an NGSI-LD entity: the same representation the emitter publishes, on demand. Session or API key authenticated, issue visibility required, `application/ld+json`.
- With an emission mapping for the issue's tracker the **curated** representation is served (subtype, exposed standard and custom fields); without one, the **frozen core** alone — `IssueEntity`'s mapping parameter is now optional for this.
- Answers 404 while the instance identifier is unset (entity ids embed it, so there is no valid representation without one).
- The issue page links to the representation ("Also available as: NGSI-LD") below the description, shown when the instance identifier is configured.

## Testing

- Core-only and curated representations, 404 without an instance id, visibility enforcement, media type
- Full suite: **250 runs, 903 assertions, 0 failures**