### PR TITLE
ci: actually run the Zeitwerk check

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -139,15 +139,21 @@ jobs:
           bundle exec rake generate_secret_token
           bundle exec rake db:create db:migrate redmine:plugins:migrate
 
+      # Eager-load gate. Test and development environments load lazily, so a
+      # filename/constant mismatch nothing references at boot can still make a
+      # production instance (which eager loads) die with a NameError. That is
+      # what happened to redmine_gtt_sync: green CI, unbootable production.
+      #
+      # This previously ran only `if grep -q zeitwerk config/application.rb`,
+      # which never matches: Redmine configures Zeitwerk in
+      # config/initializers/zeitwerk.rb, not application.rb. The step therefore
+      # passed without ever running the task. The rake task ships with Rails 6+,
+      # so every row in this matrix has it and no guard is needed.
       - name: Zeitwerk check
         env:
           RAILS_ENV: test
         working-directory: redmine
-        run: |
-          if grep -q zeitwerk config/application.rb ; then
-            bundle exec rake zeitwerk:check
-          fi
-        shell: bash
+        run: bundle exec rake zeitwerk:check
 
       - name: Run tests
         env:


### PR DESCRIPTION
Same dead guard as gtt-project/redmine_gtt#423: the Zeitwerk check step in `test-postgis.yml` has never run.

```bash
if grep -q zeitwerk config/application.rb ; then
  bundle exec rake zeitwerk:check
fi
```

`config/application.rb` mentions Zeitwerk in no supported Redmine version — it is configured in `config/initializers/zeitwerk.rb` — so the grep always fails and the step exits 0 having done nothing. It reports green, which makes the repository look covered when it is not.

## Why it matters

`eager_load` is false in test and development, true in production. A filename/constant mismatch nothing references at boot therefore passes every test and then kills a production instance at startup.

`redmine_gtt_sync` shipped exactly that: green CI on Redmine 6.1 and 7.0, while every production image built over almost four weeks failed to boot with `uninitialized constant RedmineGttSync::Oauth`. This task reproduces that failure, so an active gate would have caught it immediately.

## The change

Drop the guard and run the task unconditionally; it ships with Rails 6+, so every matrix row has it.

Verified against Redmine 7.0.0 / Ruby 4.0.6 with this plugin at v3.2.1 installed alongside nine others: `rake zeitwerk:check` reports "All is good!", so this should stay green.