### PR TITLE
Unify broker endpoint building and HTTP transport

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -24,7 +24,10 @@ class SubscriptionIssuesController < ApplicationController
   skip_before_action :check_if_login_required, only: [:create]
   before_action :authenticate_webhook, only: [:create]
 
-  WEBHOOK_SECRET_HEADER = 'X-Gtt-Webhook-Secret'.freeze
+  # The header name is protocol shared with the broker: subscriptions embed it
+  # (SubscriptionRequest), notifications carry it back here. One definition,
+  # or the two sides drift and every new subscription fails authentication.
+  WEBHOOK_SECRET_HEADER = RedmineGttFiware::SubscriptionRequest::WEBHOOK_SECRET_HEADER
 
   # Processes every entity in the notification. Returns 200 with a summary when
   # at least one issue was persisted, and 422 only when the whole batch failed

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -229,19 +229,13 @@ class SubscriptionTemplatesController < ApplicationController
       return nil
     end
 
-    template = SubscriptionTemplate.new(broker_connection: connection)
-    request_builder = RedmineGttFiware::SubscriptionRequest.build(template, base_url: callback_base_url)
-    uri = URI(request_builder.entities_url)
-    uri.query = URI.encode_www_form(type: entity_type, limit: 1)
-
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == 'https')
-    headers = { 'Accept' => 'application/json' }
-    if connection.stored_auth? && (pair = connection.token_header_pair(connection.auth_token))
-      headers[pair.first] = pair.last
-    end
-    headers.merge!(request_builder.tenant_headers)
-    response = http.request(Net::HTTP::Get.new(uri.request_uri, headers))
+    url = "#{connection.api_base}/entities?#{URI.encode_www_form(type: entity_type, limit: 1)}"
+    response = RedmineGttFiware::BrokerHttp.request(
+      :get, url,
+      connection: connection,
+      token: connection.stored_auth? ? connection.auth_token : nil,
+      headers: { 'Accept' => 'application/json' }
+    )
 
     unless response.is_a?(Net::HTTPSuccess)
       @preview_error = l(:preview_broker_error, code: response.code)
@@ -334,17 +328,11 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def fetch_remote_subscription
-    uri = URI(@subscription_request.subscription_url)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == 'https')
-
-    headers = {}
-    if (pair = @subscription_template.broker_connection.token_header_pair(@fiware_broker_auth_token))
-      headers[pair.first] = pair.last
-    end
-    headers.merge!(@subscription_request.tenant_headers)
-    # request_uri keeps any query string and never yields an empty path.
-    http.request(Net::HTTP::Get.new(uri.request_uri, headers))
+    RedmineGttFiware::BrokerHttp.request(
+      :get, @subscription_request.subscription_url,
+      connection: @subscription_template.broker_connection,
+      token: @fiware_broker_auth_token
+    )
   end
 
   # Maps the broker's reported subscription state onto the local status.
@@ -566,29 +554,22 @@ class SubscriptionTemplatesController < ApplicationController
       return false
     end
 
-    uri = URI(@broker_url)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == 'https')
-
-    headers = {}
-    if (pair = @subscription_template.broker_connection.token_header_pair(@fiware_broker_auth_token))
-      headers[pair.first] = pair.last
-    end
-    headers['Content-Type'] = @subscription_request.content_type if action == 'publish'
-    headers.merge!(@subscription_request.tenant_headers)
-
-    request = case action
-              when 'publish'
-                Net::HTTP::Post.new(uri.path, headers).tap { |req| req.body = @json_payload }
-              when 'unpublish'
-                Net::HTTP::Delete.new(uri.path, headers)
-              else
-                Rails.logger.error "Unknown action: #{action}"
-                @error_message = l(:general_action_error)
-                return false
-              end
-
-    response = http.request(request)
+    connection = @subscription_template.broker_connection
+    response = case action
+               when 'publish'
+                 RedmineGttFiware::BrokerHttp.request(
+                   :post, @broker_url, connection: connection, token: @fiware_broker_auth_token,
+                   body: @json_payload, content_type: @subscription_request.content_type
+                 )
+               when 'unpublish'
+                 RedmineGttFiware::BrokerHttp.request(
+                   :delete, @broker_url, connection: connection, token: @fiware_broker_auth_token
+                 )
+               else
+                 Rails.logger.error "Unknown action: #{action}"
+                 @error_message = l(:general_action_error)
+                 return false
+               end
 
     Rails.logger.info "FIWARE Broker Response Code: #{response.code}"
     Rails.logger.info "FIWARE Broker Response Message: #{response.message}"

