### PR TITLE
Conform subscription payloads to NGSI-LD and NGSIv2

### DIFF
--- a/app/models/subscription_template.rb
+++ b/app/models/subscription_template.rb
@@ -83,6 +83,11 @@ class SubscriptionTemplate < ApplicationRecord
   }.freeze
 
   validates :status, inclusion: { in: STATUS, message: :invalid_status }
+  # oneshot is an NGSIv2/Orion status; NGSI-LD has none (CIM 009 Table
+  # 5.2.12-2), and publishing it as isActive: false would silently create a
+  # subscription that never fires. The form hides the option for LD
+  # connections; this covers the API and direct writes.
+  validate :oneshot_only_on_ngsi_v2
   validates :federation_policy, inclusion: { in: FEDERATION_POLICIES }
   validates :throttling, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :expression_geometry, inclusion: { in: GEOMETRIES, message: :invalid_geometry }, allow_blank: true
@@ -237,9 +242,37 @@ class SubscriptionTemplate < ApplicationRecord
       errors.add :entities_string, I18n.t('model.subscription_template.must_be_valid_array_of_objects')
       return
     end
+    validate_ld_entity_selectors(parsed) if ngsi_ld?
+    return if errors[:entities_string].any?
+
     self.entities = parsed
   rescue JSON::ParserError
     errors.add :entities_string, I18n.t(:error_invalid_json)
+  end
+
+  # The NGSI-LD EntitySelector (CIM 009 Table 5.2.33-1) is stricter than the
+  # NGSIv2 one: type is required, id must be a URI, and typePattern does not
+  # exist. A selector that only NGSIv2 accepts must fail here with a clear
+  # message, not at publish time with an opaque broker 400.
+  def validate_ld_entity_selectors(selectors)
+    selectors.each do |selector|
+      if selector['type'].to_s.strip.empty?
+        errors.add :entities_string, I18n.t('model.subscription_template.ld_entities_require_type')
+      end
+      if selector.key?('typePattern')
+        errors.add :entities_string, I18n.t('model.subscription_template.ld_entities_no_type_pattern')
+      end
+      if selector.key?('id') && !selector['id'].to_s.match?(/\A\S+:\S+\z/)
+        errors.add :entities_string, I18n.t('model.subscription_template.ld_entities_id_must_be_uri')
+      end
+    end
+    errors[:entities_string].uniq!
+  end
+
+  def oneshot_only_on_ngsi_v2
+    return unless status == 'oneshot' && ngsi_ld?
+
+    errors.add :status, I18n.t('model.subscription_template.oneshot_is_ngsi_v2_only')
   end
 
   def take_json_geometry

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -58,6 +58,10 @@ de:
         invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
   model:
     subscription_template:
+      ld_entities_require_type: 'jeder NGSI-LD-Entitätsselektor braucht einen "type"'
+      ld_entities_no_type_pattern: '"typePattern" gibt es nur in NGSIv2; NGSI-LD selektiert über "type"'
+      ld_entities_id_must_be_uri: 'NGSI-LD-Entitäts-IDs müssen URIs sein (z. B. urn:ngsi-ld:Sensor:001)'
+      oneshot_is_ngsi_v2_only: 'oneshot gibt es nur in NGSIv2; NGSI-LD-Subscriptions haben keinen Einmalmodus'
       attrs_must_be_array_of_strings: 'Attribute müssen ein Array aus Strings sein'
       geo_query_fields_must_be_all_or_none: 'Alle Geoabfrage-Felder (Georel, Geometrie,
         Koordinaten) müssen angegeben werden oder keines von ihnen'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,6 +257,10 @@ en:
         invalid_subtype: "must be a JSON-LD term: letters and digits, starting with a letter"
   model:
     subscription_template:
+      ld_entities_require_type: "each NGSI-LD entity selector needs a \"type\""
+      ld_entities_no_type_pattern: "\"typePattern\" is NGSIv2 only; NGSI-LD selects by \"type\""
+      ld_entities_id_must_be_uri: "NGSI-LD entity ids must be URIs (for example urn:ngsi-ld:Sensor:001)"
+      oneshot_is_ngsi_v2_only: "oneshot is NGSIv2 only; NGSI-LD subscriptions have no one-time mode"
       attrs_must_be_array_of_strings: "Attributes must be an array of strings"
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -233,6 +233,10 @@ ja:
         invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
   model:
     subscription_template:
