### PR TITLE
Offer NGSI-LD in the issue page's export list

### DIFF
--- a/app/overrides/issues/show.rb
+++ b/app/overrides/issues/show.rb
@@ -1,0 +1,12 @@
+# Adds NGSI-LD to Redmine's own "Also available in" list at the bottom of the
+# issue page, next to PDF, Atom and (with redmine_gtt) GeoJSON, instead of
+# repeating a second export line of its own below the description.
+#
+# Anchored on the Atom link so the entry lands last, after the GeoJSON one
+# redmine_gtt inserts after the PDF link.
+Deface::Override.new(
+  virtual_path: 'issues/show',
+  name: 'deface_view_issues_show_format_ngsi_ld',
+  insert_after: "erb[loud]:contains('Atom')",
+  partial: 'issues/show/ngsi_ld'
+)

--- a/app/views/gtt_fiware/_entity_link.html.erb
+++ b/app/views/gtt_fiware/_entity_link.html.erb
@@ -1,8 +1,0 @@
-<%# Link to the issue's NGSI-LD representation (#4). Shown when the instance
-    has an identifier to mint entity ids with. %>
-<% if RedmineGttFiware::Emitter.instance_id.present? %>
-  <p class="other-formats">
-    <%= l(:label_fiware_entity_link) %>:
-    <span><%= link_to 'NGSI-LD', url_for(controller: 'fiware_entities', action: 'show', id: issue.id) %></span>
-  </p>
-<% end %>

--- a/app/views/issues/show/_ngsi_ld.html.erb
+++ b/app/views/issues/show/_ngsi_ld.html.erb
@@ -1,0 +1,9 @@
+<%# The issue's NGSI-LD representation (#4), offered like any other export
+    format. Shown only when the instance has an identifier to mint entity ids
+    with, which is also what FiwareEntitiesController requires. %>
+<% if RedmineGttFiware::Emitter.instance_id.present? %>
+<%=
+  Redmine::Views::OtherFormatsBuilder.new(self).link_to('NGSI-LD',
+      url: { controller: 'fiware_entities', action: 'show', id: @issue.id, format: nil })
+%>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -86,7 +86,6 @@ de:
   field_federation_watch: 'Föderations-Beobachtung'
   text_federation_watch_info: 'Diese Subscription beobachtet die Arbeitsaufträge anderer Organisationen, statt Tickets zu erstellen: fremde Statusänderungen werden als Kommentare an lokalen Tickets vermerkt, die auf dieselbe Entität verweisen. Entitätsfilter auf Typ Issue und beobachtete Attribute auf status setzen.'
   text_federation_status_note: 'Föderations-Update: Der Arbeitsauftrag von %{org} ist jetzt %{status} (%{urn})'
-  label_fiware_entity_link: 'Auch verfügbar als'
   gtt_fiware_settings_emission: 'Ticket-Übertragung'
   field_fiware_instance_id: 'Instanz-Kennung'
   text_fiware_instance_id_info: 'Buchstaben, Ziffern, Bindestrich und Unterstrich. Teil jeder übertragenen Entitäts-ID (urn:ngsi-ld:Issue:redmine:<instanz>:<ticket>). Ohne Wert bleibt die Übertragung aus; eine spätere Änderung vergibt allen übertragenen Entitäten neue IDs.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,6 @@ en:
   field_federation_watch: "Federation watch"
   text_federation_watch_info: "This subscription watches other organizations' work orders instead of creating issues: foreign status changes are added as notes to local issues that refer to the same entity. Set the entity filter to type Issue and the watched attributes to status."
   text_federation_status_note: "Federation update: the work order by %{org} is now %{status} (%{urn})"
