### PR TITLE
REST API for subscriptions

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -538,7 +538,11 @@ class SubscriptionTemplatesController < ApplicationController
       # create the model's default applies.
       params[:subscription_template][:alteration_types] ||= []
     end
-    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, :geofence_notes, alteration_types: [], issue_custom_field_values: {})
+    # project_id is deliberately not permitted: the project comes from the
+    # route, and SaveSubscriptionTemplate assigns it before the attributes, so
+    # a permitted project_id would let a request move a subscription into
+    # another project (a real hole once the API can send arbitrary fields).
+    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, :geofence_notes, alteration_types: [], issue_custom_field_values: {})
   end
 
   # Stored connections supply their encrypted token server-side; browser-mode

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -9,7 +9,9 @@ class SubscriptionTemplatesController < ApplicationController
   # explicitly changes no behaviour (CodeQL rb/csrf-protection-not-enabled).
   protect_from_forgery with: :exception
 
-  before_action :find_project_by_project_id, except: [:index, :set_subscription_id]
+  # index is nested under a project since #22 (the REST API), so it needs the
+  # project too; only the broker's registration callback is project-less.
+  before_action :find_project_by_project_id, except: [:set_subscription_id]
   before_action :get_issue_priorities, only: [:new, :create, :edit, :update]
   before_action :get_issue_categories, only: [:new, :create, :edit, :update]
   before_action :find_subscription_template, only: [:edit, :update, :destroy, :copy, :publish, :unpublish, :sync, :update_subscription_id]
@@ -21,13 +23,31 @@ class SubscriptionTemplatesController < ApplicationController
   # no manual verify_authenticity_token skip is needed. The state-changing
   # browser actions (publish/unpublish) keep full CSRF protection via the
   # rails-ujs token.
-  accept_api_auth :set_subscription_id
+  accept_api_auth :set_subscription_id, :index, :show, :create, :update, :destroy
   before_action :authorize, except: [:set_subscription_id]
 
   helper_method :index_path, :form_issue_statuses
 
   def index
-    @subscription_templates = subscription_template_scope
+    respond_to do |format|
+      # The HTML surface for the list is the project's FIWARE tab.
+      format.html { redirect_to index_path }
+      format.api do
+        scope = subscription_template_scope
+        @subscription_template_count = scope.count
+        @offset, @limit = api_offset_and_limit
+        @subscription_templates = scope.includes(:broker_connection, :tracker, :issue_status, :member)
+                                       .offset(@offset).limit(@limit).to_a
+      end
+    end
+  end
+
+  def show
+    @subscription_template = subscription_template_scope.find(params[:id])
+    respond_to do |format|
+      format.html { redirect_to edit_project_subscription_template_path(@project, @subscription_template) }
+      format.api
+    end
   end
 
   # Prefilled defaults keep the happy path publishable without opening any
@@ -55,21 +75,36 @@ class SubscriptionTemplatesController < ApplicationController
 
   def create
     r = RedmineGttFiware::SaveSubscriptionTemplate.(subscription_template_params, project: @project)
+    @subscription_template = r.subscription_template
     if r.subscription_template_saved?
-      publish_after_create(r.subscription_template) if params[:publish_after_create].present?
-      redirect_to params[:continue] ? new_path : index_path
+      publish_after_create(@subscription_template) if params[:publish_after_create].present?
+      respond_to do |format|
+        format.html { redirect_to params[:continue] ? new_path : index_path }
+        format.api do
+          render action: 'show', status: :created,
+                 location: project_subscription_template_path(@project, @subscription_template)
+        end
+      end
     else
-      @subscription_template = r.subscription_template
-      render 'new'
+      respond_to do |format|
+        format.html { render 'new' }
+        format.api { render_validation_errors(@subscription_template) }
+      end
     end
   end
 
   def update
     r = RedmineGttFiware::SaveSubscriptionTemplate.(subscription_template_params, subscription_template: @subscription_template)
     if r.subscription_template_saved?
-      redirect_to index_path
+      respond_to do |format|
+        format.html { redirect_to index_path }
+        format.api { render_api_ok }
+      end
     else
-      render 'edit'
+      respond_to do |format|
+        format.html { render 'edit' }
+        format.api { render_validation_errors(@subscription_template) }
+      end
     end
   end
 
@@ -106,7 +141,10 @@ class SubscriptionTemplatesController < ApplicationController
 
   def destroy
     @subscription_template.destroy