+      ld_entities_require_type: "NGSI-LDのエンティティセレクタには \"type\" が必要です"
+      ld_entities_no_type_pattern: "\"typePattern\" はNGSIv2専用です。NGSI-LDでは \"type\" で選択します"
+      ld_entities_id_must_be_uri: "NGSI-LDのエンティティIDはURI形式である必要があります（例: urn:ngsi-ld:Sensor:001）"
+      oneshot_is_ngsi_v2_only: "oneshotはNGSIv2専用です。NGSI-LDのサブスクリプションに単発モードはありません"
       attrs_must_be_array_of_strings: "Attributes must be an array of strings"
       must_be_valid_array_of_objects: "must be a valid array of objects"
       geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,

--- a/lib/redmine_gtt_fiware/subscription_request.rb
+++ b/lib/redmine_gtt_fiware/subscription_request.rb
@@ -68,6 +68,18 @@ module RedmineGttFiware
       raise NotImplementedError
     end
 
+    # Both standards want subscription expiry as an ISO 8601 UTC timestamp
+    # ("YYYY-MM-DDThh:mm:ssZ", CIM 009 clause 4.6.3; Orion: "in ISO8601
+    # format"). A raw TimeWithZone in the payload would be serialized by
+    # JSON.generate as its to_s ("2026-08-05 12:00:00 UTC"), which brokers
+    # reject; an offset-local iso8601 deviates from the mandated UTC form.
+    def expires_utc
+      return nil if @template.expires.blank?
+
+      time = @template.expires
+      time.respond_to?(:utc) ? time.utc.iso8601 : time.to_s
+    end
+
     # Plain appends, not URI.join with an absolute path: joining "/fiware/..."
     # discards any path in the base, which breaks sub-URI deployments
     # (Setting.host_name may legitimately be "example.com/redmine", #101).

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -47,7 +47,8 @@ module RedmineGttFiware
         payload[:geoQ] = geo_q if geo_q
         triggers = @template.notification_triggers
         payload[:notificationTrigger] = triggers if triggers.present?
-        payload[:expiresAt] = expires_utc if expires_utc
+        expires = expires_utc
+        payload[:expiresAt] = expires if expires
 
         payload
       end

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_ld.rb
@@ -34,10 +34,12 @@ module RedmineGttFiware
           description: @template.name,
           entities: @template.entities,
           notification: notification,
-          isActive: @template.status == 'active',
-          throttling: @throttling
+          isActive: @template.status == 'active'
         }
 
+        # CIM 009 requires throttling "greater than 0"; 0 means "no
+        # throttling" in this plugin and is expressed by omitting the field.
+        payload[:throttling] = @throttling if @throttling.to_i.positive?
         payload[:id] = @template.subscription_id if @template.subscription_id.present?
         payload['@context'] = ld_context if ld_context
         payload[:watchedAttributes] = parsed_attrs if parsed_attrs.present?
@@ -45,7 +47,7 @@ module RedmineGttFiware
         payload[:geoQ] = geo_q if geo_q
         triggers = @template.notification_triggers
         payload[:notificationTrigger] = triggers if triggers.present?
-        payload[:expiresAt] = expires_at if expires_at
+        payload[:expiresAt] = expires_utc if expires_utc
 
         payload
       end
@@ -64,6 +66,15 @@ module RedmineGttFiware
         }
       end
 
+      # The stored geo filter uses NGSIv2 syntax (the form and the Area
+      # picker write it, and it predates LD support): georel `coveredBy`,
+      # near modifiers with `:`, and coordinates as "lat,lon;lat,lon" pairs.
+      # NGSI-LD (CIM 009 clause 4.10 / Table 5.2.13-1) has no coveredBy
+      # (within is the equivalent), near modifiers use `==`, and coordinates
+      # are a GeoJSON coordinates array in lon,lat order. Translate here so
+      # the same stored triple publishes correctly to both standards.
+      GEOREL_MAP = { 'coveredBy' => 'within' }.freeze
+
       def geo_q
         return nil unless @template.expression_georel.present? &&
                           @template.expression_geometry.present? &&
@@ -71,10 +82,46 @@ module RedmineGttFiware
 
         geometry = @template.expression_geometry
         {
-          georel: @template.expression_georel,
+          georel: ld_georel(@template.expression_georel),
           geometry: GEOMETRY_TYPE_MAP.fetch(geometry, geometry),
-          coordinates: @template.expression_coords
+          coordinates: ld_coordinates(@template.expression_coords, geometry)
         }