--- a/app/models/broker_connection.rb
+++ b/app/models/broker_connection.rb
@@ -95,6 +95,48 @@ class BrokerConnection < (defined?(ApplicationRecord) == 'constant' ? Applicatio
     standard.to_s.casecmp('NGSI-LD').zero?
   end
 
+  # Recognizes a version segment already present in the URL path, per
+  # standard. NGSIv2 accepts /v2 with or without a minor version (/v2.1).
+  VERSIONED_PATH_PATTERNS = {
+    'NGSI-LD' => %r{/ngsi-ld/v\d+(/|\z)},
+    'NGSIv2' => %r{/v2(\.\d+)?(/|\z)}
+  }.freeze
+
+  # Default version prefix appended when the URL does not name one.
+  DEFAULT_VERSION_PREFIXES = {
+    'NGSI-LD' => 'ngsi-ld/v1',
+    'NGSIv2' => 'v2'
+  }.freeze
+
+  # The API root every broker request builds on: the connection URL with the
+  # standard's version prefix, without a trailing slash. A URL that already
+  # carries a versioned path is used as-is; otherwise the default prefix is
+  # appended to the URL's path. Appended, never substituted: a broker mounted
+  # under a path prefix (https://host/broker) must keep that prefix
+  # (https://host/broker/ngsi-ld/v1), which absolute-path URI merging would
+  # silently drop.
+  def api_base
+    key = ngsi_ld? ? 'NGSI-LD' : 'NGSIv2'
+    uri = URI(url)
+    path = uri.path.chomp('/')
+    uri.path = path.match?(VERSIONED_PATH_PATTERNS[key]) ? path : "#{path}/#{DEFAULT_VERSION_PREFIXES[key]}"
+    uri.to_s
+  end
+
+  # Tenant headers for broker requests: NGSIv2 uses Fiware-Service /
+  # Fiware-ServicePath, NGSI-LD uses NGSILD-Tenant (no service path).
+  def tenant_headers
+    return {} if fiware_service.blank?
+
+    if ngsi_ld?
+      { 'NGSILD-Tenant' => fiware_service }
+    else
+      headers = { 'Fiware-Service' => fiware_service }
+      headers['Fiware-ServicePath'] = fiware_servicepath if fiware_servicepath.present?
+      headers
+    end
+  end
+
   # How the broker expects its token (#99). Blank token_header keeps the
   # Authorization: Bearer scheme; any other value names the header the raw
   # token is sent in (X-Api-Key, X-Auth-Token, ...).

--- a/app/models/broker_connection.rb
+++ b/app/models/broker_connection.rb
@@ -120,6 +120,10 @@ class BrokerConnection < (defined?(ApplicationRecord) == 'constant' ? Applicatio
     uri = URI(url)
     path = uri.path.chomp('/')
     uri.path = path.match?(VERSIONED_PATH_PATTERNS[key]) ? path : "#{path}/#{DEFAULT_VERSION_PREFIXES[key]}"
+    # Callers append "/subscriptions" etc. as plain strings, so a query or
+    # fragment in the configured URL would corrupt every built URL.
+    uri.query = nil
+    uri.fragment = nil
     uri.to_s
   end
 

--- a/lib/redmine_gtt_fiware/broker_http.rb
+++ b/lib/redmine_gtt_fiware/broker_http.rb
@@ -1,0 +1,56 @@
+require 'net/http'
+require 'uri'
+
+module RedmineGttFiware
+  # The one place broker HTTP requests are built and sent. Every caller
+  # (publish/unpublish, sync, preview, emission, federation queries) goes
+  # through here, so timeouts and the auth/tenant header conventions cannot
+  # drift between call sites.
+  #
+  # Responses are returned as-is and network errors are raised as-is: what a
+  # failure means (log and continue, show the user an error, degrade to an
+  # empty list) is the caller's decision, not the transport's.
+  class BrokerHttp
+    # Short timeouts: broker calls run inside web requests or issue saves,
+    # where a hung broker must not pin a worker for net/http's 60s defaults.
+    OPEN_TIMEOUT = 5 # seconds
+    READ_TIMEOUT = 10 # seconds
+
+    REQUEST_CLASSES = {
+      get: Net::HTTP::Get,
+      post: Net::HTTP::Post,
+      patch: Net::HTTP::Patch,
+      delete: Net::HTTP::Delete
+    }.freeze
+
+    # Sends one request to a full URL (usually built from
+    # BrokerConnection#api_base) and returns the Net::HTTPResponse.
+    #
+    # connection: supplies the tenant headers and the auth header scheme.
+    # token: the auth token to send, turned into the connection's header via
+    #   BrokerConnection#token_header_pair; nil or blank sends no auth header.
+    #   Passed separately from the connection because browser/proxied modes
+    #   supply a per-request token that is never stored on the connection.
+    # body: a String is sent verbatim, anything else is JSON-encoded.
+    def self.request(method, url, connection:, token: nil, headers: {}, body: nil, content_type: nil)
+      uri = URI(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == 'https')
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+
+      request_headers = connection ? connection.tenant_headers.dup : {}
+      if connection && (pair = connection.token_header_pair(token))
+        request_headers[pair.first] = pair.last
+      end
+      request_headers['Content-Type'] = content_type if content_type
+      request_headers.merge!(headers)
+
+      # request_uri (not path) keeps any query string and never yields the
+      # empty path Net::HTTP rejects for a bare-host URL.
+      request = REQUEST_CLASSES.fetch(method).new(uri.request_uri, request_headers)
+      request.body = body.is_a?(String) ? body : body.to_json if body
+      http.request(request)
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/emitter.rb
+++ b/lib/redmine_gtt_fiware/emitter.rb
@@ -7,8 +7,9 @@ module RedmineGttFiware
   # broker must never block saving an issue. This class is the seam for a
   # later job-based backend.
   class Emitter
-    OPEN_TIMEOUT = 5
-    READ_TIMEOUT = 10
+    # URN-safe slug; anything else counts as unset so a stray value cannot
+    # produce malformed entity ids.
+    INSTANCE_ID_PATTERN = /\A[A-Za-z0-9_-]+\z/
 
     class << self
       # Wraps NotificationProcessor issue writes: issues created or updated
@@ -26,10 +27,6 @@ module RedmineGttFiware
       def suppressed?
         Thread.current[:gtt_fiware_suppress_emission] == true
       end
-
-      # URN-safe slug; anything else counts as unset so a stray value cannot
-      # produce malformed entity ids.
-      INSTANCE_ID_PATTERN = /\A[A-Za-z0-9_-]+\z/
 
       # The instance identifier baked into every emitted URN. Emission is off
       # until the admin sets it (and it must stay stable once set - changing
@@ -88,37 +85,14 @@ module RedmineGttFiware
         end
       end
 
-      def request(connection, method, resource, body = nil)
-        uri = URI(connection.url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = (uri.scheme == 'https')
-        http.open_timeout = OPEN_TIMEOUT
-        http.read_timeout = READ_TIMEOUT
-
-        klass = { post: Net::HTTP::Post, patch: Net::HTTP::Patch, delete: Net::HTTP::Delete }.fetch(method)
-        req = klass.new("#{ld_path(uri)}/#{resource}", headers(connection, body))
-        req.body = body.to_json if body
-        http.request(req)
-      end
-
       # The payload embeds @context (PATCH bodies inherit the entity's), so
       # bodies are declared as JSON-LD. Server-side emission can only use a
       # stored token; a token-less or browser-mode connection emits
       # unauthenticated (fine for open brokers, 401s are logged otherwise).
-      def headers(connection, body)
-        result = {}
-        result['Content-Type'] = 'application/ld+json' if body
-        result['NGSILD-Tenant'] = connection.fiware_service if connection.fiware_service.present?
-        pair = connection.token_header_pair(connection.auth_token)
-        result[pair.first] = pair.last if pair
-        result
-      end
-
-      # Preserve an explicit /ngsi-ld/v1 path in the connection URL, append
-      # the default prefix otherwise (same convention as SubscriptionRequest).
-      def ld_path(uri)
-        path = uri.path.chomp('/')
-        path.match?(%r{/ngsi-ld/v1\z}) ? path : "#{path}/ngsi-ld/v1"
+      def request(connection, method, resource, body = nil)
+        BrokerHttp.request(method, "#{connection.api_base}/#{resource}",
+                           connection: connection, token: connection.auth_token,
+                           body: body, content_type: body ? 'application/ld+json' : nil)
       end
 
       def log_failure(issue, connection, response)

--- a/lib/redmine_gtt_fiware/federation_siblings.rb
+++ b/lib/redmine_gtt_fiware/federation_siblings.rb
@@ -14,8 +14,6 @@ module RedmineGttFiware
     # The published core vocabulary, usable as a JSON-LD @context.
     CONTEXT_URL = 'https://gtt-project.org/ns/fiware.jsonld'.freeze
     LINK_HEADER = %(<#{CONTEXT_URL}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json").freeze
-    OPEN_TIMEOUT = 5
-    READ_TIMEOUT = 10
     CACHE_TTL = 60 # seconds; the issue-page panel refetches at most this often
 
     Sibling = Struct.new(:urn, :org, :subtype, :status, :status_label, :title, :source, keyword_init: true) do
@@ -45,15 +43,10 @@ module RedmineGttFiware
     end
 
     def fetch(entity_urn)
-      uri = URI(@connection.url)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == 'https')
-      http.open_timeout = OPEN_TIMEOUT
-      http.read_timeout = READ_TIMEOUT
-
       query = Rack::Utils.build_query(type: 'Issue', q: %(refersTo=="#{entity_urn}"))
-      request = Net::HTTP::Get.new("#{ld_path(uri)}/entities?#{query}", headers)
-      response = http.request(request)
+      response = BrokerHttp.request(:get, "#{@connection.api_base}/entities?#{query}",
+                                    connection: @connection, token: @connection.auth_token,
+                                    headers: { 'Accept' => 'application/ld+json', 'Link' => LINK_HEADER })
       unless response.is_a?(Net::HTTPSuccess)
         Rails.logger.warn "[FIWARE] Sibling query on #{@connection.name} answered #{response.code}"
         return []
@@ -63,22 +56,6 @@ module RedmineGttFiware
     rescue StandardError => e
       Rails.logger.warn "[FIWARE] Sibling query on #{@connection.name} failed: #{e.class}: #{e.message}"
       []
-    end
-
-    # Preserve an explicit /ngsi-ld/v1 path in the connection URL, append the
-    # default prefix otherwise (same convention as Emitter and
-    # SubscriptionRequest).
-    def ld_path(uri)
-      path = uri.path.chomp('/')
-      path.match?(%r{/ngsi-ld/v1\z}) ? path : "#{path}/ngsi-ld/v1"
-    end
-
-    def headers
-      result = { 'Accept' => 'application/ld+json', 'Link' => LINK_HEADER }
-      result['NGSILD-Tenant'] = @connection.fiware_service if @connection.fiware_service.present?
-      pair = @connection.token_header_pair(@connection.auth_token)
-      result[pair.first] = pair.last if pair
-      result
     end
 
     def parse(body)

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -1,6 +1,4 @@
-require 'cgi'
 require 'json'
-require 'uri'
 
 module RedmineGttFiware
   # Builds the broker subscription request (endpoints + JSON body) for a
@@ -29,17 +27,17 @@ module RedmineGttFiware
 
     # POST target that creates a subscription.
     def subscriptions_url
-      broker_uri.merge("#{version_path}subscriptions").to_s
+      "#{api_base}/subscriptions"
     end
 
     # DELETE target that removes the template's current subscription.
     def subscription_url
-      broker_uri.merge("#{version_path}subscriptions/#{@template.subscription_id}").to_s
+      "#{api_base}/subscriptions/#{@template.subscription_id}"
     end
 
     # Broker entities collection (used by the copy-as-curl helper).
     def entities_url
-      broker_uri.merge("#{version_path}entities").to_s
+      "#{api_base}/entities"
     end
 
     def to_json(*_args)
@@ -52,48 +50,22 @@ module RedmineGttFiware
       'application/json'
     end
 
-    # Tenant headers for broker requests. NGSIv2 uses Fiware-Service /
-    # Fiware-ServicePath; NGSI-LD uses NGSILD-Tenant (no service path).
+    # Tenant headers for broker requests, defined by the connection.
     def tenant_headers
-      service = @template.fiware_service
-      return {} if service.blank?
-
-      if @template.ngsi_ld?
-        { 'NGSILD-Tenant' => service }
-      else
-        headers = { 'Fiware-Service' => service }
-        headers['Fiware-ServicePath'] = @template.fiware_servicepath if @template.fiware_servicepath.present?
-        headers
-      end
+      @template.broker_connection&.tenant_headers || {}
     end
 
     private
 
-    # Preserve an explicit versioned API path in the broker URL, with or
-    # without a trailing slash (normalized to end with one), otherwise fall
-    # back to the standard's default prefix.
-    def version_path
-      path = broker_uri.path
-      return default_version_path unless path.match?(versioned_path_pattern)
-
-      path.end_with?('/') ? path : "#{path}/"
+    # The connection URL with the standard's version prefix
+    # (BrokerConnection#api_base handles preserving explicit versioned paths).
+    def api_base
+      @template.broker_connection.api_base
     end
 
-    # Subclasses implement these.
-    def default_version_path
-      raise NotImplementedError
-    end
-
-    def versioned_path_pattern
-      raise NotImplementedError
-    end
-
+    # Subclasses implement this.
     def payload
       raise NotImplementedError
-    end
-
-    def broker_uri
-      URI(@template.broker_url)
     end
 
     # Plain appends, not URI.join with an absolute path: joining "/fiware/..."

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -28,16 +28,6 @@ module RedmineGttFiware
 
       private
 
-      # An explicit /ngsi-ld/v1-style path in the broker URL is preserved by
-      # SubscriptionRequest#version_path; otherwise the standard prefix.
-      def default_version_path
-        '/ngsi-ld/v1/'
-      end
-
-      def versioned_path_pattern
-        %r{/ngsi-ld/v\d+(/|\z)}
-      end
-
       def payload
         payload = {
           type: 'Subscription',

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
@@ -4,21 +4,17 @@ module RedmineGttFiware
     # httpCustom block carries only the callback URL and auth headers; the
     # `json` field-templating block is gone (the plugin renders fields itself).
     class NgsiV2 < SubscriptionRequest
+      # Orion rejects strings containing its forbidden characters
+      # (<, >, ", ', =, ;, (, )) with an opaque 400, so they are stripped from
+      # the free-text description. Everything else, including non-ASCII text,
+      # passes through unchanged.
+      ORION_FORBIDDEN_CHARACTERS = /[<>"'=;()]/
+
       private
-
-      # An explicit versioned path in the broker URL (e.g. /orion/v2.1) is
-      # preserved by SubscriptionRequest#version_path; otherwise /v2/.
-      def default_version_path
-        '/v2/'
-      end
-
-      def versioned_path_pattern
-        %r{/v2\.\d+(/|\z)}
-      end
 
       def payload
         payload = {
-          description: CGI.escape(@template.name),
+          description: @template.name.to_s.gsub(ORION_FORBIDDEN_CHARACTERS, ''),
           subject: {
             entities: @template.entities,
             condition: {

--- a/test/unit/broker_connection_test.rb
+++ b/test/unit/broker_connection_test.rb
@@ -168,4 +168,53 @@ class BrokerConnectionTest < ActiveSupport::TestCase
   ensure
     BrokerConnection.delete_all
   end
+
+  # --- api_base ------------------------------------------------------------
+  # Every broker request URL builds on api_base; the invariant under test is
+  # that an existing path prefix survives whether or not the URL already
+  # names an API version.
+
+  def connection_with(standard, url)
+    BrokerConnection.new(name: 'b', standard: standard, url: url, auth_mode: 'stored')
+  end
+
+  def test_api_base_appends_the_default_ld_prefix
+    assert_equal 'https://host.example.com/ngsi-ld/v1',
+                 connection_with('NGSI-LD', 'https://host.example.com').api_base
+  end
+
+  def test_api_base_appends_the_default_v2_prefix
+    assert_equal 'https://host.example.com/v2',
+                 connection_with('NGSIv2', 'https://host.example.com').api_base
+  end
+
+  def test_api_base_keeps_a_path_prefix_when_appending
+    assert_equal 'https://host.example.com/broker/ngsi-ld/v1',
+                 connection_with('NGSI-LD', 'https://host.example.com/broker').api_base
+    assert_equal 'https://host.example.com/orion/v2',
+                 connection_with('NGSIv2', 'https://host.example.com/orion/').api_base
+  end
+
+  def test_api_base_keeps_an_explicit_versioned_path
+    assert_equal 'https://host.example.com/broker/ngsi-ld/v1',
+                 connection_with('NGSI-LD', 'https://host.example.com/broker/ngsi-ld/v1/').api_base
+    assert_equal 'https://host.example.com/orion/v2',
+                 connection_with('NGSIv2', 'https://host.example.com/orion/v2').api_base
+    assert_equal 'https://host.example.com/orion/v2.1',
+                 connection_with('NGSIv2', 'https://host.example.com/orion/v2.1').api_base
+  end
+
+  def test_tenant_headers_by_standard
+    ld = connection_with('NGSI-LD', 'https://h.example.com')
+    ld.fiware_service = 'smartcity'
+    assert_equal({ 'NGSILD-Tenant' => 'smartcity' }, ld.tenant_headers)
+
+    v2 = connection_with('NGSIv2', 'https://h.example.com')
+    v2.fiware_service = 'smartcity'
+    v2.fiware_servicepath = '/roads'
+    assert_equal({ 'Fiware-Service' => 'smartcity', 'Fiware-ServicePath' => '/roads' },
+                 v2.tenant_headers)
+
+    assert_equal({}, connection_with('NGSIv2', 'https://h.example.com').tenant_headers)
+  end
 end

--- a/test/unit/broker_connection_test.rb
+++ b/test/unit/broker_connection_test.rb
@@ -195,6 +195,13 @@ class BrokerConnectionTest < ActiveSupport::TestCase
                  connection_with('NGSIv2', 'https://host.example.com/orion/').api_base
   end
 
+  # Callers append segments as plain strings; a query or fragment in the
+  # configured URL must not end up in the middle of every built URL.
+  def test_api_base_drops_query_and_fragment
+    assert_equal 'https://host.example.com/v2',
+                 connection_with('NGSIv2', 'https://host.example.com?tenant=x#top').api_base
+  end
+
   def test_api_base_keeps_an_explicit_versioned_path
     assert_equal 'https://host.example.com/broker/ngsi-ld/v1',
                  connection_with('NGSI-LD', 'https://host.example.com/broker/ngsi-ld/v1/').api_base

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -86,6 +86,27 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_equal 'https://broker.example.com/broker/ngsi-ld/v1/subscriptions', req.subscriptions_url
   end
 
+  # A broker mounted under a path prefix without a version segment gets the
+  # default prefix appended to its path, not substituted for it. Absolute-path
+  # URI merging used to drop the prefix and target the wrong URL.
+  def test_ngsi_ld_appends_the_prefix_to_a_broker_path_without_a_version
+    req = build('NGSI-LD', broker_url: 'https://broker.example.com/context-broker')
+    assert_equal 'https://broker.example.com/context-broker/ngsi-ld/v1/subscriptions', req.subscriptions_url
+  end
+
+  def test_ngsi_v2_appends_the_prefix_to_a_broker_path_without_a_version
+    req = build('NGSIv2', broker_url: 'https://broker.example.com/orion')
+    assert_equal 'https://broker.example.com/orion/v2/subscriptions', req.subscriptions_url
+  end
+
+  # /v2 without a minor version is the common spelling and counts as an
+  # explicit versioned path (it used to be unrecognized, which both doubled
+  # the version segment and dropped any prefix before it).
+  def test_ngsi_v2_recognizes_a_plain_v2_path
+    req = build('NGSIv2', broker_url: 'https://broker.example.com/orion/v2')
+    assert_equal 'https://broker.example.com/orion/v2/subscriptions', req.subscriptions_url
+  end
+
   # --- NGSIv2 payload -------------------------------------------------------
 
   def test_ngsi_v2_payload_shape
@@ -94,6 +115,19 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_equal %w[entityCreate entityChange], p.dig('subject', 'condition', 'alterationTypes')
     assert_equal 3, p['throttling']
     assert_equal 'active', p['status']
+  end
+
+  # The description is the template name with only Orion's forbidden
+  # characters removed: readable on the broker, and non-ASCII (Japanese
+  # names) untouched. It used to be URL-encoded wholesale.
+  def test_ngsi_v2_description_strips_only_orion_forbidden_characters
+    p = payload('NGSIv2', name: %(Road damage (Aoyama) <test> "quoted" 道路損傷))
+    assert_equal 'Road damage Aoyama test quoted 道路損傷', p['description']
+  end
+
+  def test_ngsi_ld_description_is_the_name_verbatim
+    p = payload('NGSI-LD', name: 'Road damage (Aoyama)')
+    assert_equal 'Road damage (Aoyama)', p['description']
   end
 
   # Setting.host_name may carry a sub-URI path ("example.com/redmine"); the


### PR DESCRIPTION
First of a series from a full maintainer review of the plugin (readability, structure, Rails/Redmine idioms, and FIWARE standard conformance). This one unifies how broker URLs and broker HTTP requests are built.

## The bug

The `/ngsi-ld/v1` / `/v2` path convention existed three times with different semantics. `SubscriptionRequest` merged an absolute default path into the broker URI, so a broker mounted under a path prefix lost it:

| Broker URL | subscriptions went to | emission went to |
|---|---|---|
| `https://host/context-broker` | `https://host/ngsi-ld/v1/...` (wrong) | `https://host/context-broker/ngsi-ld/v1/...` |
| `https://host/orion/v2` | `https://host/v2/...` (wrong: `/v2` unrecognized, prefix dropped) | n/a |

## The fix

- `BrokerConnection#api_base` is now the single home of the convention: append the standard's version prefix to the URL's path unless the path already names a version; never substitute. Tenant headers also move to the connection (they were already a property of it).
- `RedmineGttFiware::BrokerHttp` is the single transport: every broker call (publish, unpublish, sync, preview, emission, federation queries) goes through it. This gives the three controller call sites the open/read timeouts they were missing (a hung broker used to pin a Rails worker for net/http's 60 s defaults inside user-facing requests), and uses `request_uri` everywhere (publish/unpublish used `uri.path`, dropping query strings).

## Also folded in (same one-definition theme)

- `WEBHOOK_SECRET_HEADER` was defined in two files; the webhook controller now references the protocol constant next to where subscriptions embed it.
- The NGSIv2 subscription `description` was `CGI.escape`d wholesale, which stored `Road+damage+report` (and percent-soup for Japanese names) on the broker. Now only Orion's forbidden characters (`<>"'=;()`) are stripped; everything else, including non-ASCII, passes through. The NGSI-LD builder always sent the name verbatim.
- `INSTANCE_ID_PATTERN` moves off the `Emitter` singleton class so `Emitter::INSTANCE_ID_PATTERN` resolves.

## Verification

New tests pin the fixed semantics: prefix preservation for unversioned and plain-`/v2` URLs, `api_base` and `tenant_headers` on the connection, and description handling for both standards. The pre-existing versioned-path tests (`/orion/v2.1`, `/broker/ngsi-ld/v1`) pass unchanged, so behavior for already-working configurations is identical.

Full suite: 311 runs, 1105 assertions, 0 failures.
