### PR TITLE
Cover the failure paths the suite was missing

### DIFF
--- a/test/functional/federation_controller_test.rb
+++ b/test/functional/federation_controller_test.rb
@@ -53,13 +53,24 @@ class FederationControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
-  # The panel shows broker data correlated to the issue, so seeing the issue
-  # is the requirement.
-  def test_invisible_issue_is_404
+  # Core redirects anonymous requests to login before this controller runs.
+  def test_anonymous_request_is_redirected_to_login_when_login_is_required
     @request.session[:user_id] = nil
     with_settings login_required: '1' do
       get :show, params: { id: @issue.id }
-      assert_response 302 # redirected to login by check_if_login_required
+      assert_response 302
     end
+  end
+
+  # The panel shows broker data correlated to the issue, so seeing the issue
+  # is the requirement: an authenticated user without visibility gets a 404,
+  # and critically, the broker is never queried for an issue the user cannot
+  # see.
+  def test_invisible_issue_is_404_and_never_queries_the_broker
+    @issue.project.update_columns(is_public: false)
+    @request.session[:user_id] = 7 # someone, not a member of project 1
+    RedmineGttFiware::FederationSiblings.any_instance.expects(:for_entity).never
+    get :show, params: { id: @issue.id }
+    assert_response :not_found
   end
 end

--- a/test/functional/subscription_issues_controller_test.rb
+++ b/test/functional/subscription_issues_controller_test.rb
@@ -557,6 +557,51 @@ class SubscriptionIssuesControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  # 422 when the whole batch failed validation: a permanent error the broker
+  # should not retry, carrying the validation messages.
+  def test_create_answers_422_with_errors_when_the_whole_batch_fails_validation
+    # A subject template resolving to nothing renders a blank subject, which
+    # Issue validation rejects.
+    @template.update_columns(subject: '${attrs.nonexistent.value}')
+    assert_no_difference 'Issue.count' do
+      post_notification
+    end
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert body['errors'].any?, 'the response must carry the validation messages'
+  end
+
+  # One bad geometry never fails the whole notification: the conversion
+  # degrades to no geometry with a warning, and the issue is still created.
+  def test_an_unconvertible_geometry_does_not_fail_the_notification
+    project = Project.find(1)
+    project.enabled_module_names = project.enabled_module_names | ['gtt']
+    @template.update!(geometry_string: '"${location}"')
+
+    broken_location = { 'type' => 'geo:json', 'value' => { 'type' => 'Point' } } # no coordinates
+    assert_difference 'Issue.count', 1 do
+      post_notification(entities: [entity('location' => broken_location)])
+    end
+    assert_response :success
+  end
+
+  # A mixed batch is a 200: at least one issue persisted, and a retry would
+  # duplicate it. The failures are visible in the counts.
+  def test_create_answers_200_for_a_mixed_batch
+    @template.update_columns(subject: '${attrs.subject_source.value}')
+    good = entity('id' => 'urn:ngsi-ld:TemperatureSensor:good',
+                  'subject_source' => { 'type' => 'Text', 'value' => 'Renders fine' })
+    bad = entity('id' => 'urn:ngsi-ld:TemperatureSensor:bad')
+
+    assert_difference 'Issue.count', 1 do
+      post_notification(entities: [good, bad])
+    end
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 2, body['processed']
+    assert_equal 1, body['created']
+  end
+
   # A malformed body is a 400 (bad request), distinct from a well-formed
   # notification that simply carries no entities (422). Sent without a JSON
   # content type so the controller's own parse (not Rails' params middleware,

--- a/test/functional/subscription_templates_controller_test.rb
+++ b/test/functional/subscription_templates_controller_test.rb
@@ -204,6 +204,96 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     assert_equal 'sub-777', @template.reload.subscription_id
   end
 
