### PR TITLE
Bump plugin version to 3.2.0

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,7 +1,7 @@
 # REST API
 
-Subscriptions can be read and written over Redmine's REST API, in JSON and
-XML. Enable **Administration → Settings → API → Enable REST
+Since version 3.2 subscriptions can be read and written over Redmine's REST
+API, in JSON and XML. Enable **Administration → Settings → API → Enable REST
 web service** first, and authenticate as usual: an `X-Redmine-API-Key` header,
 `key=` parameter, or HTTP Basic. The acting user needs the *Manage
 Subscriptions* permission in the project, and the project needs the GTT FIWARE

--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '3.1.0'
+  version '3.2.0'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Release preparation for v3.2.0.

- `init.rb`: 3.1.0 → 3.2.0
- `doc/api.md`: restores the "Since version 3.2" line that was deliberately left out of #128, so main never claimed a version `init.rb` did not have

Contents of the release: the guided subscription flow (#102), Issue details following the tracker including custom field templates (#103), boundary crossing notes (#87), the REST API (#22), the on-demand NGSI-LD entity endpoint (#4), and the fix for issues created from notifications not being emitted (#120).