### PR TITLE
Correctness long tail from the maintainer review

### DIFF
--- a/app/controllers/subscription_issues_controller.rb
+++ b/app/controllers/subscription_issues_controller.rb
@@ -81,6 +81,10 @@ class SubscriptionIssuesController < ApplicationController
   # empty list. Returns the :invalid_json sentinel for a malformed body so
   # #create can answer 400 (bad request) rather than 422 (well-formed but
   # unprocessable).
+  #
+  # Entities without an id are dropped: both standards require one, and an
+  # id-less entity cannot be deduplicated, so a broker redelivery would
+  # create a fresh duplicate issue on every attempt.
   def notification_entities
     body = JSON.parse(request.raw_post)
 
@@ -95,7 +99,7 @@ class SubscriptionIssuesController < ApplicationController
         []
       end
 
-    entities.select { |entity| entity.is_a?(Hash) }
+    entities.select { |entity| entity.is_a?(Hash) && entity['id'].present? }
   rescue JSON::ParserError
     :invalid_json
   end

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -285,10 +285,7 @@ class SubscriptionTemplatesController < ApplicationController
       return
     end
 
-    # Reload: the just-saved instance carries alteration_types in its
-    # serialized (before_save) form, which would fail revalidation on the
-    # subscription-id update after publishing. A fresh load deserializes it.
-    @subscription_template = template.reload
+    @subscription_template = template
     @subscription_template.ensure_webhook_secret!
     @fiware_broker_auth_token = connection.auth_token
     prepare_payload

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -115,7 +115,10 @@ class SubscriptionTemplatesController < ApplicationController
     # before_action. presence: browser-mode unpublish PATCHes an empty string;
     # store nil so a cleared subscription looks the same regardless of which
     # mode cleared it.
-    @subscription_template.update(subscription_id: params[:subscription_id].presence)
+    unless @subscription_template.update(subscription_id: params[:subscription_id].presence)
+      Rails.logger.error "Subscription id for template #{@subscription_template.id} could not be stored: " \
+                         "#{@subscription_template.errors.full_messages.join(', ')}"
+    end
 
     @subscription_templates = subscription_template_scope
     respond_to do |format|
@@ -129,16 +132,22 @@ class SubscriptionTemplatesController < ApplicationController
       return
     end
 
-    @subscription_template = SubscriptionTemplate.find(params[:subscription_template_id])
+    @subscription_template = SubscriptionTemplate.find_by(id: params[:subscription_template_id])
+    if @subscription_template.nil?
+      render json: { error: 'Subscription template not found' }, status: :not_found
+      return
+    end
 
     unless User.current.allowed_to?(:manage_subscription_templates, @subscription_template.project)
       render json: { error: 'You do not have permission to manage subscription templates' }, status: :forbidden
       return
     end
 