+      end
+
+      def ld_georel(georel)
+        base, modifier = georel.to_s.split(';', 2)
+        base = GEOREL_MAP.fetch(base, base)
+        return base if modifier.nil?
+
+        "#{base};#{modifier.sub(/\A(maxDistance|minDistance):/, '\1==')}"
+      end
+
+      # v2 pair syntax converts to the GeoJSON nesting for the geometry
+      # type; anything else (including box, which NGSI-LD does not have)
+      # passes through verbatim so the broker reports it instead of the
+      # plugin guessing.
+      def ld_coordinates(coords, geometry)
+        pairs = v2_coordinate_pairs(coords)
+        return coords if pairs.nil?
+
+        case geometry
+        when 'point' then pairs.first
+        when 'line' then pairs
+        when 'polygon' then [pairs]
+        else coords
+        end
+      end
+
+      # "lat1,lon1;lat2,lon2" (the v2/Orion order) as [[lon, lat], ...]
+      # (GeoJSON order), or nil when the string is not that syntax.
+      def v2_coordinate_pairs(coords)
+        number = /\A-?\d+(\.\d+)?\z/
+        coords.to_s.strip.split(';').map do |pair|
+          lat, lon, extra = pair.split(',').map(&:strip)
+          return nil unless extra.nil? && lat&.match?(number) && lon&.match?(number)
+
+          [Float(lon), Float(lat)]
+        end.presence
       end
 
       # @context may be a single URL or a JSON array/object of contexts. Parse
@@ -97,11 +144,6 @@ module RedmineGttFiware
         nil
       end
 
-      def expires_at
-        return nil if @template.expires.blank?
-
-        @template.expires.respond_to?(:iso8601) ? @template.expires.iso8601 : @template.expires.to_s
-      end
     end
   end
 end

--- a/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
+++ b/lib/redmine_gtt_fiware/subscription_request/ngsi_v2.rb
@@ -32,8 +32,10 @@ module RedmineGttFiware
           status: @template.status
         }
 
-        payload[:id] = @template.subscription_id if @template.subscription_id.present?
-        payload[:expires] = @template.expires if @template.expires.present?
+        # No payload[:id]: NGSIv2 subscription ids are broker-assigned
+        # ("Automatically created at creation time"), and Orion rejects a
+        # client-supplied one on POST. (NGSI-LD allows it; see NgsiLd.)
+        payload[:expires] = expires_utc if @template.expires.present?
 
         condition = payload[:subject][:condition]
         condition[:expression] = expression if expression.present?

--- a/test/unit/subscription_request_test.rb
+++ b/test/unit/subscription_request_test.rb
@@ -219,6 +219,70 @@ class SubscriptionRequestTest < ActiveSupport::TestCase
     assert_nil geo_q['coords']
   end
 