-    redirect_to index_path
+    respond_to do |format|
+      format.html { redirect_to index_path }
+      format.api { render_api_ok }
+    end
   end
 
   def copy
@@ -438,8 +476,53 @@ class SubscriptionTemplatesController < ApplicationController
     @issue_priorities = IssuePriority.all.sorted
   end
 
+  # API clients naturally send structures where the form sends JSON strings
+  # (the textareas are a UI detail): entities/attachments/geometry as objects
+  # and arrays, attrs as an array of names. Convert them to the *_string
+  # inputs the model already validates, so both shapes work and the
+  # validation stays in one place. The converted values are re-parsed and
+  # shape-checked by the model before landing in the serialized columns, so
+  # this is not a mass-assignment path.
+  def normalize_api_structures
+    attributes = params[:subscription_template]
+    return unless attributes.respond_to?(:key?)
+
+    { entities: :entities_string, attachments: :attachments_string, geometry: :geometry_string }
+      .each do |structured, string_field|
+        next unless attributes.key?(structured)
+
+        value = attributes.delete(structured)
+        # An explicit null carries no structure to convert; leave whatever the
+        # client sent in the *_string field alone.
+        next if value.nil?
+
+        attributes[string_field] = value.is_a?(String) ? value : structured_to_json(value)
+      end
+
+    attributes[:attrs] = structured_to_json(attributes[:attrs]) if attributes[:attrs].is_a?(Array)
+  end
+
+  def structured_to_json(value)
+    plain_structure(value).to_json
+  end
+
+  def plain_structure(value)
+    case value
+    when ActionController::Parameters then value.to_unsafe_h
+    when Array then value.map { |element| plain_structure(element) }
+    else value
+    end
+  end
+
   def subscription_template_params
-    params[:subscription_template][:alteration_types] ||= []
+    if api_request?
+      normalize_api_structures
+    else
+      # The form omits unchecked boxes, so an absent value means "none".
+      # An API client that omits the key means "leave it alone", and on
+      # create the model's default applies.
+      params[:subscription_template][:alteration_types] ||= []
+    end
     params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :project_id, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, :geofence_notes, alteration_types: [], issue_custom_field_values: {})
   end
 

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -36,7 +36,9 @@ class SubscriptionTemplatesController < ApplicationController
         scope = subscription_template_scope
         @subscription_template_count = scope.count
         @offset, @limit = api_offset_and_limit
-        @subscription_templates = scope.includes(:broker_connection, :tracker, :issue_status, :member)
+        # Preload everything the API renders as a reference.
+        @subscription_templates = scope.includes(:project, :broker_connection, :tracker, :issue_status,
+                                                 :issue_priority, :issue_category, :version, :member)
                                        .offset(@offset).limit(@limit).to_a
       end
     end
@@ -496,10 +498,23 @@ class SubscriptionTemplatesController < ApplicationController
         # client sent in the *_string field alone.
         next if value.nil?
 
-        attributes[string_field] = value.is_a?(String) ? value : structured_to_json(value)
+        attributes[string_field] = json_input(value)
       end
 
     attributes[:attrs] = structured_to_json(attributes[:attrs]) if attributes[:attrs].is_a?(Array)
+  end
+
+  # The model parses the *_string fields as JSON. A structure is dumped; a
+  # string that already is JSON passes through; anything else is a scalar
+  # template value and gets encoded as the JSON string it stands for, so
+  # geometry: "${location}" works as documented instead of failing to parse.
+  def json_input(value)
+    return structured_to_json(value) unless value.is_a?(String)
+
+    JSON.parse(value)
+    value
+  rescue JSON::ParserError
+    value.to_json
   end
 
   def structured_to_json(value)

