### PR TITLE
Custom field templates per tracker (phase 2)

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -440,7 +440,7 @@ class SubscriptionTemplatesController < ApplicationController
 
   def subscription_template_params
     params[:subscription_template][:alteration_types] ||= []
-    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, alteration_types: [])
+    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, alteration_types: [], issue_custom_field_values: {})
   end
 
   # Stored connections supply their encrypted token server-side; browser-mode

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -28,6 +28,37 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   delegate :standard, :fiware_service, :fiware_servicepath, :ngsi_ld?, :stored_auth?,
            to: :broker_connection, allow_nil: true
 
+  # Per-tracker custom field templates (#103, phase 2): a JSON object mapping
+  # issue custom field ids (string keys) to template strings. Tolerant on
+  # read like EmissionMapping's coder: malformed stored JSON reads as {}.
+  class CustomFieldValuesCoder
+    def self.dump(value)
+      JSON.dump(value || {})
+    end
+
+    def self.load(value)
+      return {} if value.blank?
+
+      parsed = JSON.parse(value)
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue JSON::ParserError
+      {}
+    end
+  end
+
+  serialize :issue_custom_field_values, coder: CustomFieldValuesCoder
+
+  # Normalizes form input (ActionController::Parameters or a hash with mixed
+  # key types) into plain string keys and values, dropping blank templates so
+  # untouched inputs never store empty strings.
+  def issue_custom_field_values=(value)
+    hash = value.respond_to?(:to_h) && value ? value.to_h : {}
+    cleaned = hash.each_with_object({}) do |(key, template), result|
+      result[key.to_s] = template.to_s unless template.to_s.strip.empty?
+    end
+    super(cleaned)
+  end
+
   STATUS = ['active', 'inactive', 'oneshot'].freeze
 
   # Federation awareness at creation time (#70, 4a): what to do when another
@@ -229,6 +260,13 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     self.issue_priority_id = nil if disabled.include?('priority_id')
     self.issue_category_id = nil if disabled.include?('category_id')
     self.version_id = nil if disabled.include?('fixed_version_id')
+    # Same rule for custom fields: values for fields the tracker does not
+    # carry must not persist (the form disables their inputs, but the form is
+    # not the only writer).
+    if issue_custom_field_values.present?
+      allowed = tracker.custom_field_ids.map(&:to_s)
+      self.issue_custom_field_values = issue_custom_field_values.slice(*allowed)
+    end
   end
 
   def serialize_alteration_types

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -78,6 +78,30 @@
     <%= content_tag :label, l(:label_version) %>
     <%= f.collection_select :version_id, @project.versions, :id, :name, include_blank: true %>
   </p>
+  <%# Per-tracker custom fields (#103, phase 2): every tracker's fields are
+      rendered, grouped, and the form shows only the selected tracker's group
+      (hidden groups are disabled so they never submit). Values are template
+      strings; ${...} placeholders render against the notification entity. %>
+  <% @project.trackers.each do |tracker| %>
+    <% custom_fields = tracker.custom_fields.sorted & @project.all_issue_custom_fields %>
+    <% next if custom_fields.empty? %>
+    <%# fieldset because its disabled attribute disables every input inside:
+        hidden groups must not submit their values. %>
+    <fieldset class="js-tracker-custom-fields" data-tracker-id="<%= tracker.id %>"
+              <%= 'disabled style="display:none;"'.html_safe unless tracker.id == @subscription_template.tracker_id %>>
+      <% custom_fields.each do |custom_field| %>
+        <p>
+          <%= content_tag :label, custom_field.name, for: "gtt_fiware_custom_field_#{tracker.id}_#{custom_field.id}" %>
+          <%= text_field_tag "subscription_template[issue_custom_field_values][#{custom_field.id}]",
+                @subscription_template.issue_custom_field_values[custom_field.id.to_s],
+                id: "gtt_fiware_custom_field_#{tracker.id}_#{custom_field.id}", size: 40,
+                placeholder: '${...}' %>
+        </p>
+      <% end %>
+      <em class="info"><%= l(:text_issue_custom_field_values_info) %></em>
+    </fieldset>
+  <% end %>
+
   <p class="min-width">
     <%= content_tag :label, l(:field_subscription_template_notification_user) %>
     <%= f.collection_select :member_id, @project.members, :id, :name %>