+  # The stored geo triple uses NGSIv2 syntax (the Area picker writes
+  # coveredBy + "lat,lon;..." pairs). NGSI-LD has no coveredBy (within is
+  # the equivalent), near modifiers use ==, and coordinates are a GeoJSON
+  # array in lon,lat order; the builder translates.
+  def test_ngsi_ld_translates_a_v2_style_boundary_triple
+    p = payload('NGSI-LD',
+                expression_georel: 'coveredBy',
+                expression_geometry: 'polygon',
+                expression_coords: '35.0,135.0;35.0,136.0;36.0,136.0;35.0,135.0')
+    geo_q = p['geoQ']
+    assert_equal 'within', geo_q['georel']
+    assert_equal 'Polygon', geo_q['geometry']
+    assert_equal [[[135.0, 35.0], [136.0, 35.0], [136.0, 36.0], [135.0, 35.0]]],
+                 geo_q['coordinates']
+  end
+
+  def test_ngsi_ld_translates_a_v2_style_near_point
+    p = payload('NGSI-LD',
+                expression_georel: 'near;maxDistance:2000',
+                expression_geometry: 'point',
+                expression_coords: '35.68,139.69')
+    geo_q = p['geoQ']
+    assert_equal 'near;maxDistance==2000', geo_q['georel']
+    assert_equal [139.69, 35.68], geo_q['coordinates']
+  end
+
+  # The same stored triple stays untouched for NGSIv2 (Orion wants exactly
+  # this syntax).
+  def test_ngsi_v2_keeps_the_boundary_triple_verbatim
+    p = payload('NGSIv2',
+                expression_georel: 'coveredBy',
+                expression_geometry: 'polygon',
+                expression_coords: '35.0,135.0;35.0,136.0;36.0,136.0;35.0,135.0')
+    expression = p.dig('subject', 'condition', 'expression')
+    assert_equal 'coveredBy', expression['georel']
+    assert_equal '35.0,135.0;35.0,136.0;36.0,136.0;35.0,135.0', expression['coords']
+  end
+
+  # Expiry must be an ISO 8601 UTC timestamp in both standards; a raw
+  # TimeWithZone serialized through JSON.generate is "2026-01-01 00:00:00
+  # +0900", which brokers reject.
+  def test_expires_is_iso8601_utc_in_both_standards
+    time = Time.utc(2027, 1, 2, 3, 4, 5)
+    assert_equal '2027-01-02T03:04:05Z', payload('NGSIv2', expires: time)['expires']
+    assert_equal '2027-01-02T03:04:05Z', payload('NGSI-LD', expires: time)['expiresAt']
+  end
+
+  # CIM 009 requires throttling > 0; "no throttling" (0) is expressed by
+  # omitting the field. NGSIv2/Orion accepts 0.
+  def test_ngsi_ld_omits_zero_throttling
+    builder = RedmineGttFiware::SubscriptionRequest.build(template('NGSI-LD'), base_url: BASE_URL, throttling: 0)
+    assert_not JSON.parse(builder.to_json).key?('throttling')
+    assert_equal 0, JSON.parse(RedmineGttFiware::SubscriptionRequest.build(template('NGSIv2'), base_url: BASE_URL, throttling: 0).to_json)['throttling']
+  end
+
+  # NGSIv2 subscription ids are broker-assigned; Orion rejects a
+  # client-supplied id on POST. NGSI-LD allows one.
+  def test_only_ngsi_ld_carries_a_client_supplied_id
+    v2 = payload('NGSIv2', subscription_id: 'sub-1')
+    assert_not v2.key?('id')
+    ld = payload('NGSI-LD', subscription_id: 'urn:ngsi-ld:Subscription:1')
+    assert_equal 'urn:ngsi-ld:Subscription:1', ld['id']
+  end
+
   def test_ngsi_ld_maps_line_and_polygon_geometry_names
     line = payload('NGSI-LD', expression_georel: 'intersects', expression_geometry: 'line', expression_coords: '[[0,0],[1,1]]')
     assert_equal 'LineString', line.dig('geoQ', 'geometry')

--- a/test/unit/subscription_template_test.rb
+++ b/test/unit/subscription_template_test.rb
@@ -375,6 +375,72 @@ class SubscriptionTemplateTest < ActiveSupport::TestCase
     assert_not template.valid_webhook_secret?(nil)
   end
 
+  # --- standard-specific validation ------------------------------------------
+  # The NGSI-LD EntitySelector is stricter than NGSIv2's: type required, id a
+  # URI, no typePattern. A selector only NGSIv2 accepts must fail at save
+  # time with a clear message, not at publish time with an opaque broker 400.
+
+  def ld_connection
+    @ld_connection ||= BrokerConnection.create!(
+      name: 'LD validation broker', standard: 'NGSI-LD',
+      url: 'https://broker.example.com', auth_mode: 'browser',
+      context: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'
+    )
+  end
+
+  def test_ld_entity_selectors_require_a_type
+    template = SubscriptionTemplate.new(valid_attributes(
+      broker_connection_id: ld_connection.id, entities_string: '[{"idPattern": ".*"}]'
+    ))
+    assert_not template.valid?
+    assert template.errors[:entities_string].any?
+  end
+
+  def test_ld_entity_selectors_reject_type_pattern
+    template = SubscriptionTemplate.new(valid_attributes(
+      broker_connection_id: ld_connection.id,
+      entities_string: '[{"typePattern": "Temp.*"}]'
+    ))
+    assert_not template.valid?
+    assert template.errors[:entities_string].any?
+  end
+
+  def test_ld_entity_selectors_require_uri_ids
+    template = SubscriptionTemplate.new(valid_attributes(
+      broker_connection_id: ld_connection.id,
+      entities_string: '[{"type": "Sensor", "id": "not a uri"}]'
+    ))
+    assert_not template.valid?
+    assert template.errors[:entities_string].any?
+
+    template = SubscriptionTemplate.new(valid_attributes(
+      broker_connection_id: ld_connection.id,
+      entities_string: '[{"type": "Sensor", "id": "urn:ngsi-ld:Sensor:001"}]'
+    ))
+    assert template.valid?, template.errors.full_messages.join(', ')
+  end
+
+  def test_v2_entity_selectors_stay_permissive
+    template = SubscriptionTemplate.new(valid_attributes(entities_string: '[{"idPattern": ".*"}]'))
+    assert template.valid?, template.errors.full_messages.join(', ')
+  end
+
+  # oneshot is NGSIv2 only; published to an LD broker it would become a
+  # paused subscription that never fires. The form hides the option, this
+  # covers the API and direct writes.
+  def test_oneshot_is_rejected_on_an_ngsi_ld_connection
+    template = SubscriptionTemplate.new(valid_attributes(
+      broker_connection_id: ld_connection.id,
+      entities_string: '[{"type": "Sensor"}]',
+      status: 'oneshot'
+    ))
+    assert_not template.valid?
+    assert template.errors[:status].any?
+
+    template.status = 'active'
+    assert template.valid?, template.errors.full_messages.join(', ')
+  end
+
   # --- project scoping -------------------------------------------------------
   # The member is the sharpest edge: the webhook acts as the member's user,
   # so a foreign member_id would author issues as a user from an unrelated