+  # --- server-side publish/unpublish failure matrix -------------------------
+  # The sync action has one of these for every failure shape; publish and
+  # unpublish get the same treatment. In every case the local subscription_id
+  # must not change and the response must carry the error message header.
+
+  def stored_template
+    connection = BrokerConnection.create!(
+      name: "Failure broker #{SecureRandom.hex(2)}", standard: 'NGSIv2',
+      url: 'https://broker.example.com', auth_mode: 'stored', auth_token: 'tok'
+    )
+    @template.update_column(:broker_connection_id, connection.id)
+    @template
+  end
+
+  def error_message_header
+    response.headers['X-Redmine-Message']
+  end
+
+  def test_publish_reports_a_broker_error_and_stores_no_id
+    stored_template
+    error = Net::HTTPBadRequest.new('1.1', '400', 'Bad Request')
+    error.stubs(:body).returns('{"error":"BadRequest"}')
+    Net::HTTP.any_instance.stubs(:request).returns(error)
+
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:general_action_error), error_message_header
+    assert_nil @template.reload.subscription_id
+  end
+
+  def test_publish_reports_a_missing_location_header_and_stores_no_id
+    stored_template
+    created = Net::HTTPCreated.new('1.1', '201', 'Created')
+    Net::HTTP.any_instance.stubs(:request).returns(created)
+
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:general_action_error), error_message_header
+    assert_nil @template.reload.subscription_id
+  end
+
+  def test_publish_reports_a_network_failure_and_stores_no_id
+    stored_template
+    Net::HTTP.any_instance.stubs(:request).raises(Errno::ECONNREFUSED)
+
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:general_action_error), error_message_header
+    assert_nil @template.reload.subscription_id
+  end
+
+  def test_unpublish_server_side_clears_the_id_on_204
+    stored_template.update_column(:subscription_id, 'sub-gone')
+    no_content = Net::HTTPNoContent.new('1.1', '204', 'No Content')
+    Net::HTTP.any_instance.stubs(:request).returns(no_content)
+
+    post :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:subscription_unpublished), error_message_header
+    assert_nil @template.reload.subscription_id
+  end
+
+  def test_unpublish_keeps_the_id_when_the_broker_errors
+    stored_template.update_column(:subscription_id, 'sub-stays')
+    error = Net::HTTPInternalServerError.new('1.1', '500', 'Internal Server Error')
+    error.stubs(:body).returns('boom')
+    Net::HTTP.any_instance.stubs(:request).returns(error)
+
+    post :unpublish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:general_action_error), error_message_header
+    assert_equal 'sub-stays', @template.reload.subscription_id
+  end
+
+  # Proxied mode relays a browser-supplied token; without the header token
+  # the broker is never called.
+  def test_proxied_publish_without_a_header_token_is_an_error
+    connection = BrokerConnection.create!(
+      name: 'Proxied broker', standard: 'NGSIv2',
+      url: 'https://broker.example.com', auth_mode: 'proxied'
+    )
+    @template.update_column(:broker_connection_id, connection.id)
+    Net::HTTP.any_instance.expects(:request).never
+
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :success
+    assert_equal I18n.t(:subscription_unauthorized_error), error_message_header
+    assert_nil @template.reload.subscription_id
+  end
+
   # A connection with a custom token header (#99) sends the raw token in that
   # header instead of Authorization: Bearer (API-key brokers like GeonicDB).
   def test_publish_uses_the_connection_token_header
@@ -584,6 +674,31 @@ class SubscriptionTemplatesControllerTest < ActionController::TestCase
     post :preview, params: preview_params
     assert_response :unprocessable_entity
     assert_includes JSON.parse(response.body)['error'], '401'
+  end
+
+  # A broker answering 200 with a body that is not JSON is an error, not a
+  # 500 from the parse.
+  def test_preview_reports_an_unparsable_broker_body
+    response_stub = Net::HTTPOK.new('1.1', '200', 'OK')
+    response_stub.stubs(:body).returns('<html>gateway error page</html>')
+    Net::HTTP.any_instance.stubs(:request).returns(response_stub)
+
+    post :preview, params: preview_params
+    assert_response :unprocessable_entity
+    assert JSON.parse(response.body)['error'].present?
+  end
+
+  # authorize guards every action here; preview matters most because it
+  # makes outbound broker calls with stored tokens.
+  def test_actions_are_denied_without_the_permission
+    Role.find(1).remove_permission!(:manage_subscription_templates)
+
+    post :preview, params: preview_params
+    assert_response :forbidden
+
+    Net::HTTP.any_instance.expects(:request).never
+    post :publish, params: { project_id: @project.id, id: @template.id }, xhr: true
+    assert_response :forbidden
   end
 
   def test_preview_requires_a_connection_and_an_entity_type

--- a/test/unit/emitter_test.rb
+++ b/test/unit/emitter_test.rb
@@ -229,11 +229,12 @@ class EmitterTest < ActiveSupport::TestCase
     )
     EmissionMapping.create!(broker_connection: second, tracker: Tracker.find(1), subtype: 'WorkOrder')
 