-    @subscription_template.update(subscription_id: params[:subscription_id])
-
-    render json: { message: 'Subscription ID updated successfully' }, status: :ok
+    if @subscription_template.update(subscription_id: params[:subscription_id])
+      render json: { message: 'Subscription ID updated successfully' }, status: :ok
+    else
+      render json: { errors: @subscription_template.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -303,13 +312,19 @@ class SubscriptionTemplatesController < ApplicationController
     response = fetch_remote_subscription
     case response
     when Net::HTTPNotFound
-      @subscription_template.update(subscription_id: nil)
-      l(:subscription_sync_removed)
+      if @subscription_template.update(subscription_id: nil)
+        l(:subscription_sync_removed)
+      else
+        Rails.logger.error "FIWARE broker sync: clearing the removed subscription failed: " \
+                           "#{@subscription_template.errors.full_messages.join(', ')}"
+        l(:subscription_sync_error)
+      end
     when Net::HTTPSuccess
       if apply_remote_status(JSON.parse(response.body))
         l(:subscription_synced)
       else
-        Rails.logger.error 'FIWARE broker sync: unrecognized subscription status in response'
+        Rails.logger.error 'FIWARE broker sync: unrecognized subscription status in response, ' \
+                           'or the local status update failed validation'
         l(:subscription_sync_error)
       end
     else
@@ -352,7 +367,9 @@ class SubscriptionTemplatesController < ApplicationController
       end
     return nil if normalized.nil?
 
-    @subscription_template.update(status: normalized) unless normalized == @subscription_template.status
+    unless normalized == @subscription_template.status
+      return nil unless @subscription_template.update(status: normalized)
+    end
     normalized
   end
 
@@ -411,12 +428,13 @@ class SubscriptionTemplatesController < ApplicationController
     settings_project_path(@project, tab: 'subscription_templates')
   end
 
+  # find_project_by_project_id comes from core's ApplicationController,
+  # including its render_404 on an unknown project.
+
   def find_subscription_template
     @subscription_template = subscription_template_scope.find(params[:id])
-  end
-
-  def find_project_by_project_id
-    @project = Project.find(params[:project_id])
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def subscription_template_scope
@@ -597,7 +615,14 @@ class SubscriptionTemplatesController < ApplicationController
         return false
       end
     elsif response.code.to_i == 204 && action == 'unpublish'
-      @subscription_template.update(subscription_id: nil)
+      # The subscription is gone on the broker either way; failing to clear
+      # the local id must be surfaced, like the publish case above.
+      unless @subscription_template.update(subscription_id: nil)
+        Rails.logger.error "Subscription removed on the broker but the local id could not be cleared: " \
+                           "#{@subscription_template.errors.full_messages.join(', ')}"
+        @error_message = l(:general_action_error)
+        return false
+      end
       return true
     end
 

--- a/app/helpers/subscription_templates_helper.rb
+++ b/app/helpers/subscription_templates_helper.rb
@@ -23,10 +23,7 @@ module SubscriptionTemplatesHelper
     api.expression_georel template.expression_georel
     api.expression_geometry template.expression_geometry
     api.expression_coords template.expression_coords
-    # alteration_types is an Array after a find but still the serialized
-    # string on a just-saved record (see the model's before_save/after_find),
-    # so it goes through the same tolerant conversion as attrs.
-    api.alteration_types api_json_array(template.alteration_types)
+    api.alteration_types template.alteration_types || []
     api.notify_on_metadata_change template.notify_on_metadata_change
     api.throttling template.throttling
     api.expires template.expires

--- a/app/models/broker_connection.rb
+++ b/app/models/broker_connection.rb
@@ -53,16 +53,16 @@ class BrokerConnection < (defined?(ApplicationRecord) == 'constant' ? Applicatio
 
   validates :name, presence: true, uniqueness: true
   validates :url, presence: true
-  validates :standard, inclusion: { in: STANDARDS, message: I18n.t('model.subscription_template.valid_standard') }
+  validates :standard, inclusion: { in: STANDARDS, message: :invalid_standard }
   validates :auth_mode, inclusion: { in: AUTH_MODES }
   validates :throttling, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :fiware_service, format: { with: SERVICE_PATTERN, message: I18n.t('model.broker_connection.invalid_service') }, allow_blank: true
-  validates :fiware_servicepath, format: { with: SERVICE_PATH_PATTERN, message: I18n.t('model.broker_connection.invalid_service_path') }, allow_blank: true
+  validates :fiware_service, format: { with: SERVICE_PATTERN, message: :invalid_service }, allow_blank: true
+  validates :fiware_servicepath, format: { with: SERVICE_PATH_PATTERN, message: :invalid_service_path }, allow_blank: true
   # Typing "Authorization" must mean the same as leaving the field blank
   # (Authorization: Bearer), not a raw token in the Authorization header --
   # otherwise the two spellings of the default silently differ.
   before_validation :normalize_token_header
-  validates :token_header, format: { with: HEADER_NAME_PATTERN, message: I18n.t('model.broker_connection.invalid_token_header') }, allow_blank: true
+  validates :token_header, format: { with: HEADER_NAME_PATTERN, message: :invalid_token_header }, allow_blank: true
   validate :url_must_be_http
 
   scope :sorted, -> { order(:name) }

--- a/app/models/broker_connection.rb
+++ b/app/models/broker_connection.rb
@@ -10,7 +10,7 @@
 # 'browser' keeps the pre-#67 behaviour for deployments that do not want the
 # server to hold broker credentials: the token is supplied in the browser on
 # every publish/unpublish and never stored.
-class BrokerConnection < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
+class BrokerConnection < ApplicationRecord
   include Redmine::Ciphering
 
   self.table_name = 'fiware_broker_connections'

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -3,7 +3,7 @@
 # declared a subclass of the core Issue type in the instance's published
 # context (design step 2); it travels as the `subtype` property because the
 # target brokers reject multi-type entities (spike on #69).
-class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
+class EmissionMapping < ApplicationRecord
   self.table_name = 'fiware_emission_mappings'
 
   # A JSON-LD term: ASCII letters and digits, starting with a letter.

--- a/app/models/emission_mapping.rb
+++ b/app/models/emission_mapping.rb
@@ -63,7 +63,7 @@ class EmissionMapping < (defined?(ApplicationRecord) == 'constant' ? Application
   belongs_to :tracker
 
   validates :subtype, presence: true,
-                      format: { with: SUBTYPE_PATTERN, message: I18n.t('model.emission_mapping.invalid_subtype') }
+                      format: { with: SUBTYPE_PATTERN, message: :invalid_subtype }
   validate :subtype_must_not_shadow_reserved_terms
   validate :custom_terms_must_be_valid
   validates :tracker_id, uniqueness: { scope: :broker_connection_id }

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -179,15 +179,20 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     ActiveSupport::SecurityUtils.secure_compare(secret, provided)
   end
 
-  attr_accessor :threshold_create_hours
-  # Override the getter for threshold_create_hours
+  # The form edits the create-vs-update window in hours; the column stores
+  # seconds (the API reads and writes threshold_create directly). The getter
+  # must be exact: a truncating division would display an API-set 5400s as
+  # "1" and silently rewrite the column to 3600 on the next unrelated form
+  # save. Whole hours read back as Integers so the form shows "2", not "2.0".
   def threshold_create_hours
-    threshold_create / 3600 if threshold_create
+    return nil if threshold_create.nil?
+
+    hours = threshold_create / 3600.0
+    hours % 1 == 0 ? hours.to_i : hours
   end
 
-  # Override the setter for threshold_create_hours
   def threshold_create_hours=(hours)
-    self.threshold_create = hours.to_i * 3600
+    self.threshold_create = hours.blank? ? nil : (hours.to_f * 3600).round
   end
 
   attr_writer :entities_string

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 require 'active_support/security_utils'
 
-class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
+class SubscriptionTemplate < ApplicationRecord
   self.table_name = "fiware_subscription_templates"
 
   # Number of random bytes for the per-template webhook secret. The broker
@@ -92,7 +92,7 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   # either (present? is false for both).
   validates :alteration_types, inclusion: { in: ALTERATION_TYPES, message: :invalid_alteration_types }, allow_nil: true
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { scope: :project_id, case_sensitive: true }
   validates :subject, presence: true
   validates :description, presence: true
   validates :entities_string, presence: true
@@ -108,7 +108,6 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   # unrelated project.
   validate :associations_must_belong_to_project
 
-  validate :name_uniqueness
   validate :take_json_entities
   validate :take_json_geometry
   validate :take_json_attachments
@@ -317,14 +316,6 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     end
     if version && !project.shared_versions.include?(version)
       errors.add :version, :inclusion
-    end
-  end
-
-  def name_uniqueness
-    scope = SubscriptionTemplate.where.not(id: id).where(name: name, project_id: project_id)
-
-    if scope.any?
-      errors.add :name, I18n.t('model.subscription_template.name_uniqueness')
     end
   end
 

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -86,11 +86,10 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   validates :federation_policy, inclusion: { in: FEDERATION_POLICIES }
   validates :throttling, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :expression_geometry, inclusion: { in: GEOMETRIES, message: I18n.t('model.subscription_template.valid_geometry') }, allow_blank: true
-  # allow_nil: a template saved with no alteration types stores nil (see
-  # serialize_alteration_types), which is valid persisted state - the
-  # builders simply omit the field. Without allow_nil every later validated
-  # update on such a template fails (new records are shielded only by the
-  # after_initialize default).
+  # The jsonb column stores the array natively (older rows were JSON-string
+  # encoded; migration 20260805000000 unwrapped them). allow_nil: nil and []
+  # are both valid "no types chosen" states - the builders omit the field for
+  # either (present? is false for both).
   validates :alteration_types, inclusion: { in: ALTERATION_TYPES, message: I18n.t('model.subscription_template.valid_alteration_types') }, allow_nil: true
 
   validates :name, presence: true
@@ -120,8 +119,6 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
   # (#103): the form hides the selects, but hidden inputs still submit, and
   # the form is not the only writer.
   before_validation :clear_tracker_disabled_fields
-  before_save :serialize_alteration_types
-  after_find :deserialize_alteration_types
 
   def self.generate_webhook_secret
     SecureRandom.hex(WEBHOOK_SECRET_BYTES)
@@ -283,14 +280,6 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
       allowed = tracker.custom_field_ids.map(&:to_s)
       self.issue_custom_field_values = issue_custom_field_values.slice(*allowed)
     end
-  end
-
-  def serialize_alteration_types
-    self.alteration_types = alteration_types.empty? ? nil : alteration_types.to_json if alteration_types.is_a?(Array)
-  end
-
-  def deserialize_alteration_types
-    self.alteration_types = JSON.parse(alteration_types) if alteration_types.is_a?(String)
   end
 
   def attrs_must_be_array_of_strings

--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -82,15 +82,15 @@ class SubscriptionTemplate < (defined?(ApplicationRecord) == 'constant' ? Applic
     'entityDelete' => 'entityDeleted'
   }.freeze
 
-  validates :status, inclusion: { in: STATUS, message: I18n.t('model.subscription_template.valid_status') }
+  validates :status, inclusion: { in: STATUS, message: :invalid_status }
   validates :federation_policy, inclusion: { in: FEDERATION_POLICIES }
   validates :throttling, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :expression_geometry, inclusion: { in: GEOMETRIES, message: I18n.t('model.subscription_template.valid_geometry') }, allow_blank: true
+  validates :expression_geometry, inclusion: { in: GEOMETRIES, message: :invalid_geometry }, allow_blank: true
   # The jsonb column stores the array natively (older rows were JSON-string
   # encoded; migration 20260805000000 unwrapped them). allow_nil: nil and []
   # are both valid "no types chosen" states - the builders omit the field for
   # either (present? is false for both).
-  validates :alteration_types, inclusion: { in: ALTERATION_TYPES, message: I18n.t('model.subscription_template.valid_alteration_types') }, allow_nil: true
+  validates :alteration_types, inclusion: { in: ALTERATION_TYPES, message: :invalid_alteration_types }, allow_nil: true
 
   validates :name, presence: true
   validates :subject, presence: true

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -26,7 +26,10 @@
 <div class="box tabular">
   <p><%= f.text_area :description, required: true, rows: 6, class: 'wiki-edit', placeholder: l(:field_subscription_template_description_placeholder) %></p>
   <p><%= f.text_area :notes, rows: 4, class: 'wiki-edit', placeholder: l(:field_subscription_template_notes_placeholder) %></p>
-  <p><%= f.number_field :threshold_create_hours, min: 0, step: 1 %> <em class="info"><%= l(:field_subscription_template_threshold_create_hours_hint) %></em></p>
+  <%# step: any because the stored seconds value (API-writable) may not be a
+      whole number of hours, and the browser rejects submitting e.g. 1.5
+      against step=1. %>
+  <p><%= f.number_field :threshold_create_hours, min: 0, step: 'any' %> <em class="info"><%= l(:field_subscription_template_threshold_create_hours_hint) %></em></p>
 
   <p>
     <%= content_tag :label, l(:field_subscription_template_issue_geometry) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,24 +43,29 @@ de:
     attachement_not_found: 'Anlage nicht gefunden'
     project_not_found: 'Projekt nicht gefunden'
     status_not_found: 'Tracker nicht gefunden'
+  # Validation messages referenced by symbol from the models
+  # (message: :invalid_...), resolved lazily in the request locale.
+  activerecord:
+    errors:
+      messages:
+        invalid_standard: '%{value} ist kein gültiger Standard'
+        invalid_status: '%{value} ist kein gültiger Status'
+        invalid_geometry: '%{value} ist keine gültige Geometrie'
+        invalid_alteration_types: '%{value} ist kein gültiger Änderungstyp'
+        invalid_service: 'darf nur Buchstaben, Ziffern und Unterstriche enthalten (max. 50 Zeichen)'
+        invalid_service_path: 'muss aus /-getrennten Ebenen aus Buchstaben, Ziffern und Unterstrichen bestehen (max. 10 Ebenen)'
+        invalid_token_header: 'muss ein gültiger HTTP-Header-Name sein'
+        invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
   model:
     subscription_template:
-      valid_geometry: '%{value} ist keine gültige Geometrie'
-      valid_status: '%{value} ist kein gültiger Status'
-      valid_standard: '%{value} ist kein gültiger Standard'
       attrs_must_be_array_of_strings: 'Attribute müssen ein Array aus Strings sein'
       name_uniqueness: 'Eine Subscription-Vorlage mit diesem Namen existiert bereits.'
       geo_query_fields_must_be_all_or_none: 'Alle Geoabfrage-Felder (Georel, Geometrie,
         Koordinaten) müssen angegeben werden oder keines von ihnen'
-      valid_alteration_types: '%{value} ist kein gültiger Änderungstyp'
       must_be_valid_array_of_objects: 'muss ein gültiges Array von Objekten sein'
     broker_connection:
       invalid_url: 'muss eine http(s)-URL sein'
-      invalid_service: 'darf nur Buchstaben, Ziffern und Unterstriche enthalten (max. 50 Zeichen)'
-      invalid_service_path: 'muss aus /-getrennten Ebenen aus Buchstaben, Ziffern und Unterstrichen bestehen (max. 10 Ebenen)'
-      invalid_token_header: 'muss ein gültiger HTTP-Header-Name sein'
     emission_mapping:
-      invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
       reserved_subtype: 'ist ein reservierter Vokabular-Term und kann nicht als Subtyp verwendet werden'
       invalid_custom_term: 'Term %{term} muss ein nicht reservierter JSON-LD-Term sein (Buchstaben und Ziffern, beginnend mit einem Buchstaben)'
       duplicate_custom_term: 'Terme benutzerdefinierter Felder müssen innerhalb einer Zuordnung eindeutig sein'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -59,7 +59,6 @@ de:
   model:
     subscription_template:
       attrs_must_be_array_of_strings: 'Attribute müssen ein Array aus Strings sein'
-      name_uniqueness: 'Eine Subscription-Vorlage mit diesem Namen existiert bereits.'
       geo_query_fields_must_be_all_or_none: 'Alle Geoabfrage-Felder (Georel, Geometrie,
         Koordinaten) müssen angegeben werden oder keines von ihnen'
       must_be_valid_array_of_objects: 'muss ein gültiges Array von Objekten sein'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,19 @@ en:
 
     error_plugin_not_enabled: "GTT FIWARE plugin is not enabled for this project"
 
+  # Validation messages referenced by symbol from the models
+  # (message: :invalid_...), resolved lazily in the request locale.
+  activerecord:
+    errors:
+      messages:
+        invalid_standard: "%{value} is not a valid standard"
+        invalid_status: "%{value} is not a valid status"
+        invalid_geometry: "%{value} is not a valid geometry"
+        invalid_alteration_types: "%{value} is not a valid alteration type"
+        invalid_service: "may only contain letters, digits and underscores (max 50 characters)"
+        invalid_service_path: "must be /-separated levels of letters, digits and underscores (max 10 levels)"
+        invalid_token_header: "must be a valid HTTP header name"
+        invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
   model:
     subscription_template:
       name_uniqueness: A subscription with that name already exists.
@@ -249,17 +262,9 @@ en:
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,
         Coordinates) must be provided or none of them"
