### PR TITLE
Guided subscription creation

### DIFF
--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -12,6 +12,10 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
 
   after_initialize :set_default_alteration_types, if: :new_record?
   after_initialize :set_default_notify_on_metadata_change, if: :new_record?
+  # A new subscription should be creatable from the visible fields alone
+  # (#66, #102): the status select otherwise starts blank and, being
+  # required, silently blocks the submit.
+  after_initialize :set_default_status, if: :new_record?
   before_create :ensure_webhook_secret
 
   belongs_to :project, optional: false
@@ -204,6 +208,10 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
 
   def set_default_notify_on_metadata_change
     self.notify_on_metadata_change = true if notify_on_metadata_change.nil?
+  end
+
+  def set_default_status
+    self.status ||= 'active'
   end
 
   # Parsable JSON is not enough: the subscription builders and the form's

--- a/app/views/subscription_templates/_form_basics.html.erb
+++ b/app/views/subscription_templates/_form_basics.html.erb
@@ -10,11 +10,11 @@
 %>
 
 <div class="box tabular">
-  <p><%= f.text_field :name, required: true, size: 75, placeholder: l(:field_subscription_template_name_placeholder) %></p>
+  <p data-wizard-step="1"><%= f.text_field :name, required: true, size: 75, placeholder: l(:field_subscription_template_name_placeholder) %></p>
 
   <%# Broker URL, standard, tenant headers and auth live on the connection (#67).
       data-standard/data-auth-mode drive the standard-aware toggles below. %>