-    hosts = []
-    Net::HTTP.any_instance.stubs(:request).with { |_req| true }.returns(created_response)
+    attempts = []
+    # One stub: the matcher counts attempts and raises on the first, so the
+    # first connection fails and the second is the one that must still run.
     Net::HTTP.any_instance.stubs(:request).with do |_req|
-      hosts << 'called'
-      raise Errno::ECONNREFUSED if hosts.length == 1
+      attempts << 1
+      raise Errno::ECONNREFUSED if attempts.length == 1
 
       true
     end.returns(created_response)
@@ -246,6 +247,6 @@ class EmitterTest < ActiveSupport::TestCase
       end
     end
     assert issue.persisted?
-    assert_equal 2, hosts.length, 'the second connection must still be attempted'
+    assert_equal 2, attempts.length, 'the second connection must still be attempted'
   end
 end

--- a/test/unit/emitter_test.rb
+++ b/test/unit/emitter_test.rb
@@ -168,4 +168,84 @@ class EmitterTest < ActiveSupport::TestCase
     end
     assert issue.persisted?
   end
+
+  def error_response
+    response = Net::HTTPInternalServerError.new('1.1', '500', 'Internal Server Error')
+    response.stubs(:body).returns('broker exploded')
+    response
+  end
+
+  # A broker rejection is logged (including a body excerpt) and the save
+  # still succeeds: log_failure must not itself raise on the response.
+  def test_broker_error_response_is_logged_and_does_not_block_the_save
+    stub_broker(error_response)
+    issue = nil
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).with { |msg| msg.include?('answered 500') && msg.include?('broker exploded') }
+      issue = build_issue
+      issue.save!
+    end
+    assert issue.persisted?
+  end
+
+  # 409 -> PATCH fallback where the PATCH also fails: the failure of the
+  # second request is the one reported.
+  def test_conflict_then_failed_patch_is_logged
+    conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
+    responses = [conflict, error_response]
+    requests = []
+    Net::HTTP.any_instance.stubs(:request).with { |req| requests << req; true }
+             .returns(*responses)
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).with { |msg| msg.include?('answered 500') }
+      build_issue.save!
+    end
+    assert requests.any? { |r| r.is_a?(Net::HTTP::Patch) }, 'the 409 must trigger the PATCH fallback'
+  end
+
+  # DELETE answering 404 means "never emitted or already gone": deliberately
+  # not a failure, so nothing is logged.
+  def test_delete_tolerates_a_404
+    not_found = Net::HTTPNotFound.new('1.1', '404', 'Not Found')
+    issue = nil
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      stub_broker(created_response)
+      issue = build_issue
+      issue.save!
+    end
+
+    stub_broker(not_found)
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).never
+      issue.destroy
+    end
+  end
+
+  # One failing connection neither raises nor blocks the others.
+  def test_a_failing_connection_does_not_block_the_next_one
+    second = BrokerConnection.create!(
+      name: 'Second broker', standard: 'NGSI-LD',
+      url: 'https://other.example.com', auth_mode: 'stored'
+    )
+    EmissionMapping.create!(broker_connection: second, tracker: Tracker.find(1), subtype: 'WorkOrder')
+
+    hosts = []
+    Net::HTTP.any_instance.stubs(:request).with { |_req| true }.returns(created_response)
+    Net::HTTP.any_instance.stubs(:request).with do |_req|
+      hosts << 'called'
+      raise Errno::ECONNREFUSED if hosts.length == 1
+
+      true
+    end.returns(created_response)
+
+    issue = nil
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      assert_nothing_raised do
+        issue = build_issue
+        issue.save!
+      end
+    end
+    assert issue.persisted?
+    assert_equal 2, hosts.length, 'the second connection must still be attempted'
+  end
 end


### PR DESCRIPTION
Seventh PR from the maintainer review: tests only, no production changes.

The review found the failure coverage asymmetric: the sync action has a broker-failure test for every shape, while publish/unpublish server-side failures, the emitter's non-success responses, and the webhook's 422 contract had none. One federation test also asserted a login redirect under a name promising a 404.

What is now pinned (details in the commit message): the emitter's error logging, PATCH-fallback failure, DELETE 404 tolerance and per-connection isolation; the webhook's all-invalid-batch 422 with errors, mixed-batch 200, and geometry degradation; the publish/unpublish failure matrix (broker error, missing Location, network failure, proxied without a token) with the invariant that `subscription_id` never changes on failure; the federation panel's real visibility guard including that the broker is never queried for an invisible issue; preview's unparsable-body 422; and HTML 403s without the permission.

Full suite: 355 runs, 1215 assertions, 0 failures.