-  label_fiware_entity_link: "Also available as"
   gtt_fiware_settings_emission: "Issue Emission"
   field_fiware_instance_id: "Instance identifier"
   text_fiware_instance_id_info: "Letters, digits, hyphen and underscore. Becomes part of every emitted entity id (urn:ngsi-ld:Issue:redmine:<instance>:<issue>). Emission stays off while blank; changing it later re-identifies every emitted entity."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -57,7 +57,6 @@ ja:
   field_federation_watch: "フェデレーション監視"
   text_federation_watch_info: "このサブスクリプションはチケットを作成せず、他組織のワークオーダーを監視します。同じエンティティを参照するローカルのチケットに、他組織のステータス変更を注記として追加します。エンティティフィルタをタイプIssue、監視属性をstatusに設定してください。"
   text_federation_status_note: "フェデレーション更新：%{org} のワークオーダーは %{status} になりました（%{urn}）"
-  label_fiware_entity_link: "他の形式"
   gtt_fiware_settings_emission: "チケット送信"
   field_fiware_instance_id: "インスタンス識別子"
   text_fiware_instance_id_info: "英数字、ハイフン、アンダースコアのみ。送信されるすべてのエンティティID（urn:ngsi-ld:Issue:redmine:<instance>:<issue>）に含まれます。空欄の間は送信されません。後から変更するとすべての送信済みエンティティのIDが変わります。"

--- a/doc/issue_emission.md
+++ b/doc/issue_emission.md
@@ -77,6 +77,6 @@ them. For federation, configure the host name.
 ## Issues as NGSI-LD on demand
 
 Every issue is also available as an NGSI-LD entity at
-`GET /fiware/issues/<id>/entity` (session or API key; the issue page links to
-it as "Also available as: NGSI-LD"). This returns the same representation the
-emitter publishes.
+`GET /fiware/issues/<id>/entity` (session or API key). The issue page links to
+it from its "Also available in" list, next to PDF and Atom. This returns the
+same representation the emitter publishes.

--- a/init.rb
+++ b/init.rb
@@ -53,6 +53,13 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   end
 end
 
+# Deface overrides are not autoloaded (they define no constants), so they are
+# required here and hidden from Zeitwerk, the same way redmine_gtt does it.
+Dir.glob("#{Rails.root}/plugins/redmine_gtt_fiware/app/overrides/**/*.rb").each do |path|
+  Rails.autoloaders.main.ignore(path)
+  require path
+end
+
 Rails.application.config.after_initialize do
   RedmineGttFiware.setup
 end

--- a/init.rb
+++ b/init.rb
@@ -55,7 +55,9 @@ end
 
 # Deface overrides are not autoloaded (they define no constants), so they are
 # required here and hidden from Zeitwerk, the same way redmine_gtt does it.
-Dir.glob("#{Rails.root}/plugins/redmine_gtt_fiware/app/overrides/**/*.rb").each do |path|
+# Resolved from __dir__ rather than Rails.root, so the directory this plugin
+# happens to be installed under does not matter.
+Dir.glob(File.join(__dir__, 'app', 'overrides', '**', '*.rb')).each do |path|
   Rails.autoloaders.main.ignore(path)
   require path
 end

--- a/lib/redmine_gtt_fiware/view_hooks.rb
+++ b/lib/redmine_gtt_fiware/view_hooks.rb
@@ -8,7 +8,8 @@ module RedmineGttFiware
     # Federation panel (#70, 4b) below the issue description.
     render_on :view_issues_show_description_bottom, partial: 'gtt_fiware/federation_panel'
 
-    # Link to the issue's NGSI-LD representation (#4).
-    render_on :view_issues_show_description_bottom, partial: 'gtt_fiware/entity_link'
+    # The link to the issue's NGSI-LD representation (#4) is not a hook: it
+    # belongs in the core "Also available in" list, which has no hook, so it
+    # is a Deface override (app/overrides/issues/show.rb).
   end
 end