### PR DESCRIPTION
Fourth PR from the maintainer review: standards conformance, audited against ETSI GS CIM 009 V1.8.1 (NGSI-LD) and the Orion API specification (NGSIv2), not from memory. Two findings broke real subscriptions.

## The two that mattered

**`expires` was not ISO 8601.** The raw `TimeWithZone` went through `JSON.generate`, which serializes it as `"2026-08-05 12:00:00 UTC"`. Orion rejects the create whenever an expiry is set (verified empirically in the dev container). Both standards now get the mandated UTC form, `2026-08-05T12:00:00Z` (CIM 009 clause 4.6.3).

**Geo filters reached NGSI-LD brokers in NGSIv2 syntax.** The stored triple uses v2 syntax by design (the Area picker writes `coveredBy` and `"lat,lon;lat,lon"` pairs). CIM 009 has no `coveredBy` (`within` is the equivalent), near modifiers use `==` not `:`, and `coordinates` must be a GeoJSON array in lon,lat order. So every geo-filtered NGSI-LD subscription, including the plugin's own project-boundary Area, was rejected by the broker, or, in the worst case, accepted with latitude and longitude swapped. The LD builder now translates the stored triple; NGSIv2 keeps it verbatim, which is exactly what Orion expects.

## Also aligned

- LD `throttling` is omitted when 0 (CIM 009 Table 5.2.12-1: "greater than 0"; Orion v2 accepts 0, so v2 keeps sending it).
- NGSIv2 subscription POSTs no longer carry a client-supplied `id` (broker-assigned in v2; Orion's strict parsing rejects it). NGSI-LD keeps it, where the spec allows one (0..1).
- NGSI-LD EntitySelector constraints (Table 5.2.33-1: `type` required, `id` a URI, no `typePattern`) are validated at save time with clear messages in en/ja/de, instead of an opaque broker 400 at publish time. NGSIv2 selectors stay permissive.
- `status: oneshot` is rejected on NGSI-LD connections. LD has no oneshot (status is read-only `active/paused/expired`), and the old mapping to `isActive: false` silently created a subscription that never fires. The form already hid the option for LD; the validation covers the API path.

## What the audit confirmed as already correct

Subscription shape (`notificationTrigger` naming and values, `receiverInfo`, `format: normalized`, `endpoint.accept`), content types (`application/ld+json` for @context-carrying payloads), tenant headers per standard, the notification intake shape, emitted-entity structure (UTC-Z DateTimes, lon,lat GeoJSON, core context in last position per clause 4.4), the 409-then-PATCH upsert, and the federation query grammar. Not changed here, noted for a follow-up: the emitter never deletes attributes that disappear locally (the spec mechanism is the `urn:ngsi-ld:null` value, clause 4.5.0), so cleared fields stay stale broker-side.

## Verification

New tests pin the v2-triple translation for LD (boundary polygon and near-point), the verbatim v2 passthrough, ISO-UTC expiry in both standards, zero-throttling omission, the id asymmetry, the LD selector validations, and the oneshot rejection. Full suite: 339 runs, 1169 assertions, 0 failures.