--- a/app/helpers/subscription_templates_helper.rb
+++ b/app/helpers/subscription_templates_helper.rb
@@ -1,0 +1,85 @@
+# Shared body of the subscription REST API responses (#22).
+#
+# What is deliberately NOT rendered: the per-subscription webhook secret (it
+# authenticates broker notifications, so it must never leave the server) and
+# anything from the connection beyond its identity (the stored broker token
+# lives there).
+module SubscriptionTemplatesHelper
+  def render_api_subscription_template(template, api)
+    api.id template.id
+    api.name template.name
+    api.status template.status
+    api.subscription_id template.subscription_id
+    api.published !template.subscription_id.blank?
+
+    render_api_reference(api, :project, template.project, :name)
+    render_api_reference(api, :broker_connection, template.broker_connection, :name,
+                         standard: template.broker_connection&.standard)
+
+    # What to watch.
+    api.entities template.entities.presence || []
+    api.attrs api_json_array(template.attrs)
+    api.expression_query template.expression_query
+    api.expression_georel template.expression_georel
+    api.expression_geometry template.expression_geometry
+    api.expression_coords template.expression_coords
+    # alteration_types is an Array after a find but still the serialized
+    # string on a just-saved record (see the model's before_save/after_find),
+    # so it goes through the same tolerant conversion as attrs.
+    api.alteration_types api_json_array(template.alteration_types)
+    api.notify_on_metadata_change template.notify_on_metadata_change
+    api.throttling template.throttling
+    api.expires template.expires
+
+    # What to create.
+    render_api_reference(api, :tracker, template.tracker, :name)
+    render_api_reference(api, :issue_status, template.issue_status, :name)
+    render_api_reference(api, :issue_priority, template.issue_priority, :name)
+    render_api_reference(api, :issue_category, template.issue_category, :name)
+    render_api_reference(api, :version, template.version, :name)
+    render_api_reference(api, :member, template.member, :name)
+    api.subject template.subject
+    api.description template.description
+    api.notes template.notes
+    api.geometry template.geometry
+    api.attachments template.attachments.presence || []
+    api.issue_custom_field_values template.issue_custom_field_values
+    api.threshold_create template.threshold_create
+    api.is_private template.is_private
+
+    # Federation and boundary behaviour.
+    api.federation_policy template.federation_policy
+    api.federation_watch template.federation_watch
+    api.geofence_notes template.geofence_notes
+
+    api.context template.context
+    api.comment template.comment
+    api.created_at template.created_at
+    api.updated_at template.updated_at
+  end
+
+  # An association rendered as an id/name reference, like core does for
+  # project/tracker/status. Skipped entirely when the association is empty.
+  #
+  # __send__, not send: the API builders are BasicObjects, so `send` is not
+  # defined on them and would be swallowed by method_missing as a tag named
+  # "send" - silently dropping the reference. Attributes only, no block: the
+  # builders ignore attributes when a block is given.
+  def render_api_reference(api, key, record, name_method, extra = {})
+    return if record.nil?
+
+    api.__send__(key, { id: record.id, name: record.public_send(name_method) }.merge(extra.compact))
+  end
+
+  # attrs is stored as a JSON string (the watched attribute names); the API
+  # presents it as what it means, an array of strings.
+  def api_json_array(value)
+    return [] if value.blank?
+    return value if value.is_a?(Array)
+
+    parsed = JSON.parse(value)
+    parsed.is_a?(Array) ? parsed : []
+  rescue JSON::ParserError
+    []
+  end
+end

--- a/app/views/subscription_templates/index.api.rsb
+++ b/app/views/subscription_templates/index.api.rsb
@@ -1,0 +1,8 @@
+api.array :subscription_templates,
+          api_meta(total_count: @subscription_template_count, offset: @offset, limit: @limit) do
+  @subscription_templates.each do |subscription_template|
+    api.subscription_template do
+      render_api_subscription_template(subscription_template, api)
+    end
+  end
+end