-  <p class="min-width">
+  <p class="min-width" data-wizard-step="1">
     <%= f.select :broker_connection_id,
                  options_for_select(
                    BrokerConnection.sorted.map do |c|
@@ -30,7 +30,7 @@
   </p>
 
   <%# Structured entity picker (#66); serialized into entities_string on submit. %>
-  <p>
+  <p data-wizard-step="2">
     <%= content_tag :label, l(:field_subscription_template_entities) %>
     <span id="gtt-fiware-entity-rows" <%= 'style=display:none;'.html_safe unless entities_pickerable %>>
       <% entity_rows.each do |entity| %>
@@ -43,13 +43,13 @@
     </span>
     <a href="#" class="js-json-toggle" data-target="entities" style="font-size: 0.9em;"><%= l(:label_edit_as_json) %></a>
   </p>
-  <p id="gtt-fiware-entities-json" <%= 'class=hidden'.html_safe if entities_pickerable %>>
+  <p id="gtt-fiware-entities-json" data-wizard-step="2" <%= 'class=hidden'.html_safe if entities_pickerable %>>
     <%= f.text_area :entities_string, rows: 4,
           placeholder: JSON.pretty_generate(JSON.parse(l(:field_subscription_template_entities_string_placeholder))),
           value: (@subscription_template.entities.presence ? JSON.pretty_generate(@subscription_template.entities) : '') %>
   </p>
 
-  <p class="min-width">
+  <p class="min-width" data-wizard-step="3">
     <%= content_tag :label, l(:label_tracker) %>
     <%# data-disabled-fields drives the tracker-aware Issue details (#103):
         the form hides core fields the selected tracker disables. %>
@@ -57,12 +57,12 @@
           data: { disabled_fields: @project.trackers.each_with_object({}) { |t, h| h[t.id] = t.disabled_core_fields }.to_json } %>
   </p>
 
-  <p><%= f.text_field :subject, required: true, size: 75, placeholder: l(:field_subscription_template_subject_placeholder) %>
+  <p data-wizard-step="3"><%= f.text_field :subject, required: true, size: 75, placeholder: l(:field_subscription_template_subject_placeholder) %>
     <em class="info"><%= t(:gtt_fiware_subscription_template_variable_hint).html_safe %></em></p>
 
   <%# Live preview (#68): renders the templates against a sample entity
       fetched from the selected broker connection. %>
-  <p>
+  <p data-wizard-step="4">
     <%= content_tag :label, '' %>
     <a href="#" id="gtt-fiware-preview-button"
        data-url="<%= preview_project_subscription_templates_path(@project) %>"

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -1,9 +1,11 @@
 <%
   # Issue geometry radio: the common case is mapping the entity's location
   # GeoProperty; custom keeps a raw GeoJSON template; none clears it.
+  # New templates default to the entity's location (#102): mapping the
+  # GeoProperty is the overwhelmingly common case. A stored blank stays None.
   geometry_mode =
     if @subscription_template.geometry.blank?
-      'none'
+      @subscription_template.new_record? ? 'location' : 'none'
     elsif @subscription_template.geometry == '${location}'
       'location'
     else
@@ -105,6 +107,7 @@
   <p class="min-width">
     <%= content_tag :label, l(:field_subscription_template_notification_user) %>
     <%= f.collection_select :member_id, @project.members, :id, :name %>
+    <em class="info"><%= l(:text_subscription_template_member_info) %></em>
   </p>
   <p><%= f.check_box :is_private %></p>
 </div>

--- a/app/views/subscription_templates/_form_script.html.erb
+++ b/app/views/subscription_templates/_form_script.html.erb
@@ -3,3 +3,4 @@
     the script needs from the server travels through data-* attributes and
     the ids/classes pinned by the Rails DOM-contract tests. %>
 <%= javascript_include_tag 'gtt_fiware_form', plugin: 'redmine_gtt_fiware' %>
+<%= javascript_include_tag 'gtt_fiware_wizard', plugin: 'redmine_gtt_fiware' %>

--- a/app/views/subscription_templates/_form_section.html.erb
+++ b/app/views/subscription_templates/_form_section.html.erb
@@ -1,5 +1,9 @@
-<%# One collapsible advanced section (core fieldset.collapsible idiom). %>
-<fieldset class="collapsible <%= 'collapsed' unless expanded %>" id="gtt-fiware-section-<%= section %>">
+<%# One collapsible advanced section (core fieldset.collapsible idiom).
+    data-wizard-step assigns the section to a step of the guided flow (#102);
+    outside wizard mode the attribute is inert. %>
+<% wizard_step = { 'filters' => 2, 'issue_details' => 3, 'subscription_options' => 4 }[section] %>
+<fieldset class="collapsible <%= 'collapsed' unless expanded %>" id="gtt-fiware-section-<%= section %>"
+          data-wizard-step="<%= wizard_step %>">
   <legend onclick="toggleFieldset(this);" class="icon icon-<%= expanded ? 'expanded' : 'collapsed' %>">
     <%= sprite_icon(expanded ? 'angle-down' : 'angle-right', rtl: !expanded) %>
     <%= label %>

--- a/app/views/subscription_templates/new.html.erb
+++ b/app/views/subscription_templates/new.html.erb
@@ -1,8 +1,29 @@
 <%= title [l(:label_subscription_template_plural), index_path], l(:label_subscription_template_new) %>
 
-<%= labelled_form_for @subscription_template, url: project_subscription_templates_path(@project) do |f| %>
+<%= labelled_form_for @subscription_template, url: project_subscription_templates_path(@project),
+                      html: { data: { wizard: 'true' } } do |f| %>
+  <%# Guided flow (#102): a presentation layer over the single form. The nav
+      stays hidden until the wizard script activates it, so without JS the
+      classic full form renders unchanged. %>
+  <div id="gtt-fiware-wizard" style="display: none;">
+    <ol class="gtt-fiware-wizard-steps">
+      <li data-step="1" data-help="<%= l(:gtt_fiware_wizard_help_1) %>"><%= l(:gtt_fiware_wizard_step_1) %></li>
+      <li data-step="2" data-help="<%= l(:gtt_fiware_wizard_help_2) %>"><%= l(:gtt_fiware_wizard_step_2) %></li>
+      <li data-step="3" data-help="<%= l(:gtt_fiware_wizard_help_3) %>"><%= l(:gtt_fiware_wizard_step_3) %></li>
+      <li data-step="4" data-help="<%= l(:gtt_fiware_wizard_help_4) %>"><%= l(:gtt_fiware_wizard_step_4) %></li>
+    </ol>
+    <p class="gtt-fiware-wizard-help"><em class="info" id="gtt-fiware-wizard-help"></em></p>
+  </div>
+
   <%= render partial: 'form', locals: { f: f } %>
-  <p>
+
+  <p id="gtt-fiware-wizard-buttons" style="display: none;">
+    <button type="button" id="gtt-fiware-wizard-back"><%= l(:gtt_fiware_wizard_back) %></button>
+    <button type="button" id="gtt-fiware-wizard-next"><%= l(:gtt_fiware_wizard_next) %></button>
+    <a href="#" id="gtt-fiware-wizard-all" style="margin-left: 8px; font-size: 0.9em;"><%= l(:gtt_fiware_wizard_show_all) %></a>
+  </p>
+
+  <p data-wizard-step="4">
     <%= submit_tag l :button_create %>
     <%# Publish runs server-side with the connection's stored token; the
         script hides this button for browser-mode connections. %>

--- a/assets/javascripts/gtt_fiware_wizard.js
+++ b/assets/javascripts/gtt_fiware_wizard.js
@@ -33,8 +33,15 @@
 
     // Sections are the collapsible fieldsets from the classic form; a step
     // that contains one gets it expanded, nothing stays behind a fold.
+    // Expansion goes through Redmine's own toggleFieldset so the legend icon
+    // stays in sync; the manual fallback covers environments without it.
     function expandSection(el) {
-      if (!el.classList.contains('collapsible')) { return; }
+      if (!el.classList.contains('collapsible') || !el.classList.contains('collapsed')) { return; }
+      var legend = el.querySelector(':scope > legend');
+      if (typeof window.toggleFieldset === 'function' && legend) {
+        window.toggleFieldset(legend);
+        return;
+      }
       el.classList.remove('collapsed');
       var body = el.querySelector(':scope > div');
       if (body) { body.style.display = ''; }
@@ -54,6 +61,11 @@
       help.textContent = activeItem ? activeItem.dataset.help : '';
       back.disabled = step === 1;
       next.style.display = step === TOTAL_STEPS ? 'none' : '';
+      // The preview result manages its own visibility (the preview button
+      // shows it); the wizard only makes sure it never lingers on steps
+      // before Review & publish.
+      var previewResult = document.getElementById('gtt-fiware-preview-result');
+      if (previewResult && step !== TOTAL_STEPS) { previewResult.style.display = 'none'; }
     }
 
     // Required fields of the current step must hold before advancing;

--- a/assets/javascripts/gtt_fiware_wizard.js
+++ b/assets/javascripts/gtt_fiware_wizard.js
@@ -1,0 +1,102 @@
+/* Guided subscription creation (#102): a presentation layer over the single
+ * form. Form elements and sections carry data-wizard-step (1..4); the wizard
+ * shows one step at a time with Back/Next, validates the visible required
+ * fields before advancing, and offers a "show all fields" escape hatch that
+ * returns to the classic full form. State always lives in the one form, so
+ * nothing is lost when stepping around or leaving the wizard.
+ *
+ * Activates only on forms marked data-wizard (the new-template page). With
+ * the script absent or JavaScript off, the classic form renders unchanged.
+ */
+(function() {
+  'use strict';
+
+  var TOTAL_STEPS = 4;
+
+  function init() {
+    var form = document.querySelector('form[data-wizard]');
+    var nav = document.getElementById('gtt-fiware-wizard');
+    var buttons = document.getElementById('gtt-fiware-wizard-buttons');
+    if (!form || !nav || !buttons) { return; }
+    if (form.dataset.gttFiwareWizardInit) { return; }
+    form.dataset.gttFiwareWizardInit = '1';
+
+    var back = document.getElementById('gtt-fiware-wizard-back');
+    var next = document.getElementById('gtt-fiware-wizard-next');
+    var showAll = document.getElementById('gtt-fiware-wizard-all');
+    var help = document.getElementById('gtt-fiware-wizard-help');
+    var current = 1;
+
+    function stepped() {
+      return form.querySelectorAll('[data-wizard-step]');
+    }
+
+    // Sections are the collapsible fieldsets from the classic form; a step
+    // that contains one gets it expanded, nothing stays behind a fold.
+    function expandSection(el) {
+      if (!el.classList.contains('collapsible')) { return; }
+      el.classList.remove('collapsed');
+      var body = el.querySelector(':scope > div');
+      if (body) { body.style.display = ''; }
+    }
+
+    function showStep(step) {
+      current = step;
+      stepped().forEach(function(el) {
+        var active = Number(el.dataset.wizardStep) === step;
+        el.style.display = active ? '' : 'none';
+        if (active) { expandSection(el); }
+      });
+      nav.querySelectorAll('li').forEach(function(li) {
+        li.classList.toggle('active', Number(li.dataset.step) === step);
+      });
+      var activeItem = nav.querySelector('li[data-step="' + step + '"]');
+      help.textContent = activeItem ? activeItem.dataset.help : '';
+      back.disabled = step === 1;
+      next.style.display = step === TOTAL_STEPS ? 'none' : '';
+    }
+
+    // Required fields of the current step must hold before advancing;
+    // otherwise the browser would refuse to submit while the invalid field
+    // is hidden on an earlier step, with no visible feedback.
+    function currentStepValid() {
+      var selector = '[data-wizard-step="' + current + '"] input[required], ' +
+                     '[data-wizard-step="' + current + '"] select[required], ' +
+                     '[data-wizard-step="' + current + '"] textarea[required]';
+      var fields = form.querySelectorAll(selector);
+      for (var i = 0; i < fields.length; i++) {
+        if (!fields[i].checkValidity()) {
+          if (fields[i].reportValidity) { fields[i].reportValidity(); }
+          return false;
+        }
+      }
+      return true;
+    }
+
+    function teardown() {
+      nav.style.display = 'none';
+      buttons.style.display = 'none';
+      stepped().forEach(function(el) {
+        el.style.display = '';
+      });
+    }
+
+    back.addEventListener('click', function() {
+      if (current > 1) { showStep(current - 1); }
+    });
+    next.addEventListener('click', function() {
+      if (current < TOTAL_STEPS && currentStepValid()) { showStep(current + 1); }
+    });
+    showAll.addEventListener('click', function(e) {
+      e.preventDefault();
+      teardown();
+    });
+
+    nav.style.display = '';
+    buttons.style.display = '';
+    showStep(1);
+  }
+
+  window.GttFiwareWizard = { init: init };
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/assets/stylesheets/gtt_fiware.css
+++ b/assets/stylesheets/gtt_fiware.css
@@ -81,3 +81,28 @@ fieldset.js-tracker-custom-fields {
   margin: 0;
   padding: 0;
 }
+
+/* Guided subscription creation (#102): the step list above the form. */
+.gtt-fiware-wizard-steps {
+  list-style: none;
+  margin: 0 0 4px 0;
+  padding: 0;
+}
+
+.gtt-fiware-wizard-steps li {
+  display: inline-block;
+  padding: 4px 10px;
+  margin-right: 4px;
+  border-radius: 3px;
+  background: rgba(127, 127, 127, 0.12);
+  color: inherit;
+}
+
+.gtt-fiware-wizard-steps li.active {
+  background: rgba(127, 127, 127, 0.28);
+  font-weight: bold;
+}
+
+.gtt-fiware-wizard-help {
+  margin-top: 0;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,10 +120,24 @@ en:
   field_subscription_template_attachments_placeholder: "[{\"filename\": \"image.jpg\"\
     , \"url\": \"https://example.com/image.jpg\"}]"
   field_subscription_template_notification_user: "Sent from user"
+  text_subscription_template_member_info: "The created issues are authored as this member; permissions and workflow follow this user."
   text_issue_custom_field_values_info: "Custom fields of the selected tracker. ${...} placeholders render against the notification entity; blank fields are left unset."
+
+  gtt_fiware_wizard_step_1: "Connection"
+  gtt_fiware_wizard_step_2: "What to watch"
+  gtt_fiware_wizard_step_3: "The issue"
+  gtt_fiware_wizard_step_4: "Review & publish"
+  gtt_fiware_wizard_help_1: "Name the subscription and pick the broker connection it registers on."
+  gtt_fiware_wizard_help_2: "Choose which entities and changes notify Redmine. Blank filters mean every change of the entity type."
+  gtt_fiware_wizard_help_3: "Define the issue each notification creates; ${...} placeholders read values from the entity."
+  gtt_fiware_wizard_help_4: "Preview the templates against a live entity from the broker, then create the subscription."
+  gtt_fiware_wizard_back: "Back"
+  gtt_fiware_wizard_next: "Next"
+  gtt_fiware_wizard_show_all: "Show all fields"
   field_subscription_template_threshold_create_hours: "Threshold (h)"
-  field_subscription_template_threshold_create_hours_hint: "Threshold to create new
-    issue in hours."
+  field_subscription_template_threshold_create_hours_hint: "Within this window,
+    repeated notifications for the same entity update the first issue instead
+    of creating duplicates. 0 creates a new issue every time."
   field_subscription_template_notes: "Issue notes"
   field_subscription_template_notes_placeholder: "Post an issue note instead of creating
     a new issue if an issue has been created within the threshold."

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -340,6 +340,34 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal [Tracker.find(1).default_status_id, 2, 5].sort, values.sort
   end
 
+  # --- guided creation (#102) ----------------------------------------------
+
+  # The wizard is a presentation layer over the single form: the new page
+  # carries the nav, the step tagging and the escape hatch; without JS the
+  # classic form renders unchanged (the nav starts hidden).
+  def test_new_carries_the_wizard_contract
+    get :new, params: { project_id: @project.id }
+    assert_response :success
+    assert_select 'form[data-wizard]'
+    assert_select '#gtt-fiware-wizard ol.gtt-fiware-wizard-steps li', 4
+    assert_select '#gtt-fiware-wizard-buttons #gtt-fiware-wizard-back'
+    assert_select '#gtt-fiware-wizard-buttons #gtt-fiware-wizard-next'
+    assert_select 'a#gtt-fiware-wizard-all'
+    assert_select 'fieldset#gtt-fiware-section-filters[data-wizard-step="2"]'
+    assert_select 'fieldset#gtt-fiware-section-issue_details[data-wizard-step="3"]'
+    assert_select 'fieldset#gtt-fiware-section-subscription_options[data-wizard-step="4"]'
+    assert_select 'p[data-wizard-step="4"] input[type=submit]'
+    # New templates default the issue geometry to the entity location (#102).
+    assert_select 'input[name="gtt_fiware_geometry_mode"][value="location"][checked]'
+  end
+
+  def test_edit_stays_on_the_classic_form
+    get :edit, params: { project_id: @project.id, id: @template.id }
+    assert_response :success
+    assert_select 'form[data-wizard]', 0
+    assert_select '#gtt-fiware-wizard', 0
+  end
+
   # Sections with stored values are expanded on edit so nothing is hidden.
   def test_edit_expands_sections_that_contain_values
     @template.update_column(:expression_query, 'temperature>30')

--- a/test/javascripts/wizard.test.js
+++ b/test/javascripts/wizard.test.js
@@ -1,0 +1,115 @@
+// Guided subscription creation (#102): stepping, validation gating, the
+// escape hatch, and section auto-expansion. The fixture mirrors the wizard
+// DOM contract of new.html.erb and the data-wizard-step tagging.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, '../../assets/javascripts/gtt_fiware_wizard.js'), 'utf8');
+
+beforeAll(() => window.eval(source));
+
+function buildWizardForm({ wizard = true, nameValue = 'My subscription' } = {}) {
+  document.body.innerHTML = `
+    <form ${wizard ? 'data-wizard="true"' : ''}>
+      <div id="gtt-fiware-wizard" style="display: none;">
+        <ol class="gtt-fiware-wizard-steps">
+          <li data-step="1" data-help="Help one">Connection</li>
+          <li data-step="2" data-help="Help two">What to watch</li>
+          <li data-step="3" data-help="Help three">The issue</li>
+          <li data-step="4" data-help="Help four">Review &amp; publish</li>
+        </ol>
+        <p class="gtt-fiware-wizard-help"><em id="gtt-fiware-wizard-help"></em></p>
+      </div>
+
+      <p data-wizard-step="1"><input type="text" id="name" required value="${nameValue}" /></p>
+      <fieldset class="collapsible collapsed" data-wizard-step="2" id="section-filters">
+        <legend>Filters</legend>
+        <div style="display: none;"><input type="text" id="query" /></div>
+      </fieldset>
+      <p data-wizard-step="3"><input type="text" id="subject" required value="A subject" /></p>
+      <p data-wizard-step="4"><input type="submit" value="Create" /></p>
+
+      <p id="gtt-fiware-wizard-buttons" style="display: none;">
+        <button type="button" id="gtt-fiware-wizard-back">Back</button>
+        <button type="button" id="gtt-fiware-wizard-next">Next</button>
+        <a href="#" id="gtt-fiware-wizard-all">Show all fields</a>
+      </p>
+    </form>`;
+  window.GttFiwareWizard.init();
+}
+
+const visible = (sel) => document.querySelector(sel).style.display !== 'none';
+const next = () => document.getElementById('gtt-fiware-wizard-next').click();
+const back = () => document.getElementById('gtt-fiware-wizard-back').click();
+
+describe('activation', () => {
+  it('shows only step 1 and the nav on a wizard form', () => {
+    buildWizardForm();
+    expect(visible('#gtt-fiware-wizard')).toBe(true);
+    expect(visible('#gtt-fiware-wizard-buttons')).toBe(true);
+    expect(visible('[data-wizard-step="1"]')).toBe(true);
+    expect(visible('[data-wizard-step="2"]')).toBe(false);
+    expect(visible('[data-wizard-step="4"]')).toBe(false);
+    expect(document.getElementById('gtt-fiware-wizard-help').textContent).toBe('Help one');
+  });
+
+  it('stays inert without data-wizard (the edit form)', () => {
+    buildWizardForm({ wizard: false });
+    expect(visible('#gtt-fiware-wizard')).toBe(false);
+    expect(visible('[data-wizard-step="2"]')).toBe(true);
+  });
+});
+
+describe('stepping', () => {
+  beforeEach(() => buildWizardForm());
+
+  it('advances and goes back, tracking the active item and help text', () => {
+    next();
+    expect(visible('[data-wizard-step="2"]')).toBe(true);
+    expect(visible('[data-wizard-step="1"]')).toBe(false);
+    expect(document.querySelector('li.active').dataset.step).toBe('2');
+    expect(document.getElementById('gtt-fiware-wizard-help').textContent).toBe('Help two');
+    back();
+    expect(visible('[data-wizard-step="1"]')).toBe(true);
+  });
+
+  it('disables Back on step 1 and hides Next on the last step', () => {
+    expect(document.getElementById('gtt-fiware-wizard-back').disabled).toBe(true);
+    next(); next(); next();
+    expect(document.querySelector('li.active').dataset.step).toBe('4');
+    expect(visible('#gtt-fiware-wizard-next')).toBe(false);
+    expect(visible('[data-wizard-step="4"]')).toBe(true);
+  });
+
+  it('expands a collapsed section when its step activates', () => {
+    next();
+    const section = document.getElementById('section-filters');
+    expect(section.classList.contains('collapsed')).toBe(false);
+    expect(section.querySelector('div').style.display).toBe('');
+  });
+});
+
+describe('validation gate', () => {
+  it('does not advance while a required field of the step is empty', () => {
+    buildWizardForm({ nameValue: '' });
+    next();
+    expect(document.querySelector('li.active').dataset.step).toBe('1');
+    expect(visible('[data-wizard-step="1"]')).toBe(true);
+  });
+});
+
+describe('escape hatch', () => {
+  it('shows the whole form and hides the wizard chrome', () => {
+    buildWizardForm();
+    document.getElementById('gtt-fiware-wizard-all').click();
+    expect(visible('#gtt-fiware-wizard')).toBe(false);
+    expect(visible('#gtt-fiware-wizard-buttons')).toBe(false);
+    ['1', '2', '3', '4'].forEach((step) => {
+      expect(visible(`[data-wizard-step="${step}"]`)).toBe(true);
+    });
+  });
+});

--- a/test/javascripts/wizard.test.js
+++ b/test/javascripts/wizard.test.js
@@ -91,6 +91,36 @@ describe('stepping', () => {
     expect(section.classList.contains('collapsed')).toBe(false);
     expect(section.querySelector('div').style.display).toBe('');
   });
+
+  it('expands sections through toggleFieldset when Redmine provides it', () => {
+    const toggled = [];
+    window.toggleFieldset = (legend) => {
+      toggled.push(legend.closest('fieldset').id);
+      legend.closest('fieldset').classList.remove('collapsed');
+    };
+    try {
+      buildWizardForm();
+      next();
+      expect(toggled).toEqual(['section-filters']);
+      // Already-expanded sections are left alone on revisits.
+      back(); next();
+      expect(toggled).toEqual(['section-filters']);
+    } finally {
+      delete window.toggleFieldset;
+    }
+  });
+
+  it('hides a shown preview result when navigating away from the last step', () => {
+    document.body.insertAdjacentHTML('beforeend',
+      '<div id="gtt-fiware-preview-result" style="display: none;"></div>');
+    // jsdom: move it inside the form so the fixture stays realistic.
+    document.querySelector('form').appendChild(document.getElementById('gtt-fiware-preview-result'));
+    next(); next(); next();
+    const preview = document.getElementById('gtt-fiware-preview-result');
+    preview.style.display = '';
+    back();
+    expect(preview.style.display).toBe('none');
+  });
 });
 
 describe('validation gate', () => {

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -94,6 +94,12 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_equal({}, template.reload.issue_custom_field_values)
   end
 
+  # A new subscription must be creatable from the visible fields alone
+  # (#102): the required status select otherwise starts blank.
+  def test_default_status_is_active
+    assert_equal 'active', SubscriptionTemplate.new.status
+  end
+
   def test_default_alteration_types
     template = SubscriptionTemplate.new
     assert_equal ['entityCreate', 'entityChange'], template.alteration_types


### PR DESCRIPTION
Closes #102.

## What

A four-step guided flow for creating subscriptions: **Connection** → **What to watch** → **The issue** → **Review & publish**, with one line of inline help per step.

It is a pure presentation layer over the existing single form, as proposed on the issue:

- Form elements and the collapsible sections carry `data-wizard-step` tags; the wizard shows one step at a time and auto-expands the sections its step contains. State lives in the one form, so Back/Next lose nothing and no controller changes were needed.
- **Next is gated** on the current step's required fields - otherwise the browser would refuse the final submit while the invalid field is hidden on an earlier step, with no visible feedback.
- **Show all fields** is the escape hatch back to the classic form; **editing stays classic**; with JavaScript off the nav stays hidden and the full form renders unchanged (progressive enhancement).

The smaller UX wins from the issue ship along:

- New templates default the **issue geometry to the entity location** (the overwhelmingly common case) and the **subscription status to `active`** - the required status select otherwise starts blank and silently blocks the submit (surfaced by the wizard's step gating, but it bit the classic form too).
- The **threshold hint** now explains the update-window semantics and that 0 always creates a new issue.
- **Sent from user** carries a hint that author, permissions and workflow follow this member.

## Verification

- Rails suite: 270 runs, 975 assertions, 0 failures - wizard DOM contract on new, classic form pinned on edit, geometry/status defaults
- JS suite: 51 tests - activation, stepping incl. active-item/help tracking, Back/Next states, section auto-expansion, validation gate, escape hatch, inert-without-data-wizard
- Live on the demo instance: step gating blocks an empty name, sections expand per step, and a template created through the wizard round-trips (serialized entities, `${location}` geometry, active status)