### PR TITLE
Refresh the documentation for v3.1

### DIFF
--- a/doc/broker_connections.md
+++ b/doc/broker_connections.md
@@ -3,13 +3,13 @@
 Administration → FIWARE Connections.
 
 A connection describes one context broker: URL, NGSI standard, tenant,
-authentication. Subscription templates and issue emission both use
+authentication. Subscriptions and issue emission both use
 connections, so broker details are entered once and reused.
 
 ## Fields
 
-- **Name**: how the connection appears in template forms.
-- **NGSI standard**: `NGSIv2` or `NGSI-LD`. The template form adapts to the
+- **Name**: how the connection appears in subscription forms.
+- **NGSI standard**: `NGSIv2` or `NGSI-LD`. The subscription form adapts to the
   selected standard (for example, `@context` only applies to NGSI-LD,
   `Fiware-ServicePath` only to NGSIv2).
 - **Broker URL**: the broker's base URL. A URL that already contains a
@@ -19,7 +19,7 @@ connections, so broker details are entered once and reused.
   `NGSILD-Tenant` (NGSI-LD).
 - **FIWARE Service Path**: NGSIv2 only.
 - **NGSI-LD Context**: the default `@context` for subscriptions on this
-  connection; a template can override it.
+  connection; a subscription can override it.
 - **Authentication**: where the broker token comes from.
   - *Stored*: the token is saved encrypted in the database and the server
     calls the broker. Required for issue emission and federation queries,
@@ -32,7 +32,7 @@ connections, so broker details are entered once and reused.
   header name (for example `X-Api-Key`) sends the token as is, which is what
   API-key gateways expect.
 - **Throttling (s)**: minimum seconds between notifications for this
-  connection's subscriptions. A template can override it.
+  connection's subscriptions. A subscription can override it.
 
 ## Issue Emission section
 

--- a/doc/broker_connections.md
+++ b/doc/broker_connections.md
@@ -1,0 +1,41 @@
+# FIWARE Connections
+
+Administration → FIWARE Connections.
+
+A connection describes one context broker: URL, NGSI standard, tenant,
+authentication. Subscription templates and issue emission both use
+connections, so broker details are entered once and reused.
+
+## Fields
+
+- **Name**: how the connection appears in template forms.
+- **NGSI standard**: `NGSIv2` or `NGSI-LD`. The template form adapts to the
+  selected standard (for example, `@context` only applies to NGSI-LD,
+  `Fiware-ServicePath` only to NGSIv2).
+- **Broker URL**: the broker's base URL. A URL that already contains a
+  versioned API path (for example `.../ngsi-ld/v1`) is used as is; otherwise
+  the standard's default prefix is appended.
+- **FIWARE Service**: the tenant name. Sent as `Fiware-Service` (NGSIv2) or
+  `NGSILD-Tenant` (NGSI-LD).
+- **FIWARE Service Path**: NGSIv2 only.
+- **NGSI-LD Context**: the default `@context` for subscriptions on this
+  connection; a template can override it.
+- **Authentication**: where the broker token comes from.
+  - *Stored*: the token is saved encrypted in the database and the server
+    calls the broker. Required for issue emission and federation queries,
+    which run server-side.
+  - *Relayed*: the token is typed in the browser on every publish and the
+    server makes the call. Nothing is stored.
+  - *Browser*: the browser calls the broker directly (the broker must be
+    reachable from the browser and allow CORS).
+- **Token header**: blank sends `Authorization: Bearer <token>`. Any other
+  header name (for example `X-Api-Key`) sends the token as is, which is what
+  API-key gateways expect.
+- **Throttling (s)**: minimum seconds between notifications for this
+  connection's subscriptions. A template can override it.
+
+## Issue Emission section
+
+For NGSI-LD connections, the form also lists the trackers with a checkbox and
+a subtype per tracker. This controls which issues are published to this broker
+and how; see [Issue emission](issue_emission.md).