--- a/assets/javascripts/gtt_fiware_form.js
+++ b/assets/javascripts/gtt_fiware_form.js
@@ -241,6 +241,13 @@
           p.querySelectorAll('select').forEach(function(select) { select.value = ''; });
         }
       });
+      // Custom field groups (#103, phase 2): show the selected tracker's
+      // group; hidden groups are disabled so their inputs never submit.
+      document.querySelectorAll('.js-tracker-custom-fields').forEach(function(group) {
+        var active = group.dataset.trackerId === trackerSelect.value;
+        group.style.display = active ? '' : 'none';
+        group.disabled = !active;
+      });
     }
 
     function refreshIssueStatuses() {

--- a/assets/stylesheets/gtt_fiware.css
+++ b/assets/stylesheets/gtt_fiware.css
@@ -73,3 +73,11 @@ form.new_subscription_template p.min-width select {
   width: auto;
   font-weight: normal;
 }
+
+/* Per-tracker custom field groups on the subscription form (#103): plain
+   grouping containers, not visual fieldsets. */
+fieldset.js-tracker-custom-fields {
+  border: none;
+  margin: 0;
+  padding: 0;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
   field_subscription_template_attachments_placeholder: "[{\"filename\": \"image.jpg\"\
     , \"url\": \"https://example.com/image.jpg\"}]"
   field_subscription_template_notification_user: "Sent from user"
+  text_issue_custom_field_values_info: "Custom fields of the selected tracker. ${...} placeholders render against the notification entity; blank fields are left unset."
   field_subscription_template_threshold_create_hours: "Threshold (h)"
   field_subscription_template_threshold_create_hours_hint: "Threshold to create new
     issue in hours."

--- a/db/migrate/20260731000000_add_issue_custom_field_values_to_subscription_templates.rb
+++ b/db/migrate/20260731000000_add_issue_custom_field_values_to_subscription_templates.rb
@@ -1,0 +1,8 @@
+# Per-tracker custom field templates (#103, phase 2): a JSON object mapping
+# issue custom field ids to template strings (${...} placeholders allowed),
+# applied through safe_attributes when a notification creates an issue.
+class AddIssueCustomFieldValuesToSubscriptionTemplates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fiware_subscription_templates, :issue_custom_field_values, :text
+  end
+end

--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -191,7 +191,23 @@ module RedmineGttFiware
       issue.fixed_version = @template.version
       issue.fiware_entity = entity.id
       issue.subscription_template_id = @template.id
+      apply_custom_field_values(issue, entity)
       issue
+    end
+
+    # Custom field templates (#103, phase 2), rendered against the entity and
+    # applied through safe_attributes so tracker availability and the acting
+    # member's per-role field permissions keep holding. Blank rendered values
+    # are skipped: the field is simply left unset.
+    def apply_custom_field_values(issue, entity)
+      templates = @template.issue_custom_field_values
+      return if templates.blank?
+
+      rendered = templates.each_with_object({}) do |(field_id, template), values|
+        value = render(template, entity)
+        values[field_id] = value unless value.to_s.strip.empty?
+      end
+      issue.safe_attributes = { 'custom_field_values' => rendered } if rendered.any?
     end
 
     def apply_new_geometry(issue, entity)

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -103,6 +103,37 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal @template.member.user_id, issue.author_id
   end
 
+  # Custom field templates (#103, phase 2) render against the entity and are
+  # applied through safe_attributes, so tracker availability and the acting
+  # member's field permissions keep holding.
+  def test_create_applies_rendered_custom_field_values
+    field = IssueCustomField.create!(
+      name: 'Reading', field_format: 'string', is_for_all: true,
+      trackers: [Tracker.find(1)]
+    )
+    @template.reload.update!(issue_custom_field_values: { field.id.to_s => 'reading ${attrs.temperature.value}' })
+
+    assert_difference 'Issue.count', 1 do
+      post_notification
+    end
+    issue = Issue.order(id: :desc).first
+    assert_equal 'reading 30', issue.custom_field_value(field)
+  end
+
+  def test_create_skips_custom_fields_that_render_blank
+    field = IssueCustomField.create!(
+      name: 'Missing', field_format: 'string', is_for_all: true,
+      trackers: [Tracker.find(1)]
+    )
+    @template.reload.update!(issue_custom_field_values: { field.id.to_s => '${attrs.nonexistent.value}' })
+
+    assert_difference 'Issue.count', 1 do
+      post_notification
+    end
+    issue = Issue.order(id: :desc).first
+    assert issue.custom_field_value(field).to_s.strip.empty?
+  end
+
   def enable_emission
     project = Project.find(1)
     project.enabled_module_names = project.enabled_module_names | ['gtt_fiware_emission']

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -1,8 +1,9 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class SubscriptionTemplatesControllerTest < ActionController::TestCase
-  fixtures :projects, :trackers, :issue_statuses, :users, :email_addresses,
-           :members, :member_roles, :roles, :enumerations, :enabled_modules
+  fixtures :projects, :trackers, :projects_trackers, :issue_statuses, :users,
+           :email_addresses, :members, :member_roles, :roles, :enumerations,
+           :enabled_modules
 
   # A value that would break out of a single-quoted JavaScript string if
   # rendered unescaped.
@@ -275,6 +276,33 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     %w[priority_id category_id fixed_version_id].each do |field|
       assert_select "p.js-issue-core-field[data-field=?]", field
     end
+  end
+
+  # Custom field templates (#103, phase 2): every tracker's fields render in
+  # their own group; only the selected tracker's group is enabled.
+  def test_form_renders_custom_field_groups_per_tracker
+    mine = IssueCustomField.create!(name: 'Reading', field_format: 'string',
+                                    is_for_all: true, trackers: [Tracker.find(1)])
+    other = IssueCustomField.create!(name: 'Other', field_format: 'string',
+                                     is_for_all: true, trackers: [Tracker.find(2)])
+    @template.reload.update!(issue_custom_field_values: { mine.id.to_s => '${severity}' })
+
+    get :edit, params: { project_id: @project.id, id: @template.id }
+    assert_response :success
+    assert_select 'fieldset.js-tracker-custom-fields[data-tracker-id="1"]:not([disabled])' do
+      assert_select "input[name=?][value=?]", "subscription_template[issue_custom_field_values][#{mine.id}]", '${severity}'
+    end
+    assert_select 'fieldset.js-tracker-custom-fields[data-tracker-id="2"][disabled]' do
+      assert_select "input[name=?]", "subscription_template[issue_custom_field_values][#{other.id}]"
+    end
+  end
+
+  def test_create_stores_custom_field_values
+    field = IssueCustomField.create!(name: 'Reading', field_format: 'string',
+                                     is_for_all: true, trackers: [Tracker.find(1)])
+    post :create, params: create_params(issue_custom_field_values: { field.id.to_s => '${temperature}' })
+    template = SubscriptionTemplate.order(id: :desc).first
+    assert_equal({ field.id.to_s => '${temperature}' }, template.issue_custom_field_values)
   end
 
   def test_allowed_statuses_returns_the_workflow_statuses_for_the_pair

--- a/test/javascripts/issue_details.test.js
+++ b/test/javascripts/issue_details.test.js
@@ -43,6 +43,23 @@ describe('disabled core fields', () => {
     expect(qs('[data-field="fixed_version_id"]').style.display).toBe('');
   });
 
+  it('enables the selected tracker custom-field group and disables the others', () => {
+    buildForm({ selectedTracker: '1' });
+    initForm();
+    const group1 = qs('.js-tracker-custom-fields[data-tracker-id="1"]');
+    const group2 = qs('.js-tracker-custom-fields[data-tracker-id="2"]');
+    expect(group1.disabled).toBe(false);
+    expect(group2.disabled).toBe(true);
+    expect(group2.style.display).toBe('none');
+
+    stubStatuses([]);
+    changeTracker('2');
+    expect(group1.disabled).toBe(true);
+    expect(group1.style.display).toBe('none');
+    expect(group2.disabled).toBe(false);
+    expect(group2.style.display).toBe('');
+  });
+
   it('clears a hidden select so it does not submit a stale value', () => {
     buildForm();
     initForm();

--- a/test/javascripts/support/form_fixture.js
+++ b/test/javascripts/support/form_fixture.js
@@ -164,6 +164,13 @@ export function buildForm({
       <p class="min-width js-issue-core-field" data-field="category_id"><select></select></p>
       <p class="min-width js-issue-core-field" data-field="fixed_version_id"><select></select></p>
 
+      <fieldset class="js-tracker-custom-fields" data-tracker-id="1" ${selectedTracker === '1' ? '' : 'disabled style="display:none;"'}>
+        <input type="text" name="subscription_template[issue_custom_field_values][7]" value="\${severity}" />
+      </fieldset>
+      <fieldset class="js-tracker-custom-fields" data-tracker-id="2" ${selectedTracker === '2' ? '' : 'disabled style="display:none;"'}>
+        <input type="text" name="subscription_template[issue_custom_field_values][8]" value="" />
+      </fieldset>
+
       <input type="submit" name="publish_after_create" value="Create and publish" />
     </form>`;
 }

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -61,6 +61,39 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_equal category.id, template.issue_category_id
   end
 
+  # --- custom field templates (#103, phase 2) -----------------------------
+
+  def issue_custom_field(attributes = {})
+    IssueCustomField.create!({
+      name: "Severity #{SecureRandom.hex(3)}",
+      field_format: 'string',
+      is_for_all: true,
+      trackers: [Tracker.find(1)]
+    }.merge(attributes))
+  end
+
+  def test_custom_field_values_round_trip_and_drop_blanks
+    field = issue_custom_field
+    template = SubscriptionTemplate.create!(valid_attributes(
+      issue_custom_field_values: { field.id.to_s => '${severity}', '999999' => '   ' }
+    ))
+    assert_equal({ field.id.to_s => '${severity}' }, template.reload.issue_custom_field_values)
+  end
+
+  def test_custom_field_values_for_other_trackers_are_cleared_on_save
+    foreign_field = issue_custom_field(trackers: [Tracker.find(2)])
+    template = SubscriptionTemplate.create!(valid_attributes(
+      issue_custom_field_values: { foreign_field.id.to_s => '${severity}' }
+    ))
+    assert_equal({}, template.reload.issue_custom_field_values)
+  end
+
+  def test_custom_field_values_read_as_empty_hash_when_malformed
+    template = SubscriptionTemplate.create!(valid_attributes)
+    template.update_column(:issue_custom_field_values, 'not json')
+    assert_equal({}, template.reload.issue_custom_field_values)
+  end
+
   def test_default_alteration_types
     template = SubscriptionTemplate.new
     assert_equal ['entityCreate', 'entityChange'], template.alteration_types


### PR DESCRIPTION
Phase 2 of #103; closes #103.

## What

The Issue details section now carries the selected tracker's custom fields. Each value is a **template string** - `${...}` placeholders render against the notification entity, exactly like subject and description - so a broker reading can land in a typed custom field.

- **Storage**: a new `issue_custom_field_values` text column (JSON object, custom field id -> template string) with a tolerant coder (malformed stored JSON reads as `{}`). Blank templates are dropped on write; values for fields the tracker does not carry are cleared on save, extending the phase-1 core-field rule (the form is not the only writer).
- **Form**: every project tracker's custom fields render in their own group; only the selected tracker's group is visible. Hidden groups use `fieldset[disabled]`, so their inputs never submit - no stale values for other trackers. The form JS switches groups on tracker change.
- **Processing**: `NotificationProcessor` renders the templates against the entity and applies them through `safe_attributes`, so tracker availability and the acting member's per-role field permissions keep holding (the processor already runs as the template's member). Values that render blank leave the field unset.

## Verification

- Rails suite: 267 runs, 951 assertions, 0 failures - round trip incl. blank-drop and cross-tracker clearing, malformed-JSON read, form DOM contract (groups, disabled state, stored values), create-stores-values, and the notification path (rendered value lands in the custom field; blank-rendering templates leave it unset)
- JS suite: 44 tests - group toggling on tracker change (show/enable + hide/disable)
- Live smoke on the demo instance: group renders for the tracker's field, only the active group's input is in the form data, value round-trips through save