-      valid_standard: "%{value} is not a valid standard"
-      valid_status: "%{value} is not a valid status"
-      valid_geometry: "%{value} is not a valid geometry"
-      valid_alteration_types: "%{value} is not a valid alteration type"
     broker_connection:
       invalid_url: "must be an http(s) URL"
-      invalid_service: "may only contain letters, digits and underscores (max 50 characters)"
-      invalid_service_path: "must be /-separated levels of letters, digits and underscores (max 10 levels)"
-      invalid_token_header: "must be a valid HTTP header name"
     emission_mapping:
-      invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
       reserved_subtype: "is a reserved vocabulary term and cannot be used as a subtype"
       invalid_custom_term: "custom field term %{term} must be a non-reserved JSON-LD term (letters and digits, starting with a letter)"
       duplicate_custom_term: "custom field terms must be unique within a mapping"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,7 +257,6 @@ en:
         invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
   model:
     subscription_template:
-      name_uniqueness: A subscription with that name already exists.
       attrs_must_be_array_of_strings: "Attributes must be an array of strings"
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -233,7 +233,6 @@ ja:
         invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
   model:
     subscription_template:
-      name_uniqueness: A subscription template with that name already exists.
       attrs_must_be_array_of_strings: "Attributes must be an array of strings"
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -218,6 +218,19 @@ ja:
 
     error_plugin_not_enabled: "GTT FIWARE plugin is not enabled for this project"
 