--- a/doc/federation.md
+++ b/doc/federation.md
@@ -1,0 +1,51 @@
+# Federation
+
+Since version 3.1 the plugin lets organizations that share a context broker
+see and react to each other's work. Two organizations work on the same problem
+when their `Issue` entities point at the same source entity (the `refersTo`
+relationship); everything below builds on that.
+
+Federation requires [issue emission](issue_emission.md) to be configured,
+including a public host name: entities emitted without one are not visible to
+other organizations' queries.
+
+## Awareness when an issue is created
+
+Each subscription template has a **Federation** policy (Subscription options):
+
+- **Off** (default): no federation behaviour.
+- **Annotate**: the issue is created as usual, and a note lists the other
+  organizations that already have a work order for the same entity, with
+  status and a link into their tracker.
+- **Suppress**: no issue is created while another organization has an *open*
+  work order for the entity. The suppression is logged; nothing appears in the
+  tracker.
+
+## The "Also handled by" panel
+
+Issues that came from a broker show a panel below the description listing the
+other organizations' work orders for the same entity, with status and a link.
+The panel loads after the page, so a slow broker never delays the issue page.
+It shows only what each organization chose to publish.
+
+## Status updates from other organizations
+
+A subscription template with **Federation watch** enabled observes other
+organizations' work orders instead of creating issues: when a foreign work
+order changes status, a note is added to the local issues that refer to the
+same entity ("the work order by nexco-east is now Closed").
+
+To set one up: create a template on an NGSI-LD connection, check *Federation
+watch*, set the entity filter to type `Issue` and the watched attributes to
+`status`, then publish it. The template's own entities never trigger notes
+(they are recognized by the instance identifier in their ids), and an
+unchanged status is not repeated.
+
+## Notes
+
+- Sibling lookups and the panel use entity queries, which run server-side with
+  the connection's stored token.
+- Organizations are identified by the instance identifier in the entity id.
+- Matching is by entity, not by subtype: a `RoadDamageReport` and a
+  `WorkOrder` for the same entity count as the same problem, and the notes
+  show the subtype so people can judge.

--- a/doc/federation.md
+++ b/doc/federation.md
@@ -11,7 +11,7 @@ other organizations' queries.
 
 ## Awareness when an issue is created
 
-Each subscription template has a **Federation** policy (Subscription options):
+Each subscription has a **Federation** policy (Subscription options):
 
 - **Off** (default): no federation behaviour.
 - **Annotate**: the issue is created as usual, and a note lists the other
@@ -30,14 +30,14 @@ It shows only what each organization chose to publish.
 
 ## Status updates from other organizations
 
-A subscription template with **Federation watch** enabled observes other
+A subscription with **Federation watch** enabled observes other
 organizations' work orders instead of creating issues: when a foreign work
 order changes status, a note is added to the local issues that refer to the
 same entity ("the work order by nexco-east is now Closed").
 
-To set one up: create a template on an NGSI-LD connection, check *Federation
+To set one up: create a subscription on an NGSI-LD connection, check *Federation
 watch*, set the entity filter to type `Issue` and the watched attributes to
-`status`, then publish it. The template's own entities never trigger notes
+`status`, then publish it. The subscription's own entities never trigger notes
 (they are recognized by the instance identifier in their ids), and an
 unchanged status is not repeated.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -5,15 +5,21 @@ FIWARE plugin and its API endpoints.
 
 ## First Steps
 
-- Make sure REST web services is enabled: <http://localhost:3000/settings?tab=api>
-- Enable the plugin in project settings
-- For security reasons don't select a user with admin rights for the FIWARE
-  subscriptions. Instead, create a new user with the necessary permissions.
+1. Create a [FIWARE Connection](broker_connections.md) for your context
+   broker (Administration → FIWARE Connections).
+2. Set **Administration → Settings → Host name** to a host the broker can
+   reach: subscription callbacks are built from it.
+3. Enable the **GTT FIWARE** module in a project and create a
+   [subscription](subscription_template.md).
+4. Optional: configure [issue emission](issue_emission.md) and
+   [federation](federation.md) to publish your issues back to the broker.
 
