### PR TITLE
Scope template associations to the project, guard untrusted ids

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -459,7 +459,10 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def get_issue_categories
-    @issue_categories = IssueCategory.all
+    # Scoped to the project: categories are project-local in core, and the
+    # unscoped list both leaked other projects' category names and offered
+    # ids the model now rejects.
+    @issue_categories = @project.issue_categories
   end
 
   def get_issue_priorities
@@ -518,19 +521,24 @@ class SubscriptionTemplatesController < ApplicationController
   end
 
   def subscription_template_params
+    # require first: a request without the root key must answer 400
+    # (ParameterMissing), not crash on the normalization below.
+    attributes = params.require(:subscription_template)
     if api_request?
       normalize_api_structures
     else
       # The form omits unchecked boxes, so an absent value means "none".
       # An API client that omits the key means "leave it alone", and on
       # create the model's default applies.
-      params[:subscription_template][:alteration_types] ||= []
+      attributes[:alteration_types] ||= []
     end
     # project_id is deliberately not permitted: the project comes from the
     # route, and SaveSubscriptionTemplate assigns it before the attributes, so
     # a permitted project_id would let a request move a subscription into
     # another project (a real hole once the API can send arbitrary fields).
-    params.require(:subscription_template).permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry, :geometry_string, :geofence_notes, alteration_types: [], issue_custom_field_values: {})
+    # geometry is likewise only writable through geometry_string, which is
+    # parsed and validated; the raw serialized column stays unassignable.
+    attributes.permit(:broker_connection_id, :subscription_id, :name, :expires, :status, :federation_policy, :federation_watch, :throttling, :context, :entities_string, :attrs, :expression_query, :expression_georel, :expression_geometry, :expression_coords, :notify_on_metadata_change, :subject, :description, :attachments_string, :is_private, :tracker_id, :version_id, :issue_status_id, :issue_category_id, :issue_priority_id, :member_id, :comment, :threshold_create, :threshold_create_hours, :notes, :geometry_string, :geofence_notes, alteration_types: [], issue_custom_field_values: {})
   end
 
   # Stored connections supply their encrypted token server-side; browser-mode

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -101,6 +101,14 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   # template must have one: its own or the connection's default.
   validates :effective_context, presence: true, if: :ngsi_ld?
 
+  # The member, category and version must belong to the template's project,
+  # like core scopes them on Issue. Without this, a permitted foreign id
+  # crosses project boundaries; the member is the sharpest edge, because the
+  # webhook acts as the member's user (SubscriptionIssuesController), so a
+  # foreign member_id would let notifications author issues as a user from an
+  # unrelated project.
+  validate :associations_must_belong_to_project
+
   validate :name_uniqueness
   validate :take_json_entities
   validate :take_json_geometry
@@ -298,6 +306,20 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     geo_query_fields = [expression_georel, expression_geometry, expression_coords]
     if geo_query_fields.any?(&:present?) && geo_query_fields.any?(&:blank?)
       errors.add :base, I18n.t('model.subscription_template.geo_query_fields_must_be_all_or_none')
+    end
+  end
+
+  def associations_must_belong_to_project
+    return if project_id.nil?
+
+    if member && member.project_id != project_id
+      errors.add :member, :inclusion
+    end
+    if issue_category && issue_category.project_id != project_id
+      errors.add :issue_category, :inclusion
+    end
+    if version && !project.shared_versions.include?(version)
+      errors.add :version, :inclusion
     end
   end
 

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -310,7 +310,10 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   end
 
   def associations_must_belong_to_project
-    return if project_id.nil?
+    # Guard on the association, not the id: a dangling project_id must not
+    # turn the shared_versions lookup below into a NoMethodError (the
+    # belongs_to presence validation reports it instead).
+    return if project.nil?
 
     if member && member.project_id != project_id
       errors.add :member, :inclusion

--- a/lib/redmine_gtt_fiware/federation_siblings.rb
+++ b/lib/redmine_gtt_fiware/federation_siblings.rb
@@ -26,10 +26,17 @@ module RedmineGttFiware
       @connection = connection
     end
 
+    # Characters legal in the URNs this plugin queries by. The entity id
+    # comes from an untrusted notification payload and is interpolated into
+    # the quoted NGSI-LD q literal below, so anything that could break out of
+    # the quotes (") or alter the query grammar (;|()<>= ...) is rejected
+    # here rather than escaped: no real URN contains such characters.
+    QUERYABLE_URN_PATTERN = /\A[A-Za-z0-9:._~-]+\z/
+
     # Foreign Issue entities whose refersTo points at entity_urn, own
     # instance excluded (that is what makes them *siblings*).
     def for_entity(entity_urn)