--- a/test/functional/issue_other_formats_test.rb
+++ b/test/functional/issue_other_formats_test.rb
@@ -1,0 +1,35 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+# The NGSI-LD entry in the issue page's "Also available in" list (#4).
+# An integration test on purpose: what is under test is a Deface override and
+# its CSS selector, and those only take effect when the real issues/show
+# template renders. A stale selector would silently insert nothing.
+class IssueOtherFormatsTest < Redmine::IntegrationTest
+  fixtures :all
+
+  INSTANCE_SETTINGS = { 'fiware_instance_id' => 'test-town' }.freeze
+
+  def setup
+    log_user('jsmith', 'jsmith')
+    @issue = Issue.find(1)
+  end
+
+  def test_lists_ngsi_ld_among_the_other_formats
+    with_settings plugin_redmine_gtt_fiware: INSTANCE_SETTINGS do
+      get "/issues/#{@issue.id}"
+    end
+    assert_response :success
+    assert_select 'p.other-formats' do
+      assert_select "a[href=?]", "/fiware/issues/#{@issue.id}/entity", text: 'NGSI-LD'
+    end
+  end
+
+  def test_omits_ngsi_ld_without_an_instance_identifier
+    with_settings plugin_redmine_gtt_fiware: { 'fiware_instance_id' => '' } do
+      get "/issues/#{@issue.id}"
+    end
+    assert_response :success
+    assert_select 'p.other-formats'
+    assert_select 'p.other-formats a', text: 'NGSI-LD', count: 0
+  end
+end

--- a/test/functional/issue_other_formats_test.rb
+++ b/test/functional/issue_other_formats_test.rb
@@ -19,7 +19,9 @@ class IssueOtherFormatsTest < Redmine::IntegrationTest
       get "/issues/#{@issue.id}"
     end
     assert_response :success
-    assert_select 'p.other-formats' do
+    # count: 1 is the point of the change: the link used to live in a second
+    # p.other-formats of the plugin's own below the description.
+    assert_select 'p.other-formats', count: 1 do
       assert_select "a[href=?]", "/fiware/issues/#{@issue.id}/entity", text: 'NGSI-LD'
     end
   end
@@ -29,7 +31,7 @@ class IssueOtherFormatsTest < Redmine::IntegrationTest
       get "/issues/#{@issue.id}"
     end
     assert_response :success
-    assert_select 'p.other-formats'
+    assert_select 'p.other-formats', count: 1
     assert_select 'p.other-formats a', text: 'NGSI-LD', count: 0
   end
 end


### PR DESCRIPTION
The issue page had two export lists: Redmine's own `p.other-formats` at the
bottom ("Also available in: PDF, GeoJSON, Atom") plus a second line of the same
class below the description, added by this plugin, reading "Also available as:
NGSI-LD". NGSI-LD is just another export format, so it now sits with the others.

Before: two lists, the plugin's one below the description.
After: `Also available in: PDF  GeoJSON  Atom  NGSI-LD`

## How

The core list has no view hook, so this is a Deface override anchored on the
Atom link, the same mechanism `redmine_gtt` uses to add GeoJSON (which anchors
on PDF, hence the ordering). Overrides are `require`d from `init.rb` and hidden
from Zeitwerk, again following `redmine_gtt`. The `view_issues_show_description_bottom`
hook and the `_entity_link` partial are gone, as is the now-unused
`label_fiware_entity_link` string in all three locales.

## Verification

`test/functional/issue_other_formats_test.rb` asserts the link inside
`p.other-formats`, and its absence when no instance identifier is set (there is
no representation to serve then, and `FiwareEntitiesController` 404s). It is an
integration test on purpose: a stale CSS selector would silently insert nothing
and a unit test would not notice. Confirmed it does catch that, by pointing the
selector at a non-existent element and watching it fail.

Full suite: 301 runs, 1092 assertions, 0 failures. On the dev instance the
rendered list is `PDF GeoJSON Atom NGSI-LD` with exactly one `p.other-formats`
on the page, and the link returns the entity as `application/ld+json`.