-If you need a test installation of FIWARE, you can use
-[FIWARE-Small-Bang](https://github.com/lets-fiware/FIWARE-Small-Bang) (for local
-development) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang)
-(for server deployment).
+Use a dedicated user with just the needed permissions as the subscription
+author, not an administrator.
+
+If you need a test broker, [FIWARE-Small-Bang](https://github.com/lets-fiware/FIWARE-Small-Bang)
+(local) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang)
+(server) set one up.
 
 ### Redmine Permissions
 
@@ -22,8 +28,11 @@ development) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang
 ## How to use
 
 - [Plugin Settings](plugin_settings.md)
+- [FIWARE Connections](broker_connections.md)
 - [Project Settings](project_settings.md)
-- [Subscription Templates](subscription_template.md)
+- [Subscriptions](subscription_template.md)
+- [Issue Emission](issue_emission.md)
+- [Federation](federation.md)
 
 ## Tools and Utilities
 
@@ -34,9 +43,11 @@ development) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang
 
 ## Reference
 
-- [Redmine NGSI-LD vocabulary](reference/ngsi-ld-vocabulary.md) — the JSON-LD
-  vocabulary preserved from the removed read API, kept as the seed for the
-  entity model the plugin will emit to a broker (Phase 3).
+- [GTT FIWARE core vocabulary](https://gtt-project.org/ns/fiware) — the
+  published terms used by [issue emission](issue_emission.md).
+- [Historical NGSI-LD vocabulary notes](reference/ngsi-ld-vocabulary.md) —
+  preserved from the removed read API; the published vocabulary above
+  supersedes it.
 
 ## Examples and Tutorials
 

--- a/doc/issue_emission.md
+++ b/doc/issue_emission.md
@@ -1,0 +1,80 @@
+# Issue Emission
+
+Since version 3.1 the plugin can publish issues to an NGSI-LD broker as
+`Issue` entities: one entity per issue, kept up to date when the issue is
+created, updated, closed or deleted. Other systems on the broker can then see
+whether a problem is being handled, in what state, and where.
+
+## Enabling emission
+
+Three things must be configured; nothing is published until all are in place.
+
+1. **Instance identifier** in the [plugin settings](plugin_settings.md).
+2. **Tracker mapping** on an NGSI-LD [connection](broker_connections.md):
+   check the trackers to emit and give each a subtype (a JSON-LD term such as
+   `WorkOrder` or `RoadDamageReport`).
+3. **Project module**: enable *GTT FIWARE Issue Emission* in the project's
+   settings. Emission is a separate module from the subscriptions module on
+   purpose: sharing issue data with a broker is an explicit decision.
+
+Private issues are never emitted. If the broker is unreachable, the failure is
+logged and the issue is saved normally.
+
+## What is published
+
+Always (the core properties):
+
+| Property | Content |
+| --- | --- |
+| `title` | issue subject |
+| `status` | `open` or `closed` |
+| `statusLabel` | the Redmine status name |
+| `subtype` | the mapped subtype for the tracker |
+| `source` | the issue URL (when a host name is configured) |
+| `dateCreated`, `dateModified` | timestamps |
+| `location` | the issue geometry as GeoJSON, when present |
+| `refersTo` | the entity that triggered the issue, when it came from a notification |
+
+Optionally, per tracker mapping (all off by default):
+
+- **Published attributes**: description, priority, category, target version,
+  start and due date, estimated time, % done, parent (as a link to the parent
+  issue's entity), assignee. Publishing the assignee's name to a shared broker
+  is an explicit decision.
+- **Published custom fields**: each with its own term name, typed by the
+  field's format.
+
+## Authentication
+
+Emission runs on the server, so it can only authenticate with a connection's
+*stored* token. Connections without a token emit unauthenticated, which works
+for open brokers.
+
+## Public identity and the entity id
+
+Entity ids follow `urn:ngsi-ld:Issue:redmine:<instance-id>:<issue-id>` and
+stay stable for the life of the issue.
+
+When **Administration → Settings → Host name** is configured, emitted entities
+also reference the instance's own context document (see below), so their terms
+resolve through the published vocabulary. Without a host name, entities are
+emitted with the NGSI-LD core context only; they are still valid, but
+cross-organization queries based on the published vocabulary will not find
+them. For federation, configure the host name.
+
+## The published schema
+
+- The core vocabulary is published at
+  <https://gtt-project.org/ns/fiware>: the terms every emitting instance uses
+  with the same meaning.
+- Each instance serves its own context at `GET /fiware/context.jsonld`
+  (public): the configured subtypes, declared as subclasses of the core
+  `Issue`, and every exposed attribute term. Reading this one URL is enough to
+  interpret the instance's entities.
+
+## Issues as NGSI-LD on demand
+
+Every issue is also available as an NGSI-LD entity at
+`GET /fiware/issues/<id>/entity` (session or API key; the issue page links to
+it as "Also available as: NGSI-LD"). This returns the same representation the
+emitter publishes.

--- a/doc/plugin_settings.md
+++ b/doc/plugin_settings.md
@@ -1,21 +1,26 @@
-# Redmine GTT FIWARE Plugin Settings
+# Plugin Settings
 
-This page provides an overview of the settings available for the Redmine GTT
-FIWARE plugin. The plugin is designed to manage subscriptions for a FIWARE
-context broker, allowing the creation of Redmine issues through FIWARE
-notifications.
+Administration → Plugins → Redmine GTT FIWARE plugin → Configure.
 
-![Plugin Settings Screenshot](plugin_settings.png)
+Broker URLs, authentication and throttling are not configured here: they live
+on [FIWARE Connections](broker_connections.md) since version 3.0.
 
-## FIWARE Broker Settings
+## Issue Emission
 
-### Subscription Throttling
+- **Instance identifier**: letters, digits, hyphen and underscore. It becomes
+  part of every emitted entity id
+  (`urn:ngsi-ld:Issue:redmine:<instance>:<issue>`), so other organizations can
+  tell your work orders apart from theirs. [Issue emission](issue_emission.md)
+  stays off while this is blank. Choose it once and keep it: changing it later
+  re-identifies every emitted entity.
 
-- **Description**: Limits the number of subscription notifications per second.
-- **Connect via internal proxy**: If enabled, the plugin will connect to the
-  FIWARE broker through an internal proxy.
-- **Default**: 10
+## Notification Attachment Downloads
 
-## Applying Settings
+Attachments referenced in broker notifications are downloaded over HTTPS only,
+from an allowlist of hosts.
 
-After configuring the settings, click the **Apply** button to save your changes.
+- **Additional allowed hosts**: one host per line. The subscription template's
+  broker host is always allowed.
+- **Allowed content types**: one content type per line; wildcards like
+  `image/*` are supported. Leave blank for the default list (common image
+  formats, PDF, plain text, CSV, JSON).

--- a/doc/plugin_settings.md
+++ b/doc/plugin_settings.md
@@ -19,7 +19,7 @@ on [FIWARE Connections](broker_connections.md) since version 3.0.
 Attachments referenced in broker notifications are downloaded over HTTPS only,
 from an allowlist of hosts.
 
-- **Additional allowed hosts**: one host per line. The subscription template's
+- **Additional allowed hosts**: one host per line. The subscription's
   broker host is always allowed.
 - **Allowed content types**: one content type per line; wildcards like
   `image/*` are supported. Leave blank for the default list (common image

--- a/doc/project_settings.md
+++ b/doc/project_settings.md
@@ -28,7 +28,7 @@ settings. It lists the project's subscriptions and offers:
   - **Synchronize**: fetches the subscription's state from the broker and
     updates the local status (for example when it was removed or expired on
     the broker side).
-  - **Delete**: removes the template in Redmine.
+  - **Delete**: removes the subscription in Redmine.
 
 The table shows each subscription's connection details (NGSI standard, broker
 URL), the issue defaults (status, tracker) and the subscription status

--- a/doc/project_settings.md
+++ b/doc/project_settings.md
@@ -1,67 +1,35 @@
 # Project Settings
 
-## Enabling the Plugin for a Project
+## Modules
 
-To use the plugin, it needs to be enabled for each project. Once enabled, a
-**FIWARE** tab will appear in the project settings.
+The plugin provides two project modules (project → Settings → Modules):
 
-1. Go to the project where you want to enable the plugin.
-2. Navigate to **Settings**.
-3. Click on the **Modules** tab.
-4. Check the **GTT FIWARE** module to enable it.
-5. Click **Save**.
+- **GTT FIWARE**: enables the FIWARE tab and subscriptions for the project.
+- **GTT FIWARE Issue Emission**: opts the project's issues into
+  [issue emission](issue_emission.md). This is a separate module on purpose:
+  publishing issue data to a broker is an explicit decision, never a side
+  effect of using subscriptions.
 
-## FIWARE Tab in Project Settings
+## The FIWARE tab
 
-After enabling the plugin for the project, the **FIWARE** tab will appear in the
-project settings. This tab allows you to create and manage subscription templates.
+With the GTT FIWARE module enabled, a **FIWARE** tab appears in the project
+settings. It lists the project's subscriptions and offers:
 
-![Project Settings - FIWARE Tab](project_settings.png)
+- **New Subscription**: opens the
+  [subscription form](subscription_template.md).
+- For each subscription:
+  - **Clipboard**: copies a cURL command that registers the subscription on
+    the broker. Useful when the broker is not reachable from the Redmine
+    server (a stored token is replaced by a `<token>` placeholder).
+  - **Publish / Unpublish**: register or remove the subscription on the
+    broker. For connections with a stored token this runs on the server; for
+    relayed and browser connections, a token box above the list takes the
+    token for the request.
+  - **Synchronize**: fetches the subscription's state from the broker and
+    updates the local status (for example when it was removed or expired on
+    the broker side).
+  - **Delete**: removes the template in Redmine.
 
-- **Authorization token**: Bearer token to be included in the request headers.
-  Leave empty for no authorization. The token is not stored in the database.
-  When the PROXY button is enabled (green), the request will be proxied through
-  the server.
-
-### Creating a New Subscription Template
-
-In the **FIWARE** tab, you can create a new subscription template by clicking on
-the **New Subscription Template** button. This will open a form where you can
-configure the template settings, see:
-
-- [Subscription Templates](subscription_template.md)
-
-### Managing Subscription Templates
-
-In the **FIWARE** tab, you can view, edit, and delete existing subscription
-templates. You can also copy the template settings cURL command to the clipboard.
-This can be useful if the context broker is not accessible from the Redmine server.
-
-In case the context broker is accessible from the Redmine server, you can also
-(un)publish a template directly if needed.
-
-### Subscription Templates Table
-
-The subscription templates table displays the existing templates with their key details:
-
-- **Name**: The name of the subscription template. By clicking on the name, you
-  can view and edit the template settings.
-- **NGSI standard**: The NGSI standard used (e.g., *NGSIv2*).
-- **Broker URL**: The URL of the FIWARE context broker.
-- **Issue status**: The status of the Redmine issue that will be created.
-- **Tracker**: The tracker to be used for the Redmine issue.
-- **Status**: The status of the subscription template (e.g., active, inactive, oneshot).
-
-#### Actions
-
-For each subscription template, you have the following actions available:
-
-- **Clipboard**: Copy the template settings to the clipboard. In case the
-  browser does not support clipboard copying, the cURL command will be also
-  displayed in the developer console.
-- **Publish**: Publish the subscription template to the context broker.
-- **Unpublish**: Unpublish the subscription template (if it is currently published).
-- **Delete**: Delete the subscription template.
-
-These settings allow you to customize how FIWARE notifications are handled and
-how Redmine issues are created or updated based on these notifications.
+The table shows each subscription's connection details (NGSI standard, broker
+URL), the issue defaults (status, tracker) and the subscription status
+(active, inactive, oneshot).

--- a/doc/subscription_template.md
+++ b/doc/subscription_template.md
@@ -2,7 +2,7 @@
 
 A subscription tells a context broker which entity changes to send to Redmine,
 and how to turn each notification into an issue. Subscriptions are managed per
-project: Settings → FIWARE → **New Subscription**.
+project: project → Settings → FIWARE → **New Subscription**.
 
 The form shows the essential fields first; everything else lives in three
 collapsible sections. A new subscription is publishable with just the visible

--- a/doc/subscription_template.md
+++ b/doc/subscription_template.md
@@ -1,159 +1,75 @@
-# Subscription Templates
+# Subscriptions
 
-This section provides detailed instructions on how to create or edit a
-subscription template in the Redmine GTT FIWARE plugin. Subscription templates
-allow you to define how FIWARE notifications should be handled and converted
-into Redmine issues.
+A subscription tells a context broker which entity changes to send to Redmine,
+and how to turn each notification into an issue. Subscriptions are managed per
+project: Settings → FIWARE → **New Subscription**.
 
-## Accessing the Subscription Template Page
+The form shows the essential fields first; everything else lives in three
+collapsible sections. A new subscription is publishable with just the visible
+fields.
 
-1. Navigate to the project where you want to create or edit a subscription template.
-2. Go to **Settings**.
-3. Click on the **FIWARE** tab.
-4. Click on **New Subscription Template** or select an existing template to edit.
+## Basics
 
-## General Settings
+- **Name** (required).
+- **FIWARE connection** (required): the broker to subscribe on; see
+  [FIWARE Connections](broker_connections.md). The form adapts to the
+  connection's NGSI standard, and fields that do not apply are hidden.
+- **Entities**: which entity types (and optionally id patterns or exact ids)
+  the subscription covers. The rows can also be edited as raw JSON.
+- **Tracker** and **Subject** (required): the issue defaults. Attribute
+  readings can be embedded anywhere in the issue texts as `${...}`
+  placeholders, for example `${id}`, `${type}`, `${temperature}` or
+  `${attrs.temperature.value}`.
+- **Preview with a sample entity**: renders the subject and description
+  against a real entity fetched from the broker, before anything is saved or
+  published.
 
-In the **General** section, you can configure the basic details of the
-subscription template.
+## Filters
 
-![General Settings](form_subscription_template_general.png)
+- **Watched attributes**: notify only when one of these attributes changes.
+- **Query**: an attribute condition, for example `severity>3`.
+- **Area**: no geographic filter, the project boundary, or a custom
+  georel/geometry/coordinates triple.
+- **Alteration types** and **Notify on metadata change**: which kinds of
+  entity changes notify (the options follow the connection's NGSI standard).
 
-- **NGSI standard**: Select the NGSI standard to be used (defaults to *NGSIv2*).
-- **Name** (required): Enter a descriptive name for the subscription template.
-- **Broker URL** (required): Specify the URL of the FIWARE context broker.
-- **Status** (required): Set the status of the subscription (*active*,
-  *inactive* or *oneshot*,).
-- **FIWARE Service** (optional): Define the FIWARE service.
-- **FIWARE Service Path** (optional): Specify the FIWARE service path.
-- **Expiration date** (optional): Set the expiration date for the subscription.
-- **Comment** (optional): Add any additional comments about the subscription template.
+## Issue details
 
-## Subscription Settings
+- **Description** and **Issue notes** templates (`${...}` placeholders work
+  here too). The notes template is used when a notification updates an
+  existing issue instead of creating a new one.
+- **Threshold (h)**: within this window, repeated notifications for the same
+  entity update the first issue (adding the notes) instead of creating
+  duplicates. `0` creates a new issue every time.
+- **Issue geometry**: the entity's location, a custom GeoJSON template, or
+  none.
+- **Attachments**: URLs (with `${...}` placeholders) downloaded and attached
+  to the issue; see the allowlist in the
+  [plugin settings](plugin_settings.md).
+- **Issue status, priority, category, version**: the created issue's fields.
+- **Sent from user** (required): the member the issues are authored as. Use a
+  dedicated user with just the needed permissions, not an administrator.
 
-In the **Subscription Settings** section, you can define the specifics of the
-subscription, including entities, attributes, and (geospatial) queries.
+## Subscription options
 
-![Subscription Settings](form_subscription_template_subscription.png)
+- **Subscription status**: active, inactive or oneshot (oneshot is NGSIv2
+  only).
+- **Expiration date**.
+- **NGSI-LD Context**: overrides the connection's default `@context`.
+- **Federation** and **Federation watch**: see [Federation](federation.md).
+- **Throttling (s)**: overrides the connection's throttling.
+- **Subscription ID**: set automatically when publishing; shown for
+  reference.
 
-- **Subscription ID**: (Read-only) The unique identifier for the subscription,
-  provided by the broker and automatically set when publishing through the plugin.
-- **Entities (array of)** (required): Define the entities that the subscription
-  applies to; Must be a valid JSON array of objects, for example:
+## Publishing
 
-  ```json
-  [
-    {
-      "idPattern": ".*",
-      "type": "Room"
-    }
-  ]
-  ```
+Publish from the FIWARE tab (or directly with **Create and publish** for
+connections with a stored token). The broker then confirms the subscription
+and its id is stored. **Synchronize** re-reads the subscription's state from
+the broker; **Unpublish** removes it.
 
-- **Attributes (array of)**: List the attributes that will trigger notifications
-  (e.g., `["temperature"]`). If left empty, all attributes will be considered.
-- **Query**: Specify the query condition (e.g., `temperature > 30`).
-- **Geospatial Query**: Define the geospatial query parameters. You must privide
-  all or none of the following fields:
-  - **Georel**: Set the geospatial relationship (e.g., `near;maxDistance:1000`).
-  - **Geometry**: Choose the geometry type (e.g., `Point`).
-  - **Coordinates**: Enter the coordinates (`latitude`,
-    `longitude`) for the geospatial query (e.g. `34.751,135.22;34.67,135.221;34.671,135.345;34.752,135.344;34.751,135.22`).
-  - **Insert project boundary**: Automatically insert the project boundary as
-    valid geospatial query.
-
-- **Alteration types**: Select the types of alterations that will trigger
-  notifications (e.g., `entityCreate`, `entityChange`, `entityUpdate`, `entityDelete`).
-- **Notify on metadata change**: Check if you want to receive notifications on
-  metadata changes (defaults to `true`).
-
-## Issue Template
-
-In the **Issue Template** section, you can define how the Redmine issue should
-be created or updated based on the subscription notifications.
-
-![Issue Template](form_subscription_template_issue.png)
-
-- **Tracker**: Select the tracker for the issue (e.g., *Work*).
-- **Subject**: Define the subject of the issue. You can embed attribute readings
-  using `${variable}`, for example:
-
-  ```text
-  Temperature Alert in ${Room}
-  ```
-
-- **Description**: Provide the description for the issue. You can embed
-  attribute readings using `${variable}`, for example:
-
-  ```markdown
-  The sensor in room ${Room} recorded a temperature of ${temperature}°C.
-  - [ ] Open window
-  - [ ] Turn on the air conditioning
-  ```
-
-- **Notes**: Configure to post an issue note instead of creating a new issue if
-  an issue has been created within the threshold. You can embed attribute
-  readings using `${variable}`.
-- **Threshold (h)**: Set the threshold to create a new issue in hours. Subsequent
-  notifications will be added as notes to the existing issue if the threshold
-  has not been exceeded. Set to `0` to always create a new issue.
-- **Issue geometry (GeoJSON)** (optional): Define the issue geometry using
-  GeoJSON. You can embed attribute readings using `${variable}`, for example:
-
-  ```json
-  {
-    "type": "Feature",
-    "geometry": "${location}"
-  }
-  ```
-
-  You must use quotes around the `${variable}` to ensure the GeoJSON is valid!
-
-- **Attachments (array of)** (optional): List any attachments to be included in
-  the issue. You must provide a valid JSON array of objects. Each object must
-  have the `url` field set to the URL of the attachment, and optionally the
-  `filename` and `description` fields. You may embed attribute readings using
-  `${variable}`, for example:
-
-  ```json
-  [
-    {
-      "filename": "image.jpg",
-      "description": "Image of the room",
-      "url": "${image_url}"
-    }
-  ]
-  ```
-
-  For security reasons, attachment downloads are restricted:
-
-  - Only `https` URLs are downloaded.
-  - The URL host must be the subscription template's broker host, or one
-    of the additional hosts configured in the plugin settings
-    (*Administration → Plugins → Redmine GTT FIWARE plugin → Configure*).
-  - Hosts that resolve to private, loopback, or otherwise non-public
-    addresses are rejected, and redirects are not followed.
-  - The response content type must be on the configured allowlist
-    (images, PDF, plain text, CSV, and JSON by default), and downloads
-    are limited by Redmine's maximum attachment size.
-
-  Rejected attachments are skipped and logged; the issue itself is still
-  created or updated.
-
-- **Issue status**: Set the status of the issue (e.g., *New*).
-- **Priority**: Define the priority of the issue (e.g., *Normal*).
-- **Issue category**: Select the issue category. Categories can be created in
-  the project settings.
-- **Version**: Specify the version. Versions can be created in the project settings.
-- **Sent from user**: Select the user from whom the issue is sent. The user must
-  have the necessary permissions to create issues in this project. Notifications
-  from the broker are authenticated by a per-template webhook secret (rotated on
-  every publish), not by this user's Redmine API key, so no Redmine credential is
-  stored on the broker. Still, **for security reasons prefer a dedicated,
-  non-administrator user** for this role.
-- **Private**: Check if the issue should be marked *private*.
-
-## Applying Settings
-
-After configuring all the sections, click the **Create** button to save the new
-subscription template or **Create and add another** to save and create another template.
+The notification endpoint that receives the broker's callbacks is
+authenticated by a per-subscription secret, generated automatically and
+included when publishing. Callback URLs are built from
+**Administration → Settings → Host name**, so make sure it is set to a host
+the broker can reach.


### PR DESCRIPTION
The `doc/` folder still described the pre-3.0 plugin: broker settings in the plugin configuration, the flat one-page template form, and nothing about emission or federation. This brings it up to date with v3.1.

- **plugin_settings.md**: rewritten — instance identifier and attachment downloads; everything that moved to connections points there.
- **broker_connections.md** (new): fields, the three authentication modes, token header, the per-tracker emission mapping section.
- **issue_emission.md** (new): the three things that enable emission, the published core and optional properties, authentication, public identity, the published schema, the on-demand entity endpoint.
- **federation.md** (new): creation policies (annotate/suppress), the "Also handled by" panel, federation watch setup, requirements and matching rules.
- **project_settings.md**: rewritten — the two modules (emission deliberately separate), the FIWARE tab actions including Synchronize.
- **subscription_template.md**: rewritten for the current form — connection select, collapsible sections, `${...}` placeholders, live preview, threshold semantics, federation options, publish/sync lifecycle.
- **index.md**: first steps in actual configuration order; links to the new pages and the published vocabulary at gtt-project.org/ns/fiware.

Screenshots of the old flat form (`form_subscription_template_*.png`, `plugin_settings.png`) are now unreferenced; left in place for a follow-up with fresh captures.

Docs only, no code changes.