-      return [] if entity_urn.blank?
+      return [] unless entity_urn.to_s.match?(QUERYABLE_URN_PATTERN)
 
       Rails.cache.fetch(cache_key(entity_urn), expires_in: CACHE_TTL) do
         fetch(entity_urn)

--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -125,6 +125,9 @@ module RedmineGttFiware
     # guard the design demands), and a repeated unchanged status adds no
     # second note.
     def process_federation_update(entity)
+      # An id-less entity cannot be attributed to a work order (and would
+      # turn the journal dedup below into a match-everything pattern).
+      return Result.new(federated: 0) if entity.id.blank?
       return Result.new(federated: 0) if own_emission?(entity)
 
       refers_to = entity.attributes.dig('refersTo', 'value').to_s
@@ -142,8 +145,11 @@ module RedmineGttFiware
       annotated = 0
       Issue.where(fiware_entity: refers_to, project_id: @template.project_id).find_each do |issue|
         # One note per state: skip when the latest federation note for this
-        # foreign work order already says the same thing.
-        last = issue.journals.where('notes LIKE ?', "%#{entity.id}%").order(id: :desc).first
+        # foreign work order already says the same thing. The id is untrusted
+        # payload data; unescaped, a % or _ in it would turn the LIKE pattern
+        # into a wildcard and match unrelated journals.
+        pattern = "%#{Issue.sanitize_sql_like(entity.id.to_s)}%"
+        last = issue.journals.where('notes LIKE ?', pattern).order(id: :desc).first
         next if last && last.notes == note
 
         issue.init_journal(User.current, note)

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -316,6 +316,32 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal 0, JSON.parse(response.body)['federated']
   end
 
+  # The one-note-per-state dedup matches journals by the foreign entity's id.
+  # That id is untrusted payload data: a % in it must be a literal, not a SQL
+  # LIKE wildcard that matches every journal and suppresses legitimate notes.
+  def test_watch_dedup_treats_percent_in_the_entity_id_as_a_literal
+    watch_setup
+    @local_issue.init_journal(User.find(2), 'unrelated note mentioning nothing')
+    @local_issue.save!
+
+    assert_difference 'Journal.count', 1 do
+      post_notification(entities: [foreign_work_order(id: 'urn:ngsi-ld:Issue:redmine:nexco-east:%')])
+    end
+    assert_response :success
+    assert_equal 1, JSON.parse(response.body)['federated']
+  end
+
+  # An entity without an id cannot be attributed (and must not turn the
+  # dedup into a match-everything pattern); it is handled, not journaled.
+  def test_watch_ignores_an_entity_without_an_id
+    watch_setup
+    assert_no_difference 'Journal.count' do
+      post_notification(entities: [foreign_work_order.except('id')])
+    end
+    assert_response :success
+    assert_equal 0, JSON.parse(response.body)['federated']
+  end
+
   # A watch-only batch with nothing to annotate is still successful handling.
   def test_watch_without_correlated_issues_is_a_200
     watch_setup

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -234,6 +234,17 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
 
   # The new-template form renders the happy path plus three collapsed sections
   # and prefills defaults so the template is publishable without opening them.
+  # Categories are project-local in core; the select must not offer (or leak
+  # the names of) other projects' categories.
+  def test_new_offers_only_the_projects_issue_categories
+    foreign = IssueCategory.where.not(project_id: @project.id).first
+    get :new, params: { project_id: @project.id }
+    assert_response :success
+    assert_select 'select[name=?]', 'subscription_template[issue_category_id]' do
+      assert_select 'option', text: foreign.name, count: 0
+    end
+  end
+
   def test_new_renders_progressive_disclosure_form_with_defaults
     get :new, params: { project_id: @project.id }
     assert_response :success

--- a/test/unit/federation_siblings_test.rb
+++ b/test/unit/federation_siblings_test.rb
@@ -96,4 +96,20 @@ class FederationSiblingsTest < ActiveSupport::TestCase
     Net::HTTP.any_instance.stubs(:request).raises('must not be called')
     assert_equal [], RedmineGttFiware::FederationSiblings.new(@connection).for_entity('')
   end
