### PR TITLE
Bump plugin version to 3.2.1

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '3.2.0'
+  version '3.2.1'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Patch release for #131 (the NGSI-LD link moved into Redmine's own "Also available in" list). No schema, API or settings change, so nothing to migrate.

`doc/api.md` says "Since version 3.2", which stays correct on the 3.2 line and is left alone.