+  # Validation messages referenced by symbol from the models
+  # (message: :invalid_...), resolved lazily in the request locale.
+  activerecord:
+    errors:
+      messages:
+        invalid_standard: "%{value} は有効な標準ではありません"
+        invalid_status: "%{value} は有効なステータスではありません"
+        invalid_geometry: "%{value} は有効なジオメトリではありません"
+        invalid_alteration_types: "%{value} は有効な変更タイプではありません"
+        invalid_service: "は英数字とアンダースコアのみ使用できます（最大50文字）"
+        invalid_service_path: "は英数字とアンダースコアを/で区切った形式である必要があります（最大10階層）"
+        invalid_token_header: "は有効なHTTPヘッダー名である必要があります"
+        invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
   model:
     subscription_template:
       name_uniqueness: A subscription template with that name already exists.
@@ -225,17 +238,9 @@ ja:
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,
         Coordinates) must be provided or none of them"
-      valid_standard: "%{value} is not a valid standard"
-      valid_status: "%{value} is not a valid status"
-      valid_geometry: "%{value} is not a valid geometry"
-      valid_alteration_types: "%{value} is not a valid alteration type"
     broker_connection:
       invalid_url: "はhttp(s)のURLである必要があります"
-      invalid_service: "は英数字とアンダースコアのみ使用できます（最大50文字）"
-      invalid_service_path: "は英数字とアンダースコアを/で区切った形式である必要があります（最大10階層）"
-      invalid_token_header: "は有効なHTTPヘッダー名である必要があります"
     emission_mapping:
-      invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
       reserved_subtype: "は予約済みの語彙タームのためサブタイプとして使用できません"
       invalid_custom_term: "カスタムフィールドのターム %{term} は予約されていないJSON-LDタームである必要があります（英字で始まる英数字のみ）"
       duplicate_custom_term: "カスタムフィールドのタームはマッピング内で一意である必要があります"

