### PR TITLE
Issue details follow the selected tracker (phase 1)

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -10,7 +10,6 @@ class SubscriptionTemplatesController < ApplicationController
   protect_from_forgery with: :exception
 
   before_action :find_project_by_project_id, except: [:index, :set_subscription_id]
-  before_action :get_issue_statuses, only: [:new, :create, :edit, :update]
   before_action :get_issue_priorities, only: [:new, :create, :edit, :update]
   before_action :get_issue_categories, only: [:new, :create, :edit, :update]
   before_action :find_subscription_template, only: [:edit, :update, :destroy, :copy, :publish, :unpublish, :sync, :update_subscription_id]
@@ -25,7 +24,7 @@ class SubscriptionTemplatesController < ApplicationController
   accept_api_auth :set_subscription_id
   before_action :authorize, except: [:set_subscription_id]
 
-  helper_method :index_path
+  helper_method :index_path, :form_issue_statuses
 
   def index
     @subscription_templates = subscription_template_scope
@@ -43,6 +42,16 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def edit; end
+
+  # The statuses a new issue can take for a tracker/member pair (#103): the
+  # same workflow data the regular issue form uses. Fetched by the form when
+  # the tracker or the "Sent from user" member changes.
+  def allowed_statuses
+    tracker = @project.trackers.find_by(id: params[:tracker_id])
+    member = @project.members.find_by(id: params[:member_id])
+    statuses = allowed_issue_statuses(tracker: tracker, member: member)
+    render json: statuses.map { |s| { id: s.id, name: s.name } }
+  end
 
   def create
     r = RedmineGttFiware::SaveSubscriptionTemplate.(subscription_template_params, project: @project)
@@ -389,8 +398,36 @@ class SubscriptionTemplatesController < ApplicationController
     SubscriptionTemplate.where(project_id: @project.id).order(name: :asc)
   end
 
-  def get_issue_statuses
-    @issue_statuses = IssueStatus.all.sorted
+  # The status list the form renders initially (#103): workflow-allowed for
+  # the template's tracker and member, falling back to the full list when the
+  # pair is not known yet. Lazy (helper_method) because @subscription_template
+  # is built inside the actions, after before_actions ran.
+  def form_issue_statuses
+    @form_issue_statuses ||= allowed_issue_statuses(
+      tracker: @subscription_template&.tracker || @project.trackers.first,
+      member: @subscription_template&.member,
+      current_status: @subscription_template&.issue_status
+    )
+  end
+
+  # Mirrors the regular issue form: a new issue authored by the member's user
+  # can start at the tracker default and take the workflow's new-issue
+  # transitions for the member's roles. Falls back to the full sorted list
+  # when the tracker or a User principal is missing (e.g. group members), and
+  # keeps a stored status in the list so an edit never silently drops it.
+  def allowed_issue_statuses(tracker:, member:, current_status: nil)
+    user = member&.principal
+    statuses =
+      if tracker && user.is_a?(User)
+        issue = Issue.new(project: @project, tracker: tracker)
+        issue.author = user
+        allowed = issue.new_statuses_allowed_to(user, true)
+        allowed.presence || IssueStatus.sorted.to_a
+      else
+        IssueStatus.sorted.to_a
+      end
+    statuses |= [current_status] if current_status
+    statuses
   end
 
   def get_issue_categories

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -73,6 +73,10 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   validate :attrs_must_be_array_of_strings
   validate :geo_query_fields_must_be_all_or_none
 
+  # A tracker that disables a core field must not keep a stored value for it
+  # (#103): the form hides the selects, but hidden inputs still submit, and
+  # the form is not the only writer.
+  before_validation :clear_tracker_disabled_fields
   before_save :serialize_alteration_types
   after_find :deserialize_alteration_types
 
@@ -217,6 +221,14 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     self.attachments = parsed
   rescue JSON::ParserError
     errors.add :attachments_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
+  end
+
+  def clear_tracker_disabled_fields
+    return unless tracker
+    disabled = tracker.disabled_core_fields
+    self.issue_priority_id = nil if disabled.include?('priority_id')
+    self.issue_category_id = nil if disabled.include?('category_id')
+    self.version_id = nil if disabled.include?('fixed_version_id')
   end
 
   def serialize_alteration_types