+
+  # The entity id comes from an untrusted notification payload and is
+  # interpolated into the quoted q literal; an id that could break out of the
+  # quotes or alter the query grammar must never reach the broker.
+  def test_urn_with_query_grammar_characters_queries_nothing
+    Net::HTTP.any_instance.stubs(:request).raises('must not be called')
+    [
+      %(urn:x";title!="),        # quote break-out
+      'urn:x|urn:y',             # OR pattern
+      'urn:x;attrs=*',           # statement separator
+      "urn:x\nurn:y"             # header/newline smuggling
+    ].each do |bad|
+      assert_equal [], RedmineGttFiware::FederationSiblings.new(@connection).for_entity(bad),
+                   "expected #{bad.inspect} to be rejected"
+    end
+  end
 end

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class SubscriptionTemplateTest < ActiveSupport::TestCase
   fixtures :projects, :trackers, :issue_statuses, :users, :members,
-           :member_roles, :roles, :enumerations
+           :member_roles, :roles, :enumerations, :issue_categories, :versions
 
   def broker_connection(attributes = {})
     @broker_connection ||= BrokerConnection.create!(
@@ -354,5 +354,40 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     template.webhook_secret = nil
     assert_not template.valid_webhook_secret?('anything')
     assert_not template.valid_webhook_secret?(nil)
+  end
+
+  # --- project scoping -------------------------------------------------------
+  # The member is the sharpest edge: the webhook acts as the member's user,
+  # so a foreign member_id would author issues as a user from an unrelated
+  # project. Category and version follow core's Issue scoping.
+
+  def test_member_must_belong_to_the_project
+    foreign_member = Member.where.not(project_id: 1).first
+    template = SubscriptionTemplate.new(valid_attributes(member_id: foreign_member.id))
+    assert_not template.valid?
+    assert template.errors[:member].any?
+  end
+
+  def test_issue_category_must_belong_to_the_project
+    foreign_category = IssueCategory.where.not(project_id: 1).first
+    template = SubscriptionTemplate.new(valid_attributes(issue_category_id: foreign_category.id))
+    assert_not template.valid?
+    assert template.errors[:issue_category].any?
+  end
+
+  def test_version_must_be_available_to_the_project
+    foreign_version = Version.where.not(project_id: 1).where(sharing: 'none').first
+    template = SubscriptionTemplate.new(valid_attributes(version_id: foreign_version.id))
+    assert_not template.valid?
+    assert template.errors[:version].any?
+  end
+
+  def test_own_project_associations_are_accepted
+    category = IssueCategory.find_by(project_id: 1)
+    version = Version.find_by(project_id: 1)
+    template = SubscriptionTemplate.new(
+      valid_attributes(issue_category_id: category.id, version_id: version.id)
+    )
+    assert template.valid?, template.errors.full_messages.join(', ')
   end
 end


### PR DESCRIPTION
Second PR from the maintainer review (after #137). Three holes of the same shape: an id from outside crossing a boundary it should not.

## Project scoping (the important one)

`member_id`, `issue_category_id` and `version_id` were permitted but never validated to belong to the template's project. The member is the sharpest edge: the notification webhook acts as the member's user, so a user with *Manage Subscriptions* on project A could point `member_id` at a member of project B and have broker notifications author issues as that user. The model now validates all three (versions via `shared_versions`, following core's Issue scoping), and the category select is scoped to the project instead of `IssueCategory.all`, which also leaked every project's category names into the form.

## Untrusted entity ids

The entity id from a broker notification was interpolated into two query languages:

- the quoted NGSI-LD `q` literal of the federation sibling query, where a crafted id could break out of the quotes and steer the query (with `federation_policy: suppress`, that decides whether local issue creation is skipped). Ids that contain query grammar characters are rejected outright; no real URN has them.
- a SQL `LIKE` pattern in the federation-watch journal dedup, where `%`/`_` acted as wildcards. Now escaped via `sanitize_sql_like`, and id-less entities are skipped instead of producing a match-everything pattern.

## Small request-shape fixes

- `params.require` now runs before the `alteration_types` default, so a request without the root key answers 400 (`ParameterMissing`) instead of 500 (`NoMethodError`).
- The raw serialized `:geometry` column is no longer mass-assignable; `geometry_string` is the validated path (the API's structured `geometry` input is converted to it, unchanged).

## Verification

New tests: foreign member/category/version rejected and own-project ones accepted; the category select offers no foreign names; grammar-character URNs never reach the broker (four break-out shapes); `%` in an entity id treated as a literal; id-less watch entities handled without journaling. Full suite 319 runs, 1128 assertions, 0 failures.
