### PR TITLE
Narrow echo suppression to Issue-typed notifications

### DIFF
--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -47,22 +47,30 @@ module RedmineGttFiware
     end
 
     # raw_entity: one entity hash from the notification's data[] array.
-    # Emitter.suppress: issues created or updated from a broker notification
-    # must not be emitted back to a broker (#69 echo suppression) - a
-    # subscription and an emission mapping on the same tenant would loop.
+    # Echo suppression, narrowed (#70 staging finding): issues created from
+    # ordinary entities (sensors, reports) ARE emitted - that is the point of
+    # emission, and it cannot loop because the emitted entity's type (Issue)
+    # differs from what the subscription watches. The loop only exists when
+    # the notifying entity is itself an Issue (a work order creating a work
+    # order creating ...), so exactly that case is suppressed - as is the
+    # federation watch, which annotates local issues in place.
     def process(raw_entity)
-      Emitter.suppress do
-        entity = Entity.from(raw_entity, @template.standard)
-        if @template.federation_watch?
-          process_federation_update(entity)
-        else
-          existing = find_recent_issue(entity)
-          existing ? process_update(existing, entity) : process_create(entity)
-        end
+      entity = Entity.from(raw_entity, @template.standard)
+      if @template.federation_watch?
+        Emitter.suppress { process_federation_update(entity) }
+      elsif entity.type.to_s == 'Issue'
+        Emitter.suppress { create_or_update(entity) }
+      else
+        create_or_update(entity)
       end
     end
 
     private
+
+    def create_or_update(entity)
+      existing = find_recent_issue(entity)
+      existing ? process_update(existing, entity) : process_create(entity)
+    end
 
     # A new notification for an entity already turned into an issue within the
     # threshold_create window updates that issue instead of creating a duplicate

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -103,11 +103,7 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal @template.member.user_id, issue.author_id
   end
 
-  # Echo suppression (#69): an issue created from a broker notification must
-  # not be emitted back to a broker, even when the project and tracker have an
-  # emission mapping - a subscription plus an emission on the same tenant
-  # would loop otherwise.
-  def test_notification_created_issues_are_not_emitted_back
+  def enable_emission
     project = Project.find(1)
     project.enabled_module_names = project.enabled_module_names | ['gtt_fiware_emission']
     ld_connection = BrokerConnection.create!(
@@ -115,11 +111,39 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
       url: 'https://broker.example.com', auth_mode: 'stored'
     )
     EmissionMapping.create!(broker_connection: ld_connection, tracker: Tracker.find(1), subtype: 'WorkOrder')
+  end
 
-    Net::HTTP.any_instance.expects(:request).never
+  # Issues created from ordinary entities ARE emitted - that is the point of
+  # emission: the sensor event becomes a work order other organizations can
+  # see. No loop: the emitted type (Issue) differs from what the
+  # subscription watches (#70 staging finding).
+  def test_notification_created_issues_are_emitted
+    enable_emission
+    emitted = []
+    created = Net::HTTPCreated.new('1.1', '201', 'Created')
+    Net::HTTP.any_instance.stubs(:request).with { |req| emitted << req; true }.returns(created)
+
     with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' } do
       assert_difference 'Issue.count', 1 do
         post_notification
+      end
+    end
+    assert_response :success
+    post = emitted.find { |r| r.is_a?(Net::HTTP::Post) && r.path.include?('/entities') }
+    assert_not_nil post, 'the created issue must be emitted'
+    body = JSON.parse(post.body)
+    assert_equal 'urn:ngsi-ld:TemperatureSensor:001', body.dig('refersTo', 'object')
+  end
+
+  # The echo loop exists exactly when the notifying entity is itself an
+  # Issue (a work order creating a work order creating ...): that case is
+  # suppressed.
+  def test_issue_typed_notifications_are_not_emitted_back
+    enable_emission
+    Net::HTTP.any_instance.expects(:request).never
+    with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => 'test-town' } do
+      assert_difference 'Issue.count', 1 do
+        post_notification(entities: [entity('id' => 'urn:ngsi-ld:Issue:redmine:other-org:5', 'type' => 'Issue')])
       end
     end
     assert_response :success


### PR DESCRIPTION
Found by the two-instance federation staging: blanket echo suppression (in place since #111) kept **notification-created issues from ever being emitted** — but those are the primary emission case. A sensor event that becomes an issue should become a work order other organizations can see; that is the whole loop the plugin exists for.

The actual echo risk is narrower: it exists exactly when the notifying entity is **itself an Issue** — a subscription on the emitted type would otherwise loop (work order creates issue, issue emits work order, repeat). So:

- notifications for **ordinary entities** (sensors, reports): the created/updated issue **is emitted**, `refersTo` its source — no loop possible, the emitted type differs from what the subscription watches
- notifications for **`Issue`-typed entities**: suppressed, as before
- **federation watch** processing: suppressed, as before

Tests updated to the corrected semantics: ordinary notifications now assert the outbound emission (including `refersTo`), and a new test pins that `Issue`-typed notifications stay unemitted. Full suite: **253 runs, 910 assertions, 0 failures**.