--- a/app/views/subscription_templates/show.api.rsb
+++ b/app/views/subscription_templates/show.api.rsb
@@ -1,0 +1,3 @@
+api.subscription_template do
+  render_api_subscription_template(@subscription_template, api)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,10 @@ get 'fiware/issues/:id/entity', to: 'fiware_entities#show', defaults: { format: 
 
 # Define a route for FIWARE broker subscription templates
 scope 'projects/:project_id' do
-  resources :subscription_templates, only: %i(new create edit update destroy),
+  # index and show exist for the REST API (#22); in a browser they redirect to
+  # the project's FIWARE tab and to the edit form respectively, which are the
+  # HTML surfaces for the same data.
+  resources :subscription_templates, only: %i(index show new create edit update destroy),
                             as: :project_subscription_templates do
     collection do
       # Live preview (#68): renders the issue templates against a sample

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,7 +1,7 @@
 # REST API
 
-Since version 3.2 subscriptions can be read and written over Redmine's REST
-API, in JSON and XML. Enable **Administration → Settings → API → Enable REST
+Subscriptions can be read and written over Redmine's REST API, in JSON and
+XML. Enable **Administration → Settings → API → Enable REST
 web service** first, and authenticate as usual: an `X-Redmine-API-Key` header,
 `key=` parameter, or HTTP Basic. The acting user needs the *Manage
 Subscriptions* permission in the project, and the project needs the GTT FIWARE

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,114 @@
+# REST API
+
+Since version 3.2 subscriptions can be read and written over Redmine's REST
+API, in JSON and XML. Enable **Administration → Settings → API → Enable REST
+web service** first, and authenticate as usual: an `X-Redmine-API-Key` header,
+`key=` parameter, or HTTP Basic. The acting user needs the *Manage
+Subscriptions* permission in the project, and the project needs the GTT FIWARE
+module.
+
+FIWARE connections are not part of the API: they hold broker credentials and
+stay an administration surface.
+
+## Endpoints
+
+All endpoints live under a project.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/projects/:project_id/subscription_templates.json` | list the project's subscriptions |
+| GET | `/projects/:project_id/subscription_templates/:id.json` | one subscription |
+| POST | `/projects/:project_id/subscription_templates.json` | create one |
+| PUT | `/projects/:project_id/subscription_templates/:id.json` | update one |
+| DELETE | `/projects/:project_id/subscription_templates/:id.json` | delete one |
+
+The list is paginated with the usual `offset` and `limit` parameters and
+reports `total_count`. Replace `.json` with `.xml` for XML.
+
+Publishing to the broker is not part of the API: it belongs to the
+[project's FIWARE tab](project_settings.md), which also relays a browser token
+when the connection needs one. `subscription_id` and `published` tell you
+whether a subscription is currently registered on a broker.
+
+## What a subscription looks like
+
+```bash
+curl -H "X-Redmine-API-Key: $KEY" \
+  https://redmine.example.org/projects/city-parks/subscription_templates.json
+```
+
+```json
+{
+  "subscription_templates": [
+    {
+      "id": 1,
+      "name": "Waste containers",
+      "status": "active",
+      "subscription_id": "urn:ngsi-ld:Subscription:6f1c",
+      "published": true,
+      "project": { "id": 1, "name": "City Parks" },
+      "broker_connection": { "id": 2, "name": "City broker", "standard": "NGSI-LD" },
+      "entities": [{ "type": "WasteContainer", "idPattern": ".*" }],
+      "attrs": ["fillingLevel"],
+      "alteration_types": ["entityCreate", "entityChange"],
+      "tracker": { "id": 4, "name": "Task" },
+      "issue_status": { "id": 1, "name": "New" },
+      "member": { "id": 1, "name": "Aiko Tanaka" },
+      "subject": "Waste container needs emptying",
+      "geometry": "${location}",
+      "federation_policy": "annotate",
+      "geofence_notes": false
+    }
+  ],
+  "total_count": 1,
+  "offset": 0,
+  "limit": 25
+}
+```
+
+Associations are rendered as `id`/`name` references and omitted when unset.
+The per-subscription webhook secret is never returned: it authenticates broker
+notifications and stays on the server. Neither is anything from the connection
+beyond its identity, since that is where the stored broker token lives.
+
+## Creating and updating
+
+Send the fields under a `subscription_template` object. The required ones are
+`broker_connection_id`, `name`, `subject`, `description`, the entity filter,
+`tracker_id`, `issue_status_id` and `member_id`.
+
+```bash
+curl -X POST -H "X-Redmine-API-Key: $KEY" -H "Content-Type: application/json" \
+  https://redmine.example.org/projects/city-parks/subscription_templates.json \
+  -d '{
+    "subscription_template": {
+      "broker_connection_id": 2,
+      "name": "Weather stations",
+      "subject": "Reading from ${id}",
+      "description": "Temperature is ${attrs.temperature.value}",
+      "entities": [{ "type": "WeatherObserved", "idPattern": ".*" }],
+      "attrs": ["temperature"],
+      "tracker_id": 4,
+      "issue_status_id": 1,
+      "member_id": 1
+    }
+  }'
+```
+
+Structures go in as structures: `entities` and `attachments` as arrays of
+objects, `attrs` as an array of names, `geometry` as GeoJSON (or the
+`"${location}"` placeholder). The `*_string` variants the web form posts are
+accepted too, for parity with it.
+
+A create returns `201 Created` with the new subscription and a `Location`
+header. Update and delete return `204 No Content`. Invalid input returns `422`
+with an `errors` array, in Redmine's usual shape.
+
+Omitted fields are left untouched on update, and on create take their
+defaults, so `alteration_types` need not be sent to get the usual
+create-and-change triggers.
+
+## See also
+
+- [Subscriptions](subscription_template.md) for what each field means
+- [FIWARE Connections](broker_connections.md) for the broker side

--- a/doc/index.md
+++ b/doc/index.md
@@ -33,6 +33,7 @@ If you need a test broker, [FIWARE-Small-Bang](https://github.com/lets-fiware/FI
 - [Subscriptions](subscription_template.md)
 - [Issue Emission](issue_emission.md)
 - [Federation](federation.md)
+- [REST API](api.md)
 
 ## Tools and Utilities
 

--- a/init.rb
+++ b/init.rb
@@ -39,7 +39,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   # Project module configuration with permissions
   project_module :gtt_fiware do
     permission :manage_subscription_templates, {
-      subscription_templates: %i( new edit update create destroy copy preview allowed_statuses publish unpublish sync update_subscription_id set_subscription_id),
+      subscription_templates: %i( index show new edit update create destroy copy preview allowed_statuses publish unpublish sync update_subscription_id set_subscription_id),
       projects: %i( manage_subscription_templates )
     }, require: :member
   end

--- a/test/functional/subscription_templates_api_test.rb
+++ b/test/functional/subscription_templates_api_test.rb
@@ -187,6 +187,26 @@ class SubscriptionTemplatesApiTest < Redmine::IntegrationTest
     assert_equal [{ 'type' => 'Room' }], SubscriptionTemplate.order(id: :desc).first.entities
   end
 
+  # geometry is a template, so the documented "${location}" placeholder is a
+  # bare string rather than JSON; it must still be stored as the model's
+  # JSON-encoded value instead of failing to parse.
+  def test_create_accepts_the_geometry_placeholder
+    post "/projects/#{@project.id}/subscription_templates.json",
+         params: create_payload(geometry: '${location}').to_json,
+         headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :created
+    assert_equal '${location}', SubscriptionTemplate.order(id: :desc).first.geometry
+  end
+
+  def test_create_accepts_geojson_geometry
+    geojson = { 'type' => 'Point', 'coordinates' => [139.7, 35.68] }
+    post "/projects/#{@project.id}/subscription_templates.json",
+         params: create_payload(geometry: geojson).to_json,
+         headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :created
+    assert_equal geojson, SubscriptionTemplate.order(id: :desc).first.geometry
+  end
+
   def test_create_reports_validation_errors
     assert_no_difference 'SubscriptionTemplate.count' do
       post "/projects/#{@project.id}/subscription_templates.json",

--- a/test/functional/subscription_templates_api_test.rb
+++ b/test/functional/subscription_templates_api_test.rb
@@ -1,0 +1,257 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+# The subscription REST API (#22). Uses an integration test so the request
+# really goes through routing, format negotiation and API key auth.
+class SubscriptionTemplatesApiTest < Redmine::IntegrationTest
+  fixtures :projects, :trackers, :projects_trackers, :issue_statuses, :users,
+           :email_addresses, :members, :member_roles, :roles, :enumerations,
+           :enabled_modules
+
+  def setup
+    Setting.rest_api_enabled = '1'
+    @project = Project.find(1)
+    @project.enabled_module_names = @project.enabled_module_names | ['gtt_fiware']
+    Role.find(1).add_permission!(:manage_subscription_templates)
+
+    @user = User.find(2) # jsmith, manager of project 1
+    @token = @user.api_key # generated on first read
+
+    @connection = BrokerConnection.create!(
+      name: 'API broker', standard: 'NGSIv2',
+      url: 'https://broker.example.com', auth_mode: 'stored',
+      auth_token: 'do-not-leak-me'
+    )
+    @template = SubscriptionTemplate.create!(
+      broker_connection_id: @connection.id, status: 'active',
+      name: 'API alerts', subject: 'Sensor ${id}',
+      description: 'A monitored value changed',
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      attrs: '["temperature"]',
+      project_id: 1, tracker_id: 1, issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id, member_id: 1
+    )
+  end
+
+  def auth
+    { 'X-Redmine-API-Key' => @token }
+  end
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  # --- reading --------------------------------------------------------------
+
+  def test_index_lists_the_project_subscriptions
+    get "/projects/#{@project.id}/subscription_templates.json", headers: auth
+    assert_response :success
+    assert_equal 'application/json', response.media_type
+    assert_equal 1, json['total_count']
+    entry = json['subscription_templates'].first
+    assert_equal 'API alerts', entry['name']
+    assert_equal({ 'id' => @connection.id, 'name' => 'API broker', 'standard' => 'NGSIv2' },
+                 entry['broker_connection'])
+    # Every association is rendered as an id/name reference.
+    assert_equal({ 'id' => @project.id, 'name' => @project.name }, entry['project'])
+    assert_equal({ 'id' => 1, 'name' => Tracker.find(1).name }, entry['tracker'])
+    assert_equal({ 'id' => 1, 'name' => IssueStatus.find(1).name }, entry['issue_status'])
+    assert_equal({ 'id' => 1, 'name' => Member.find(1).name }, entry['member'])
+    # Associations that are not set are omitted rather than rendered as null.
+    assert_not entry.key?('version')
+    assert_not entry.key?('issue_category')
+    assert_equal [{ 'idPattern' => '.*', 'type' => 'TemperatureSensor' }], entry['entities']
+    assert_equal ['temperature'], entry['attrs']
+    assert_equal false, entry['published']
+  end
+
+  def template_attributes(overrides = {})
+    {
+      broker_connection_id: @connection.id, status: 'active',
+      subject: 'Sensor ${id}', description: 'A monitored value changed',
+      entities_string: '[{"idPattern": ".*", "type": "TemperatureSensor"}]',
+      project_id: @project.id, tracker_id: 1, issue_status_id: 1,
+      issue_priority_id: IssuePriority.first.id, member_id: 1
+    }.merge(overrides)
+  end
+
+  def test_index_paginates
+    5.times { |i| SubscriptionTemplate.create!(template_attributes(name: "Extra #{i}")) }
+    get "/projects/#{@project.id}/subscription_templates.json?limit=2&offset=1", headers: auth
+    assert_response :success
+    assert_equal 6, json['total_count']
+    assert_equal 1, json['offset']
+    assert_equal 2, json['limit']
+    assert_equal 2, json['subscription_templates'].size
+  end
+
+  def test_show_returns_one_subscription
+    get "/projects/#{@project.id}/subscription_templates/#{@template.id}.json", headers: auth
+    assert_response :success
+    assert_equal @template.id, json['subscription_template']['id']
+    assert_equal 'Sensor ${id}', json['subscription_template']['subject']
+  end
+
+  def test_show_supports_xml
+    get "/projects/#{@project.id}/subscription_templates/#{@template.id}.xml", headers: auth
+    assert_response :success
+    assert_equal 'application/xml', response.media_type
+    assert_select 'subscription_template > name', text: 'API alerts'
+  end
+
+  # The webhook secret authenticates broker notifications: it must never leave
+  # the server, and neither must the connection's stored broker token.
+  def test_responses_never_expose_secrets
+    get "/projects/#{@project.id}/subscription_templates.json", headers: auth
+    assert_response :success
+    assert_not_includes response.body, @template.reload.webhook_secret
+    assert_not_includes response.body, 'webhook_secret'
+    assert_not_includes response.body, 'do-not-leak-me'
+
+    get "/projects/#{@project.id}/subscription_templates/#{@template.id}.json", headers: auth
+    assert_not_includes response.body, @template.webhook_secret
+    assert_not_includes response.body, 'do-not-leak-me'
+  end
+
+  # A subscription of another project is not reachable through this project's
+  # collection, even for a user who may manage this one.
+  def test_show_scopes_to_the_project
+    other_project = Project.generate!
+    other_project.enabled_module_names = other_project.enabled_module_names | ['gtt_fiware']
+    other_project.trackers = [Tracker.find(1)]
+    member = Member.create!(project: other_project, user: @user, roles: [Role.find(1)])
+    foreign = SubscriptionTemplate.create!(
+      template_attributes(name: 'Elsewhere', project_id: other_project.id, member_id: member.id)
+    )
+
+    get "/projects/#{@project.id}/subscription_templates/#{foreign.id}.json", headers: auth
+    assert_response :not_found
+  end
+
+  # --- writing --------------------------------------------------------------
+
+  def create_payload(overrides = {})
+    {
+      subscription_template: {
+        broker_connection_id: @connection.id,
+        name: 'Created over the API',
+        subject: 'Sensor ${id}',
+        description: 'Entity ${id} changed.',
+        # API clients send structures where the form sends JSON strings.
+        entities: [{ type: 'WasteContainer', idPattern: '.*' }],
+        attrs: %w[fillingLevel temperature],
+        tracker_id: 1,
+        issue_status_id: 1,
+        issue_priority_id: IssuePriority.first.id,
+        member_id: 1
+      }.merge(overrides)
+    }
+  end
+
+  def test_create_accepts_structured_entities_and_attrs
+    assert_difference 'SubscriptionTemplate.count', 1 do
+      post "/projects/#{@project.id}/subscription_templates.json",
+           params: create_payload.to_json,
+           headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    end
+    assert_response :created
+    created = SubscriptionTemplate.order(id: :desc).first
+    assert_equal 'Created over the API', created.name
+    assert_equal [{ 'type' => 'WasteContainer', 'idPattern' => '.*' }], created.entities
+    assert_equal %w[fillingLevel temperature], JSON.parse(created.attrs)
+    # The response is the created resource, with a Location header.
+    assert_equal created.id, json['subscription_template']['id']
+    assert_match %r{/subscription_templates/#{created.id}\z}, response.headers['Location']
+  end
+
+  # Omitting alteration_types must leave the model default in place rather
+  # than storing "no triggers" (the form's unchecked-box semantics).
+  def test_create_keeps_the_default_alteration_types
+    post "/projects/#{@project.id}/subscription_templates.json",
+         params: create_payload.to_json,
+         headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :created
+    assert_equal %w[entityCreate entityChange],
+                 SubscriptionTemplate.order(id: :desc).first.alteration_types
+    # And the create response renders them as an array of names, not the
+    # serialized string the in-memory record still carries.
+    assert_equal %w[entityCreate entityChange], json['subscription_template']['alteration_types']
+  end
+
+  def test_create_still_accepts_the_string_form
+    post "/projects/#{@project.id}/subscription_templates.json",
+         params: create_payload(entities: nil,
+                                entities_string: '[{"type": "Room"}]',
+                                attrs: '["temperature"]').to_json,
+         headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :created
+    assert_equal [{ 'type' => 'Room' }], SubscriptionTemplate.order(id: :desc).first.entities
+  end
+
+  def test_create_reports_validation_errors
+    assert_no_difference 'SubscriptionTemplate.count' do
+      post "/projects/#{@project.id}/subscription_templates.json",
+           params: create_payload(name: '').to_json,
+           headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    end
+    assert_response :unprocessable_entity
+    assert json['errors'].any?
+  end
+
+  def test_update_changes_a_subscription
+    put "/projects/#{@project.id}/subscription_templates/#{@template.id}.json",
+        params: { subscription_template: { name: 'Renamed over the API' } }.to_json,
+        headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :no_content
+    assert_equal 'Renamed over the API', @template.reload.name
+  end
+
+  def test_update_reports_validation_errors
+    put "/projects/#{@project.id}/subscription_templates/#{@template.id}.json",
+        params: { subscription_template: { name: '' } }.to_json,
+        headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :unprocessable_entity
+    assert_equal 'API alerts', @template.reload.name
+  end
+
+  def test_destroy_removes_a_subscription
+    assert_difference 'SubscriptionTemplate.count', -1 do
+      delete "/projects/#{@project.id}/subscription_templates/#{@template.id}.json", headers: auth
+    end
+    assert_response :no_content
+  end
+
+  # --- authentication and authorization ------------------------------------
+
+  def test_requests_without_credentials_are_rejected
+    get "/projects/#{@project.id}/subscription_templates.json"
+    assert_response :unauthorized
+  end
+
+  def test_requests_without_the_permission_are_rejected
+    Role.find(1).remove_permission!(:manage_subscription_templates)
+    get "/projects/#{@project.id}/subscription_templates.json", headers: auth
+    assert_response :forbidden
+  end
+
+  def test_requests_are_rejected_when_the_module_is_disabled
+    @project.enabled_module_names = @project.enabled_module_names - ['gtt_fiware']
+    get "/projects/#{@project.id}/subscription_templates.json", headers: auth
+    assert_response :forbidden
+  end
+
+  # --- html surfaces --------------------------------------------------------
+
+  # index/show exist for the API; a browser is sent to the pages that show the
+  # same data.
+  def test_html_index_redirects_to_the_project_tab
+    log_user('jsmith', 'jsmith')
+    get "/projects/#{@project.id}/subscription_templates"
+    assert_redirected_to "/projects/#{@project.identifier}/settings/subscription_templates"
+  end
+
+  def test_html_show_redirects_to_the_edit_form
+    log_user('jsmith', 'jsmith')
+    get "/projects/#{@project.id}/subscription_templates/#{@template.id}"
+    assert_redirected_to "/projects/#{@project.identifier}/subscription_templates/#{@template.id}/edit"
+  end
+end

--- a/test/functional/subscription_templates_api_test.rb
+++ b/test/functional/subscription_templates_api_test.rb
@@ -207,6 +207,26 @@ class SubscriptionTemplatesApiTest < Redmine::IntegrationTest
     assert_equal geojson, SubscriptionTemplate.order(id: :desc).first.geometry
   end
 
+  # The project comes from the route: a project_id in the payload must not
+  # move the subscription somewhere else, on create or on update.
+  def test_create_ignores_a_project_id_in_the_payload
+    other_project = Project.generate!
+    post "/projects/#{@project.id}/subscription_templates.json",
+         params: create_payload(project_id: other_project.id).to_json,
+         headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :created
+    assert_equal @project.id, SubscriptionTemplate.order(id: :desc).first.project_id
+  end
+
+  def test_update_ignores_a_project_id_in_the_payload
+    other_project = Project.generate!
+    put "/projects/#{@project.id}/subscription_templates/#{@template.id}.json",
+        params: { subscription_template: { project_id: other_project.id } }.to_json,
+        headers: auth.merge('CONTENT_TYPE' => 'application/json')
+    assert_response :no_content
+    assert_equal @project.id, @template.reload.project_id
+  end
+
   def test_create_reports_validation_errors
     assert_no_difference 'SubscriptionTemplate.count' do
       post "/projects/#{@project.id}/subscription_templates.json",


### PR DESCRIPTION
Closes #22.

## What

Subscriptions can be listed, read, created, updated and deleted over Redmine's REST API, in JSON and XML, authenticated and authorized like any other Redmine resource (API key or Basic auth, the *Manage Subscriptions* permission, the project module).

| Method | Path |
| --- | --- |
| GET | `/projects/:project_id/subscription_templates.json` (paginated, `total_count`) |
| GET | `/projects/:project_id/subscription_templates/:id.json` |
| POST | `/projects/:project_id/subscription_templates.json` |
| PUT | `/projects/:project_id/subscription_templates/:id.json` |
| DELETE | `/projects/:project_id/subscription_templates/:id.json` |

Notes on the design:

- **index/show are new.** In a browser they redirect to the project's FIWARE tab and to the edit form - the HTML surfaces for the same data - so no new HTML views. `index` also moved under the project; it was the one project-less action, left over from before the settings tab owned the list.
- **Nothing sensitive is rendered.** The per-subscription webhook secret authenticates broker notifications, so it never leaves the server; the connection is rendered as id/name/standard only, because that record holds the stored broker token. Both are pinned by a test.
- **Structures in, structures out.** API clients send `entities`, `attachments`, `geometry` as objects/arrays and `attrs` as an array of names; the form's `*_string` variants are accepted too, and the model keeps validating the shape in one place. Associations render as `id`/`name` references and are omitted when unset.
- **Omitting `alteration_types` now leaves the model default** instead of storing "no triggers" - the form's unchecked-box semantics (absent means none) are wrong for an API.
- **Publishing stays out of the API**, since non-stored connections need the browser token flow; `subscription_id` and `published` report the broker state. FIWARE connections stay an administration-only surface.

Documented in [doc/api.md](doc/api.md), linked from the doc index.

## Verification

- Rails suite: 295 runs, 1069 assertions, 0 failures. 18 new tests run as an integration test, so they exercise real routing, format negotiation and API-key auth: reading (JSON + XML, pagination, references, project scoping), writing (structured and string payloads, validation errors, Location header, defaults), auth (no credentials → 401, no permission → 403, module off → 403), the no-secret guarantee, and the HTML redirects.
- Live on the demo instance: list, show, create with structured `entities`/`attrs`, update, delete, XML - and `grep` for the webhook secret and broker token in responses comes back empty.

Two bugs the live pass caught that the unit-level view would have missed: the API builders are `BasicObject`s, so `api.send(:tag, …)` was being swallowed as a tag literally named "send" and silently dropped every association (now `__send__`, with the associations asserted); and a just-created record still carries `alteration_types` as the serialized string, which rendered as a one-element array containing JSON (now normalized, with the create response asserted).