--- a/db/migrate/20260805000000_store_alteration_types_natively.rb
+++ b/db/migrate/20260805000000_store_alteration_types_natively.rb
@@ -1,0 +1,22 @@
+# alteration_types is a jsonb column, but the model used to JSON-encode the
+# array before saving and parse it after find, so the column held a JSON
+# *string* ('"[\"entityCreate\"]"') instead of a JSON array. The model now
+# reads and writes the array natively; this unwraps the double-encoded
+# legacy values in place. NULL rows (no types chosen) stay NULL.
+class StoreAlterationTypesNatively < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE fiware_subscription_templates
+      SET alteration_types = (alteration_types #>> '{}')::jsonb
+      WHERE jsonb_typeof(alteration_types) = 'string'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE fiware_subscription_templates
+      SET alteration_types = to_jsonb(alteration_types::text)
+      WHERE jsonb_typeof(alteration_types) = 'array'
+    SQL
+  end
+end

--- a/db/migrate/20260805100000_add_unique_index_on_subscription_template_names.rb
+++ b/db/migrate/20260805100000_add_unique_index_on_subscription_template_names.rb
@@ -1,0 +1,26 @@
+# The per-project name uniqueness was validation-only; a unique index makes
+# it hold under concurrency too. Existing duplicates would fail the index
+# creation, so they are disambiguated first (oldest keeps its name).
+class AddUniqueIndexOnSubscriptionTemplateNames < ActiveRecord::Migration[7.2]
+  def up
+    say_with_time 'disambiguating duplicate subscription template names' do
+      execute <<~SQL
+        UPDATE fiware_subscription_templates t
+        SET name = t.name || ' (' || t.id || ')'
+        WHERE EXISTS (
+          SELECT 1 FROM fiware_subscription_templates other
+          WHERE other.project_id = t.project_id
+            AND other.name = t.name
+            AND other.id < t.id
+        )
+      SQL
+    end
+    add_index :fiware_subscription_templates, [:project_id, :name],
+              unique: true, name: 'index_fiware_subscription_templates_on_project_and_name'
+  end
+
+  def down
+    remove_index :fiware_subscription_templates,
+                 name: 'index_fiware_subscription_templates_on_project_and_name'
+  end
+end

--- a/lib/redmine_gtt_fiware/attachment_fetcher.rb
+++ b/lib/redmine_gtt_fiware/attachment_fetcher.rb
@@ -18,7 +18,14 @@ module RedmineGttFiware
   # - the body is streamed and the download aborted once it exceeds the
   #   size limit (Redmine's attachment size limit)
   class AttachmentFetcher
+    # Rejected by policy (allowlist, content type, size, non-public address):
+    # retrying the same URL cannot succeed.
     class RejectedError < StandardError; end
+
+    # A network or server failure: nothing was rejected, the download just
+    # did not work this time. Kept distinct so operators reading the log do
+    # not blame the allowlist for a flaky broker.
+    class FetchError < StandardError; end
 
     Result = Struct.new(:tempfile, :content_type, keyword_init: true)
 
@@ -84,7 +91,8 @@ module RedmineGttFiware
       @transport = transport || method(:start_request)
     end
 
-    # Returns a Result on success, raises RejectedError otherwise.
+    # Returns a Result on success; raises RejectedError for policy
+    # violations and FetchError for network/server failures.
     def fetch(url)
       uri = parse_https_uri(url)
       check_host!(uri)
@@ -92,6 +100,9 @@ module RedmineGttFiware
       @transport.call(uri, ip) do |response|
         process_response(response)
       end
+    rescue Timeout::Error, SystemCallError, SocketError, IOError,
+           OpenSSL::SSL::SSLError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError => e
+      raise FetchError, "download failed: #{e.class}: #{e.message}"
     end
 
     private
@@ -144,9 +155,6 @@ module RedmineGttFiware
           return yield(response)
         end
       end
-    rescue Timeout::Error, SystemCallError, SocketError, IOError,
-           OpenSSL::SSL::SSLError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError => e
-      raise RejectedError, "download failed: #{e.class}: #{e.message}"
     end
 
     def process_response(response)

--- a/lib/redmine_gtt_fiware/emitter.rb
+++ b/lib/redmine_gtt_fiware/emitter.rb
@@ -16,6 +16,13 @@ module RedmineGttFiware
       # from broker notifications must not be emitted back (echo loop).
       # Restores the previous value so nested suppress blocks cannot
       # re-enable emission for an outer one.
+      #
+      # INVARIANT: emission fires from after_commit (IssuePatch), so the
+      # commit must happen inside the block. That holds because each save in
+      # the block commits its own transaction. Wrapping a whole notification
+      # batch in one ActiveRecord::Base.transaction would defer the commits
+      # (and the emission callbacks) past the ensure below and silently
+      # disable this echo-loop protection - do not add such a transaction.
       def suppress
         previous = Thread.current[:gtt_fiware_suppress_emission]
         Thread.current[:gtt_fiware_suppress_emission] = true

--- a/lib/redmine_gtt_fiware/entity.rb
+++ b/lib/redmine_gtt_fiware/entity.rb
@@ -31,13 +31,33 @@ module RedmineGttFiware
       geometry = nil
       entity.each do |key, raw|
         next if RESERVED_KEYS.include?(key)
+
+        # Multi-attribute (datasetId): normalized form may deliver an
+        # attribute as an array of instances; an unqualified template path
+        # means the default one.
+        raw = default_ld_instance(raw) if raw.is_a?(Array)
         next unless raw.is_a?(Hash)
 
-        value = raw.key?('object') ? raw['object'] : raw['value']
-        attributes[key] = { 'value' => value, 'type' => raw['type'] }
+        attributes[key] = { 'value' => ld_value(raw), 'type' => raw['type'] }
         geometry ||= raw['value'] if geo_property?(key, raw)
       end
       new(id: entity['id'], type: entity['type'], attributes: attributes, geometry: geometry)
+    end
+
+    # The instance without a datasetId is the default instance; when every
+    # instance is qualified, the first one stands in.
+    def self.default_ld_instance(instances)
+      hashes = instances.select { |instance| instance.is_a?(Hash) }
+      hashes.detect { |instance| !instance.key?('datasetId') } || hashes.first
+    end
+
+    # The attribute's payload member by kind: a Relationship carries object,
+    # a LanguageProperty carries languageMap, everything else carries value.
+    def self.ld_value(raw)
+      return raw['object'] if raw.key?('object')
+      return raw['languageMap'] if raw.key?('languageMap')
+
+      raw['value']
     end
 
     def self.from_ngsi_v2(entity)

--- a/lib/redmine_gtt_fiware/federation_siblings.rb
+++ b/lib/redmine_gtt_fiware/federation_siblings.rb
@@ -16,6 +16,10 @@ module RedmineGttFiware
     LINK_HEADER = %(<#{CONTEXT_URL}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json").freeze
     CACHE_TTL = 60 # seconds; the issue-page panel refetches at most this often
 
+    # Explicit page size: brokers default to small pages (Orion-LD: 20) and
+    # would silently truncate the sibling list without it.
+    QUERY_LIMIT = 100
+
     Sibling = Struct.new(:urn, :org, :subtype, :status, :status_label, :title, :source, keyword_init: true) do
       def open?
         status == 'open'
@@ -38,9 +42,12 @@ module RedmineGttFiware
     def for_entity(entity_urn)
       return [] unless entity_urn.to_s.match?(QUERYABLE_URN_PATTERN)
 
-      Rails.cache.fetch(cache_key(entity_urn), expires_in: CACHE_TTL) do
+      # fetch returns nil on failure, and skip_nil keeps that out of the
+      # cache: one broker hiccup must not blank the issue-page panel for the
+      # whole TTL. A genuinely empty sibling list ([]) is cached as usual.
+      Rails.cache.fetch(cache_key(entity_urn), expires_in: CACHE_TTL, skip_nil: true) do
         fetch(entity_urn)
-      end
+      end || []
     end
 
     private
@@ -49,20 +56,23 @@ module RedmineGttFiware
       ['gtt_fiware_siblings', @connection.id, entity_urn]
     end
 
+    # Returns the siblings, or nil on failure (the caller treats nil as "no
+    # siblings" but keeps it out of the cache).
     def fetch(entity_urn)
-      query = Rack::Utils.build_query(type: 'Issue', q: %(refersTo=="#{entity_urn}"))
+      query = Rack::Utils.build_query(type: 'Issue', limit: QUERY_LIMIT,
+                                      q: %(refersTo=="#{entity_urn}"))
       response = BrokerHttp.request(:get, "#{@connection.api_base}/entities?#{query}",
                                     connection: @connection, token: @connection.auth_token,
                                     headers: { 'Accept' => 'application/ld+json', 'Link' => LINK_HEADER })
       unless response.is_a?(Net::HTTPSuccess)
         Rails.logger.warn "[FIWARE] Sibling query on #{@connection.name} answered #{response.code}"
-        return []
+        return nil
       end
 
       parse(response.body)
     rescue StandardError => e
       Rails.logger.warn "[FIWARE] Sibling query on #{@connection.name} failed: #{e.class}: #{e.message}"
-      []
+      nil
     end
 
     def parse(body)

--- a/lib/redmine_gtt_fiware/federation_siblings.rb
+++ b/lib/redmine_gtt_fiware/federation_siblings.rb
@@ -79,7 +79,7 @@ module RedmineGttFiware
     # as foreign too: someone else works on it, whoever they are.
     def sibling(entity)
       urn = entity['id'].to_s
-      org = urn[%r{\Aurn:ngsi-ld:Issue:redmine:([^:]+):}, 1]
+      org = IssueUrn.instance_of(urn)
       return nil if org.present? && org == Emitter.instance_id
 
       Sibling.new(

--- a/lib/redmine_gtt_fiware/issue_entity.rb
+++ b/lib/redmine_gtt_fiware/issue_entity.rb
@@ -9,7 +9,7 @@ module RedmineGttFiware
     # Stable across any reconfiguration (subtype renames never change ids);
     # the federation keystone (#70).
     def self.urn(issue)
-      "urn:ngsi-ld:Issue:redmine:#{Emitter.instance_id}:#{issue.id}"
+      IssueUrn.build(issue)
     end
 
     # mapping may be nil for pull-side rendering (#4): the representation is

--- a/lib/redmine_gtt_fiware/issue_urn.rb
+++ b/lib/redmine_gtt_fiware/issue_urn.rb
@@ -1,0 +1,33 @@
+module RedmineGttFiware
+  # The URN shape of emitted Issue entities:
+  #
+  #   urn:ngsi-ld:Issue:redmine:<instance identifier>:<issue id>
+  #
+  # This is wire protocol shared between federating instances, so building
+  # and parsing live here in one place: a format change that misses a call
+  # site silently breaks the emission echo guard or the organization
+  # attribution in federation notes.
+  module IssueUrn
+    PREFIX = 'urn:ngsi-ld:Issue:redmine'.freeze
+    INSTANCE_PATTERN = /\Aurn:ngsi-ld:Issue:redmine:([^:]+):/
+
+    module_function
+
+    # The URN for an issue emitted by this instance.
+    def build(issue)
+      "#{PREFIX}:#{Emitter.instance_id}:#{issue.id}"
+    end
+
+    # The instance identifier inside a URN, or nil when the URN does not
+    # have this shape (hand-made Issue entities from non-Redmine producers).
+    def instance_of(urn)
+      urn.to_s[INSTANCE_PATTERN, 1]
+    end
+
+    # Whether the URN names an entity this instance emitted itself.
+    def own?(urn)
+      instance = Emitter.instance_id
+      instance.present? && instance_of(urn) == instance
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -133,7 +133,7 @@ module RedmineGttFiware
       refers_to = entity.attributes.dig('refersTo', 'value').to_s
       return Result.new(federated: 0) if refers_to.blank?
 
-      org = entity.id.to_s[%r{\Aurn:ngsi-ld:Issue:redmine:([^:]+):}, 1] || 'external'
+      org = IssueUrn.instance_of(entity.id) || 'external'
       status = entity.attributes.dig('status', 'value').to_s
       status_label = entity.attributes.dig('statusLabel', 'value').to_s
       # The label wins when it only differs from the normalized status by
@@ -161,8 +161,7 @@ module RedmineGttFiware
     # The 4c echo guard: our own emitted work orders come back through a
     # watch subscription on the same tenant and must be ignored.
     def own_emission?(entity)
-      instance = Emitter.instance_id
-      instance.present? && entity.id.to_s.start_with?("urn:ngsi-ld:Issue:redmine:#{instance}:")
+      IssueUrn.own?(entity.id)
     end
 
     # Only when the policy asks for it, and never fatally: sibling lookup

--- a/lib/redmine_gtt_fiware/notification_processor.rb
+++ b/lib/redmine_gtt_fiware/notification_processor.rb
@@ -25,11 +25,11 @@ module RedmineGttFiware
     # handling with no issue of its own.
     Result = Struct.new(:issue, :created, :saved, :suppressed, :federated, keyword_init: true) do
       def created?
-        created
+        created == true
       end
 
       def saved?
-        saved
+        saved == true
       end
 
       def suppressed?
@@ -116,7 +116,10 @@ module RedmineGttFiware
       end
       issue.reload
       issue.init_journal(User.current, "#{I18n.t(:text_federation_siblings_note)}\n\n#{lines.join("\n")}")
-      issue.save
+      unless issue.save
+        @logger.warn "[FIWARE] Sibling note on issue ##{issue.id} could not be saved: " \
+                     "#{issue.errors.full_messages.join(', ')}"
+      end
     end
 
     # Federation push updates (#70, 4c): the notified entity is a foreign
@@ -316,6 +319,10 @@ module RedmineGttFiware
         next if url.empty?
 
         filename = spec['filename'].presence || File.basename(URI.parse(url).path.to_s)
+        # Compare what will actually be stored: Attachment#filename= sanitizes
+        # (spaces, special characters), so the raw spec name never matches the
+        # stored one and the same file would re-attach on every update.
+        filename = Attachment.new(filename: filename).filename.to_s
         next if filename.empty? || existing_filenames.include?(filename)
 
         result = fetcher.fetch(url)
@@ -326,6 +333,8 @@ module RedmineGttFiware
         existing_filenames << filename
       rescue RedmineGttFiware::AttachmentFetcher::RejectedError => e
         @logger.warn "[FIWARE] Rejected attachment download from #{url.inspect}: #{e.message}"
+      rescue RedmineGttFiware::AttachmentFetcher::FetchError => e
+        @logger.warn "[FIWARE] Attachment download from #{url.inspect} failed: #{e.message}"
       rescue StandardError => e
         @logger.warn "[FIWARE] Failed to attach file: #{e.message}"
       end

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -331,15 +331,25 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_equal 1, JSON.parse(response.body)['federated']
   end
 
-  # An entity without an id cannot be attributed (and must not turn the
-  # dedup into a match-everything pattern); it is handled, not journaled.
-  def test_watch_ignores_an_entity_without_an_id
+  # An entity without an id is dropped at the door: both standards require
+  # one, an id-less entity cannot be deduplicated (a broker redelivery would
+  # duplicate issues forever), and it cannot be attributed to a work order.
+  # A batch with nothing else usable is a permanent 422.
+  def test_entities_without_an_id_are_dropped
     watch_setup
     assert_no_difference 'Journal.count' do
       post_notification(entities: [foreign_work_order.except('id')])
     end
+    assert_response :unprocessable_entity
+  end
+
+  def test_entities_without_an_id_do_not_fail_the_rest_of_the_batch
+    watch_setup
+    assert_difference 'Journal.count', 1 do
+      post_notification(entities: [foreign_work_order.except('id'), foreign_work_order])
+    end
     assert_response :success
-    assert_equal 0, JSON.parse(response.body)['federated']
+    assert_equal 1, JSON.parse(response.body)['federated']
   end
 
   # A watch-only batch with nothing to annotate is still successful handling.

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -752,4 +752,18 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 'urn:sub:123', @template.reload.subscription_id
   end
+
+  # An unknown template id answers a JSON 404, not an unrescued
+  # RecordNotFound (the caller is broker-side tooling expecting JSON).
+  def test_set_subscription_id_for_an_unknown_template_is_a_json_404
+    @request.session[:user_id] = nil
+    with_settings rest_api_enabled: '1' do
+      post :set_subscription_id, params: {
+        subscription_template_id: 987_654, subscription_id: 'urn:sub:123',
+        key: User.find(2).api_key, format: :json
+      }
+    end
+    assert_response :not_found
+    assert JSON.parse(response.body).key?('error')
+  end
 end

--- a/test/unit/attachment_fetcher_test.rb
+++ b/test/unit/attachment_fetcher_test.rb
@@ -130,6 +130,16 @@ class AttachmentFetcherTest < ActiveSupport::TestCase
     assert_rejected fetcher, 'https://broker.example.com/file.png', /302 \(redirects are not followed\)/
   end
 
+  # A network failure is not a policy rejection: it raises FetchError so the
+  # log does not blame the allowlist for a flaky broker.
+  def test_network_failures_raise_fetch_error_not_rejected_error
+    fetcher = build_fetcher(transport: lambda { |_uri, _ip, &_block| raise Timeout::Error, 'took too long' })
+    error = assert_raises(RedmineGttFiware::AttachmentFetcher::FetchError) do
+      fetcher.fetch('https://broker.example.com/file.png')
+    end
+    assert_match(/download failed/, error.message)
+  end
+
   def test_rejects_non_redirect_errors_without_redirect_wording
     fetcher = build_fetcher(transport: with_response(FakeResponse.new(code: '500')))
     error = assert_raises(RedmineGttFiware::AttachmentFetcher::RejectedError) do

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -90,4 +90,40 @@ class EntityTest < ActiveSupport::TestCase
     assert_nil e.geometry
     assert_nil e.resolve('anything')
   end
+
+  # NGSI-LD multi-attribute: normalized form may deliver an attribute as an
+  # array of instances (datasetId). These used to be dropped silently, so
+  # every template referencing them rendered empty.
+  def test_ngsi_ld_multi_attribute_uses_the_default_instance
+    e = Entity.from({
+      'id' => 'urn:x', 'type' => 'Sensor',
+      'speed' => [
+        { 'type' => 'Property', 'value' => 55, 'datasetId' => 'urn:ngsi-ld:Dataset:gps' },
+        { 'type' => 'Property', 'value' => 60 }
+      ]
+    }, 'NGSI-LD')
+    assert_equal 60, e.resolve('attrs.speed.value')
+  end
+
+  def test_ngsi_ld_multi_attribute_falls_back_to_the_first_instance
+    e = Entity.from({
+      'id' => 'urn:x', 'type' => 'Sensor',
+      'speed' => [
+        { 'type' => 'Property', 'value' => 55, 'datasetId' => 'urn:ngsi-ld:Dataset:gps' },
+        { 'type' => 'Property', 'value' => 60, 'datasetId' => 'urn:ngsi-ld:Dataset:radar' }
+      ]
+    }, 'NGSI-LD')
+    assert_equal 55, e.resolve('attrs.speed.value')
+  end
+
+  # A LanguageProperty carries languageMap, not value; it used to normalize
+  # to a nil value.
+  def test_ngsi_ld_language_property_resolves_the_language_map
+    e = Entity.from({
+      'id' => 'urn:x', 'type' => 'Sensor',
+      'streetName' => { 'type' => 'LanguageProperty',
+                        'languageMap' => { 'ja' => '青山通り', 'en' => 'Aoyama-dori' } }
+    }, 'NGSI-LD')
+    assert_equal '青山通り', e.resolve('attrs.streetName.value.ja')
+  end
 end

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -187,14 +187,18 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert template.valid?, template.errors.full_messages.join(', ')
   end
 
-  # A template saved without alteration types stores nil; later validated
-  # updates (e.g. storing the broker's subscription id after publish) must
-  # still pass. Regression: the inclusion validation used to reject nil on
-  # persisted records, silently breaking the publish flow.
+  # A template saved without alteration types must stay valid across later
+  # updates (e.g. storing the broker's subscription id after publish).
+  # Regression: the inclusion validation used to reject the stored empty
+  # state on persisted records, silently breaking the publish flow.
   def test_persisted_template_without_alteration_types_stays_updatable
     template = SubscriptionTemplate.create!(valid_attributes(alteration_types: []))
     reloaded = SubscriptionTemplate.find(template.id)
-    assert_nil reloaded.alteration_types
+    assert_equal [], reloaded.alteration_types
+    # And the just-saved in-memory instance is usable without a reload: the
+    # old hand-rolled before_save serialization left a JSON string behind
+    # that failed revalidation until the record was reloaded.
+    assert template.valid?, template.errors.full_messages.join(', ')
     assert reloaded.update(subscription_id: 'sub-1'), reloaded.errors.full_messages.join(', ')
   end
 
@@ -247,11 +251,9 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
   # 'null' is what the picker serializes with no rows: it clears the stored
   # attachments instead of failing validation.
   def test_attachments_string_null_clears_attachments
-    # reload: the just-created instance carries alteration_types in its
-    # serialized (before_save) form, which would fail revalidation.
     template = SubscriptionTemplate.create!(
       valid_attributes(attachments_string: '[{"url": "https://example.com/a.jpg"}]')
-    ).reload
+    )
     assert_equal 1, template.attachments.size
 
     template.attachments_string = 'null'

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -316,6 +316,23 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_equal 2, template.threshold_create_hours
   end
 
+  # The getter must be exact: an API-set 5400s used to display as "1" and be
+  # silently rewritten to 3600 by the next unrelated form save.
+  def test_threshold_create_hours_round_trips_a_non_whole_hour_value
+    template = SubscriptionTemplate.new(valid_attributes(threshold_create: 5400))
+    assert_equal 1.5, template.threshold_create_hours
+    template.threshold_create_hours = template.threshold_create_hours
+    assert_equal 5400, template.threshold_create
+  end
+
+  def test_threshold_create_hours_accepts_fractions_and_blank
+    template = SubscriptionTemplate.new(valid_attributes)
+    template.threshold_create_hours = '0.5'
+    assert_equal 1800, template.threshold_create
+    template.threshold_create_hours = ''
+    assert_nil template.threshold_create
+  end
+
   def test_geo_query_fields_must_be_all_or_none
     template = SubscriptionTemplate.new(valid_attributes(expression_georel: 'near;maxDistance:1000'))
     assert_not template.valid?


### PR DESCRIPTION
Third PR from the maintainer review (after #137, #138): the long tail of correctness fixes. Eight commits, each self-contained; best reviewed commit by commit.

1. **alteration_types stored natively** — the jsonb column held a JSON *string* because the model hand-encoded before save and parsed after find. That left every just-saved instance failing revalidation, which two call sites patched around (a `reload` in `publish_after_create`, a tolerant array conversion in the API helper). Both workarounds are deleted; a data migration unwraps the legacy double-encoded values.
2. **Checked update returns, render_404** — five `update` calls ignored their result and reported success on validation failure; all five now surface it. The local `find_project_by_project_id` override (core's method minus its `render_404` rescue) is gone, and `set_subscription_id` answers a JSON 404 for an unknown template.
3. **Lazy validation messages** — `message: I18n.t(...)` inside `validates` is evaluated once at class load, freezing every custom message in the boot locale. Messages are now symbols resolved through `activerecord.errors.messages` at error time, in the request locale.
4. **Exact threshold_create_hours** — the hours getter used truncating division, so an API-set 5400 s displayed as "1" and was silently rewritten to 3600 by the next unrelated form save.
5. **NGSI-LD multi-attributes and LanguageProperties** — normalized notifications delivering an attribute as an array of instances (datasetId) were silently dropped; the default instance now stands for the attribute. LanguageProperty carried `languageMap`, which normalized to nil; `attrs.name.value.ja` works now.
6. **IssueUrn** — the `urn:ngsi-ld:Issue:redmine:<instance>:<id>` shape was built in one place and regex-parsed in three others, each with its own pattern copy. It is wire protocol between federating instances; one module owns it now.
7. **Model cleanups** — dead `defined?(ApplicationRecord)` ternaries removed (Redmine >= 6.0 is required); name uniqueness is the standard scoped validation backed by a unique index (migration disambiguates existing duplicates first).
8. **Notification pipeline robustness** — id-less entities dropped at the webhook door (they cannot be deduplicated, so every broker redelivery duplicated issues); attachment dedup compares sanitized filenames; `FetchError` vs `RejectedError` so logs stop blaming the allowlist for flaky networks; failed sibling queries no longer cached for the full TTL and the query carries an explicit `limit` (Orion-LD truncates at 20 by default); `Emitter.suppress` documents its after_commit invariant.

## Verification

Every behavioral change has a test that fails against the old code (double-encoded round trip, non-whole-hour threshold, multi-attribute/languageMap resolution, id-less batch 422 plus batch isolation, FetchError classification, JSON 404). Full suite: 328 runs, 1145 assertions, 0 failures. Both new migrations ran forward on the dev database.