--- a/app/views/subscription_templates/_form_basics.html.erb
+++ b/app/views/subscription_templates/_form_basics.html.erb
@@ -51,7 +51,10 @@
 
   <p class="min-width">
     <%= content_tag :label, l(:label_tracker) %>
-    <%= f.collection_select :tracker_id, @project.trackers, :id, :name %>
+    <%# data-disabled-fields drives the tracker-aware Issue details (#103):
+        the form hides core fields the selected tracker disables. %>
+    <%= f.collection_select :tracker_id, @project.trackers, :id, :name, {},
+          data: { disabled_fields: @project.trackers.each_with_object({}) { |t, h| h[t.id] = t.disabled_core_fields }.to_json } %>
   </p>
 
   <p><%= f.text_field :subject, required: true, size: 75, placeholder: l(:field_subscription_template_subject_placeholder) %>

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -58,19 +58,23 @@
           value: (@subscription_template.attachments.presence ? JSON.pretty_generate(@subscription_template.attachments) : '') %>
   </p>
 
+  <%# Issue details follow the selected tracker (#103): the status list is
+      workflow-allowed for the tracker/member pair (refetched by the form JS
+      on change), and core fields the tracker disables are hidden. %>
   <p class="min-width">
     <%= content_tag :label, l(:label_issue_status) %>
-    <%= f.collection_select :issue_status_id, @issue_statuses, :id, :name %>
+    <%= f.collection_select :issue_status_id, form_issue_statuses, :id, :name, {},
+          data: { statuses_url: allowed_statuses_project_subscription_templates_path(@project) } %>
   </p>
-  <p class="min-width">
+  <p class="min-width js-issue-core-field" data-field="priority_id">
     <%= content_tag :label, l(:field_priority) %>
     <%= f.collection_select :issue_priority_id, @issue_priorities, :id, :name %>
   </p>
-  <p class="min-width">
+  <p class="min-width js-issue-core-field" data-field="category_id">
     <%= content_tag :label, l(:label_issue_category) %>
     <%= f.collection_select :issue_category_id, @issue_categories, :id, :name, include_blank: true %>
   </p>
-  <p class="min-width">
+  <p class="min-width js-issue-core-field" data-field="fixed_version_id">
     <%= content_tag :label, l(:label_version) %>
     <%= f.collection_select :version_id, @project.versions, :id, :name, include_blank: true %>
   </p>

--- a/assets/javascripts/gtt_fiware_form.js
+++ b/assets/javascripts/gtt_fiware_form.js
@@ -232,7 +232,14 @@
       if (!trackerSelect || !trackerSelect.dataset.disabledFields) { return; }
       var disabled = JSON.parse(trackerSelect.dataset.disabledFields)[trackerSelect.value] || [];
       document.querySelectorAll('.js-issue-core-field').forEach(function(p) {
-        p.style.display = disabled.indexOf(p.dataset.field) === -1 ? '' : 'none';
+        var hidden = disabled.indexOf(p.dataset.field) !== -1;
+        p.style.display = hidden ? 'none' : '';
+        // A hidden select would still submit its value; clear it so the form
+        // matches what the model persists (it clears tracker-disabled fields
+        // server-side too).
+        if (hidden) {
+          p.querySelectorAll('select').forEach(function(select) { select.value = ''; });
+        }
       });
     }
 

--- a/assets/javascripts/gtt_fiware_form.js
+++ b/assets/javascripts/gtt_fiware_form.js
@@ -219,6 +219,66 @@
     connectionSelect.addEventListener('change', applyStandard);
     applyStandard();
 
+    // --- tracker-driven issue details (#103) ----------------------------------
+    // Core fields the selected tracker disables are hidden, and the issue
+    // status select is refetched for the tracker/member pair so it offers
+    // the same statuses the regular issue form would.
+
+    var trackerSelect = document.getElementById('subscription_template_tracker_id');
+    var memberSelect = document.getElementById('subscription_template_member_id');
+    var issueStatusSelect = document.getElementById('subscription_template_issue_status_id');
+
+    function applyTrackerFields() {
+      if (!trackerSelect || !trackerSelect.dataset.disabledFields) { return; }
+      var disabled = JSON.parse(trackerSelect.dataset.disabledFields)[trackerSelect.value] || [];
+      document.querySelectorAll('.js-issue-core-field').forEach(function(p) {
+        p.style.display = disabled.indexOf(p.dataset.field) === -1 ? '' : 'none';
+      });
+    }
+
+    function refreshIssueStatuses() {
+      if (!issueStatusSelect || !issueStatusSelect.dataset.statusesUrl) { return; }
+      var url = issueStatusSelect.dataset.statusesUrl +
+        '?tracker_id=' + encodeURIComponent(trackerSelect ? trackerSelect.value : '') +
+        '&member_id=' + encodeURIComponent(memberSelect ? memberSelect.value : '');
+      fetch(url, { headers: { 'Accept': 'application/json' } })
+        .then(function(response) { return response.json(); })
+        .then(function(statuses) {
+          var current = issueStatusSelect.value;
+          var currentText = issueStatusSelect.selectedOptions[0] ?
+            issueStatusSelect.selectedOptions[0].textContent : '';
+          issueStatusSelect.innerHTML = '';
+          statuses.forEach(function(status) {
+            var option = document.createElement('option');
+            option.value = String(status.id);
+            option.textContent = status.name;
+            issueStatusSelect.appendChild(option);
+          });
+          // Keep the previous choice even when the new pair would not offer
+          // it: silently changing a stored value is worse than showing it.
+          if (current && !issueStatusSelect.querySelector('option[value="' + current + '"]')) {
+            var keep = document.createElement('option');
+            keep.value = current;
+            keep.textContent = currentText;
+            issueStatusSelect.appendChild(keep);
+          }
+          if (current) { issueStatusSelect.value = current; }
+          if (issueStatusSelect.selectedIndex === -1) { issueStatusSelect.selectedIndex = 0; }
+        })
+        .catch(function() { /* keep the current list when the lookup fails */ });
+    }
+
+    if (trackerSelect) {
+      trackerSelect.addEventListener('change', function() {
+        applyTrackerFields();
+        refreshIssueStatuses();
+      });
+      applyTrackerFields();
+    }
+    if (memberSelect) {
+      memberSelect.addEventListener('change', refreshIssueStatuses);
+    }
+
     // --- live preview (#68) ---------------------------------------------------
 
     function previewEntityType() {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ scope 'projects/:project_id' do
       # collection route. POST (it carries form state), CSRF-protected (the
       # form JS sends the token header).
       post :preview
+      # Workflow-allowed issue statuses for a tracker/member pair (#103):
+      # read-only lookup the form calls when either select changes.
+      get :allowed_statuses
     end
     member do
       # copy is read-only (it prefills a curl command), so it stays GET.

--- a/init.rb
+++ b/init.rb
@@ -39,7 +39,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   # Project module configuration with permissions
   project_module :gtt_fiware do
     permission :manage_subscription_templates, {
-      subscription_templates: %i( new edit update create destroy copy preview publish unpublish sync update_subscription_id set_subscription_id),
+      subscription_templates: %i( new edit update create destroy copy preview allowed_statuses publish unpublish sync update_subscription_id set_subscription_id),
       projects: %i( manage_subscription_templates )
     }, require: :member
   end

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -258,6 +258,60 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_select 'a.js-attachment-remove svg'
   end
 
+  # --- tracker-driven issue details (#103) --------------------------------
+
+  # The form carries the hooks the JS drives: the per-tracker disabled-fields
+  # map, the statuses endpoint, and the hideable core-field wrappers.
+  def test_new_form_carries_tracker_driven_issue_details_hooks
+    tracker = Tracker.find(1)
+    tracker.core_fields = Tracker::CORE_FIELDS - ['category_id']
+    tracker.save!
+
+    get :new, params: { project_id: @project.id }
+    assert_response :success
+    assert_select 'select#subscription_template_tracker_id[data-disabled-fields*=?]', 'category_id'
+    assert_select 'select#subscription_template_issue_status_id[data-statuses-url=?]',
+                  "/projects/#{@project.identifier}/subscription_templates/allowed_statuses"
+    %w[priority_id category_id fixed_version_id].each do |field|
+      assert_select "p.js-issue-core-field[data-field=?]", field
+    end
+  end
+
+  def test_allowed_statuses_returns_the_workflow_statuses_for_the_pair
+    WorkflowTransition.create!(tracker_id: 1, role_id: 1, old_status_id: 0, new_status_id: 2)
+
+    get :allowed_statuses, params: { project_id: @project.id, tracker_id: 1, member_id: 1 }
+    assert_response :success
+    ids = JSON.parse(response.body).map { |s| s['id'] }
+    # The new-issue transition target plus the tracker's default status.
+    assert_equal [Tracker.find(1).default_status_id, 2].sort, ids.sort
+  end
+
+  def test_allowed_statuses_falls_back_to_all_statuses_for_an_unknown_pair
+    get :allowed_statuses, params: { project_id: @project.id, tracker_id: '', member_id: '' }
+    assert_response :success
+    assert_equal IssueStatus.count, JSON.parse(response.body).size
+  end
+
+  def test_allowed_statuses_requires_login
+    @request.session[:user_id] = nil
+    get :allowed_statuses, params: { project_id: @project.id, tracker_id: 1, member_id: 1 }
+    assert_response :redirect
+  end
+
+  # The initially rendered status select is already reduced, and a stored
+  # status the workflow would no longer offer stays in the list instead of
+  # being silently dropped.
+  def test_edit_reduces_the_status_select_and_keeps_the_stored_status
+    WorkflowTransition.create!(tracker_id: 1, role_id: 1, old_status_id: 0, new_status_id: 2)
+    @template.update_columns(issue_status_id: 5)
+
+    get :edit, params: { project_id: @project.id, id: @template.id }
+    assert_response :success
+    values = css_select('select#subscription_template_issue_status_id option').map { |o| o['value'].to_i }
+    assert_equal [Tracker.find(1).default_status_id, 2, 5].sort, values.sort
+  end
+
   # Sections with stored values are expanded on edit so nothing is hidden.
   def test_edit_expands_sections_that_contain_values
     @template.update_column(:expression_query, 'temperature>30')

--- a/test/javascripts/issue_details.test.js
+++ b/test/javascripts/issue_details.test.js
@@ -42,6 +42,16 @@ describe('disabled core fields', () => {
     expect(qs('[data-field="category_id"]').style.display).toBe('');
     expect(qs('[data-field="fixed_version_id"]').style.display).toBe('');
   });
+
+  it('clears a hidden select so it does not submit a stale value', () => {
+    buildForm();
+    initForm();
+    const category = qs('[data-field="category_id"] select');
+    category.innerHTML = '<option value=""></option><option value="7" selected>Bugs</option>';
+    stubStatuses([]);
+    changeTracker('2');
+    expect(category.value).toBe('');
+  });
 });
 
 describe('status refetch', () => {

--- a/test/javascripts/issue_details.test.js
+++ b/test/javascripts/issue_details.test.js
@@ -1,0 +1,101 @@
+// Tracker-driven issue details (#103): core fields the selected tracker
+// disables are hidden, and the issue status select is refetched for the
+// tracker/member pair.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { buildForm, initForm, loadScript } from './support/form_fixture.js';
+
+beforeAll(loadScript);
+afterEach(() => vi.unstubAllGlobals());
+
+const qs = (sel) => document.querySelector(sel);
+const trackerSelect = () => document.getElementById('subscription_template_tracker_id');
+const statusSelect = () => document.getElementById('subscription_template_issue_status_id');
+
+function changeTracker(value) {
+  trackerSelect().value = value;
+  trackerSelect().dispatchEvent(new window.Event('change', { bubbles: true }));
+}
+
+function stubStatuses(statuses) {
+  const calls = [];
+  vi.stubGlobal('fetch', (url) => {
+    calls.push(url);
+    return Promise.resolve({ json: () => Promise.resolve(statuses) });
+  });
+  return calls;
+}
+
+// fetch resolution is async; one macrotask tick lets the handlers run.
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('disabled core fields', () => {
+  it('hides the fields the selected tracker disables, on init and on change', () => {
+    buildForm({ selectedTracker: '2' });
+    initForm();
+    expect(qs('[data-field="category_id"]').style.display).toBe('none');
+    expect(qs('[data-field="fixed_version_id"]').style.display).toBe('none');
+    expect(qs('[data-field="priority_id"]').style.display).toBe('');
+
+    stubStatuses([]);
+    changeTracker('1');
+    expect(qs('[data-field="category_id"]').style.display).toBe('');
+    expect(qs('[data-field="fixed_version_id"]').style.display).toBe('');
+  });
+});
+
+describe('status refetch', () => {
+  it('asks the endpoint for the tracker/member pair', async () => {
+    buildForm();
+    initForm();
+    const calls = stubStatuses([{ id: 1, name: 'New' }]);
+    changeTracker('2');
+    await tick();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('tracker_id=2');
+    expect(calls[0]).toContain('member_id=10');
+  });
+
+  it('rebuilds the select and keeps the current choice when still offered', async () => {
+    buildForm({ selectedIssueStatus: '2' });
+    initForm();
+    stubStatuses([{ id: 2, name: 'In Progress' }, { id: 3, name: 'Resolved' }]);
+    changeTracker('2');
+    await tick();
+    const values = Array.from(statusSelect().options).map(o => o.value);
+    expect(values).toEqual(['2', '3']);
+    expect(statusSelect().value).toBe('2');
+  });
+
+  it('appends the stored choice when the new pair does not offer it', async () => {
+    buildForm({ selectedIssueStatus: '1' });
+    initForm();
+    stubStatuses([{ id: 3, name: 'Resolved' }]);
+    changeTracker('2');
+    await tick();
+    const options = Array.from(statusSelect().options).map(o => [o.value, o.textContent]);
+    expect(options).toEqual([['3', 'Resolved'], ['1', 'New']]);
+    expect(statusSelect().value).toBe('1');
+  });
+
+  it('refetches when the member changes', async () => {
+    buildForm();
+    initForm();
+    const calls = stubStatuses([{ id: 1, name: 'New' }]);
+    const member = document.getElementById('subscription_template_member_id');
+    member.value = '11';
+    member.dispatchEvent(new window.Event('change', { bubbles: true }));
+    await tick();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('member_id=11');
+  });
+
+  it('keeps the current list when the lookup fails', async () => {
+    buildForm();
+    initForm();
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('down')));
+    changeTracker('2');
+    await tick();
+    expect(Array.from(statusSelect().options)).toHaveLength(2);
+  });
+});

--- a/test/javascripts/support/form_fixture.js
+++ b/test/javascripts/support/form_fixture.js
@@ -68,7 +68,14 @@ export function buildForm({
   geometryMode = 'location',
   geoMode = 'anywhere',
   status = 'active',
-  alterationChecked = ['entityCreate', 'entityChange']
+  alterationChecked = ['entityCreate', 'entityChange'],
+  // Tracker-driven issue details (#103). trackerDisabledFields maps tracker
+  // id -> disabled core fields, like the data attribute the ERB renders.
+  trackerDisabledFields = { 1: [], 2: ['category_id', 'fixed_version_id'] },
+  selectedTracker = '1',
+  issueStatuses = [{ id: 1, name: 'New' }, { id: 2, name: 'In Progress' }],
+  selectedIssueStatus = '1',
+  statusesUrl = '/projects/demo/subscription_templates/allowed_statuses'
 } = {}) {
   const checked = (type) => (alterationChecked.includes(type) ? 'checked' : '');
   const ldTriggers = {
@@ -140,6 +147,22 @@ export function buildForm({
         <option value="inactive" ${status === 'inactive' ? 'selected' : ''}>inactive</option>
         <option value="oneshot" ${status === 'oneshot' ? 'selected' : ''}>oneshot</option>
       </select>
+
+      <select id="subscription_template_tracker_id" data-disabled-fields='${JSON.stringify(trackerDisabledFields)}'>
+        ${Object.keys(trackerDisabledFields).map(id =>
+          `<option value="${id}" ${id === selectedTracker ? 'selected' : ''}>Tracker ${id}</option>`).join('')}
+      </select>
+      <select id="subscription_template_member_id">
+        <option value="10" selected>Aiko Tanaka</option>
+        <option value="11">Ben Okafor</option>
+      </select>
+      <select id="subscription_template_issue_status_id" data-statuses-url="${statusesUrl}">
+        ${issueStatuses.map(s =>
+          `<option value="${s.id}" ${String(s.id) === selectedIssueStatus ? 'selected' : ''}>${s.name}</option>`).join('')}
+      </select>
+      <p class="min-width js-issue-core-field" data-field="priority_id"><select></select></p>
+      <p class="min-width js-issue-core-field" data-field="category_id"><select></select></p>
+      <p class="min-width js-issue-core-field" data-field="fixed_version_id"><select></select></p>
 
       <input type="submit" name="publish_after_create" value="Create and publish" />
     </form>`;

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -36,6 +36,31 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert template.save
   end
 
+  # #103: a tracker that disables a core field must not keep a stored value
+  # for it - the form hides the selects, but hidden inputs still submit.
+  def test_save_clears_fields_the_tracker_disables
+    tracker = Tracker.find(1)
+    tracker.core_fields = Tracker::CORE_FIELDS - %w[category_id fixed_version_id priority_id]
+    tracker.save!
+    category = IssueCategory.create!(project_id: 1, name: 'Field test')
+    version = Version.create!(project_id: 1, name: 'Field test 1.0')
+
+    template = SubscriptionTemplate.create!(valid_attributes(
+      issue_category_id: category.id,
+      version_id: version.id,
+      issue_priority_id: IssuePriority.first.id
+    ))
+    assert_nil template.issue_category_id
+    assert_nil template.version_id
+    assert_nil template.issue_priority_id
+  end
+
+  def test_save_keeps_fields_the_tracker_allows
+    category = IssueCategory.create!(project_id: 1, name: 'Field test')
+    template = SubscriptionTemplate.create!(valid_attributes(issue_category_id: category.id))
+    assert_equal category.id, template.issue_category_id
+  end
+
   def test_default_alteration_types
     template = SubscriptionTemplate.new
     assert_equal ['entityCreate', 'entityChange'], template.alteration_types


### PR DESCRIPTION
Phase 1 of #103.

## What

The tracker select and the Issue details section were independent: the form always offered status, priority, category and version, no matter the tracker, so a template could be configured with combinations the created issue silently drops or that the regular issue form would never offer.

- **Disabled core fields**: the tracker select carries a per-tracker `data-disabled-fields` map (`Tracker#disabled_core_fields`), and the priority/category/version wrappers are marked `js-issue-core-field` - the form hides them for the selected tracker. (Of the disablable core fields, only these three appear on the template form; description stays, it is the required notification body template.)
- **Workflow-allowed statuses**: the issue status select now offers what the regular issue form would - `new_statuses_allowed_to` for the template's *Sent from user* member and the selected tracker.
  - The initially rendered list is already reduced server-side (lazy `form_issue_statuses` helper, so validation-failed re-renders stay correct).
  - A read-only `GET allowed_statuses` collection route serves the form JS when the tracker or member changes.
  - A stored status the workflow would no longer offer stays in the list (appended) instead of being silently swapped.
  - Unknown pairs - no tracker yet, or a group member - fall back to the full sorted list.

**Phase 2** (per-tracker custom fields with `${...}` templating, applied through `safe_attributes`) stays open on #103.

## Verification

- Rails suite: 258 runs, 928 assertions, 0 failures - covers the endpoint (workflow reduction, fallback, login), the DOM contract (data attributes, wrappers), and the initial server-side reduction incl. the keep-stored-status rule
- JS suite: 42 tests - field hiding on init/change, refetch per pair, keep-current/append-stored choice, member-change refetch, lookup-failure fallback
- Live smoke on the demo instance: switching Task -> Support (category+version disabled there) hides both fields and refetches the status list; no console errors