### PR TITLE
Docs accuracy and i18n completion from the maintainer review

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,31 @@ After restarting Redmine, you should be able to see the Redmine GTT FIWARE
 plugin in the Plugins page.
 
 More information on installing (and uninstalling) Redmine plugins can be found
-[here](http://www.redmine.org/wiki/redmine/Plugins).
+[here](https://www.redmine.org/wiki/redmine/Plugins).
 
 ## How to use
 
 Detailed instructions on how to use the plugin and its API endpoints can be
 found in the [documentation](doc/index.md).
+
+## Development
+
+Run the Ruby test suite from the Redmine root, against a PostGIS test
+database (CI runs the same suites across Redmine 6.0 to 7.0, see
+`.github/workflows/test-postgis.yml`):
+
+```sh
+bundle exec rails test plugins/redmine_gtt_fiware/test/unit
+bundle exec rails test plugins/redmine_gtt_fiware/test/functional
+```
+
+The subscription form's JavaScript has its own Vitest suite, runnable from
+the plugin directory without a Redmine installation:
+
+```sh
+npm ci
+npm test
+```
 
 ## Contributing and Support
 

--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -62,7 +62,7 @@ class SubscriptionTemplatesController < ApplicationController
 
   # The statuses a new issue can take for a tracker/member pair (#103): the
   # same workflow data the regular issue form uses. Fetched by the form when
-  # the tracker or the "Sent from user" member changes.
+  # the tracker or the "Create issues as" member changes.
   def allowed_statuses
     tracker = @project.trackers.find_by(id: params[:tracker_id])
     member = @project.members.find_by(id: params[:member_id])

--- a/app/views/subscription_templates/_attachment_row.html.erb
+++ b/app/views/subscription_templates/_attachment_row.html.erb
@@ -2,8 +2,8 @@
     once inside the picker's <template> prototype, which the add link clones
     -- so adding still works when every row has been removed. %>
 <span class="gtt-fiware-attachment-row" style="display: block; margin-bottom: 4px;">
-  <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" placeholder="https://example.com/photo.jpg" size="35" />
-  <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" placeholder="photo-${id}.jpg" size="20" />
+  <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" placeholder="<%= l(:field_attachment_url_placeholder) %>" size="35" />
+  <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" placeholder="<%= l(:field_attachment_filename_placeholder) %>" size="20" />
   <input type="text" class="js-attachment-description" value="<%= attachment['description'] %>" placeholder="<%= l(:field_description) %>" size="20" />
   <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
   <a href="#" class="js-attachment-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>

--- a/app/views/subscription_templates/_form_filters.html.erb
+++ b/app/views/subscription_templates/_form_filters.html.erb
@@ -27,7 +27,7 @@
   <%# Comma-separated watched attributes; serialized into the attrs JSON array. %>
   <p>
     <%= content_tag :label, l(:field_subscription_template_watched_attributes) %>
-    <input type="text" id="gtt-fiware-attrs-input" size="75" value="<%= attrs_list %>" placeholder="temperature, humidity" />
+    <input type="text" id="gtt-fiware-attrs-input" size="75" value="<%= attrs_list %>" placeholder="<%= l(:field_subscription_template_watched_attrs_placeholder) %>" />
     <em class="info"><%= l(:text_watched_attributes_info) %></em>
   </p>
   <%= f.hidden_field :attrs %>

--- a/app/views/subscription_templates/_subscription_template.html.erb
+++ b/app/views/subscription_templates/_subscription_template.html.erb
@@ -3,19 +3,19 @@
     <%= link_to subscription_template.name, edit_project_subscription_template_path(subscription_template.project, subscription_template) %>
   </td>
   <td>
-    <%= textilizable subscription_template.standard %>
+    <%= subscription_template.standard %>
   </td>
   <td class="text">
     <code><%= subscription_template.broker_url %></code>
   </td>
   <td>
-    <%= textilizable subscription_template.issue_status.name %>
+    <%= subscription_template.issue_status.name %>
   </td>
   <td>
-    <%= textilizable subscription_template.tracker.name %>
+    <%= subscription_template.tracker.name %>
   </td>
   <td>
-    <%= textilizable subscription_template.status %>
+    <%= subscription_template.status %>
   </td>
   <td>
     <%= link_to sprite_icon('fiware-clipboard', l(:link_to_copy), :plugin => :redmine_gtt_fiware), copy_project_subscription_template_path(@project, subscription_template),
@@ -26,10 +26,10 @@
       <%= link_to sprite_icon('fiware-sync', l(:link_to_sync), :plugin => :redmine_gtt_fiware), sync_project_subscription_template_path(@project, subscription_template),
           method: :post, remote: true, class: 'icon icon-reload', title: l(:link_to_sync_hint) %>
       <%= link_to sprite_icon('fiware-unpublish', l(:link_to_unpublish), :plugin => :redmine_gtt_fiware), unpublish_project_subscription_template_path(@project, subscription_template),
-          method: :post, remote: true, class: 'icon icon-shared' %>
+          method: :post, remote: true, class: 'icon icon-shared', title: l(:link_to_unpublish_hint) %>
     <% else %>
       <%= link_to sprite_icon('fiware-publish', l(:link_to_publish), :plugin => :redmine_gtt_fiware), publish_project_subscription_template_path(@project, subscription_template),
-          method: :post, remote: true, class: 'icon icon-shared' %>
+          method: :post, remote: true, class: 'icon icon-shared', title: l(:link_to_publish_hint) %>
     <% end %>
   </td>
   <td>

--- a/app/views/subscription_templates/copy.js.erb
+++ b/app/views/subscription_templates/copy.js.erb
@@ -33,14 +33,14 @@ function copyToClipboard(command) {
   if (navigator.clipboard) {
     // If Clipboard API is available
     navigator.clipboard.writeText(command).then(function() {
-      showNotification('Command copied!'); // Show success message
+      showNotification("<%= raw j l(:command_copied) %>"); // Show success message
     }).catch(function(err) {
       console.error('Could not copy cURL command to clipboard: ', err);
-      showNotification('Failed to copy command'); // Show error message
+      showNotification("<%= raw j l(:command_copy_failed) %>"); // Show error message
     });
   } else {
     // If Clipboard API is not available
-    showNotification('Clipboard API not available, see console for cURL command');
+    showNotification("<%= raw j l(:command_clipboard_unavailable) %>");
   }
 }
 

--- a/app/views/subscription_templates/publish.js.erb
+++ b/app/views/subscription_templates/publish.js.erb
@@ -43,7 +43,7 @@ fetch('<%= raw j(@broker_url) %>', requestOptions)
     });
 
     if (!locationHeader) {
-      throw new Error('Location header is missing in the response');
+      throw new Error("<%= raw j l(:subscription_published_error) %>");
     }
 
     var parts = locationHeader.split('/');

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,21 +28,6 @@ de:
   text_broker_connection_auth_mode_browser_info: 'Der Browser ruft den Broker direkt auf (erfordert einen aus dem Browser erreichbaren Broker mit CORS).'
   text_broker_connection_throttling_info: 'Mindestabstand zwischen Benachrichtigungen in Sekunden, für die Subscriptions dieser Verbindung, sofern eine Vorlage ihn nicht überschreibt. Leer bedeutet %{default_value}.'
   text_broker_connection_token_info: 'Verschlüsselt gespeichert (database_cipher_key). Leer lassen, um den aktuellen Token zu behalten. Wird nur im Modus "Gespeichert" verwendet; die Modi "Über den Server" und "Browser" nehmen den Token aus dem Browser.'
-  gtt_fiware:
-    tracker_not_found: 'Status nicht gefunden'
-    version_not_found: 'Version nicht gefunden'
-    relation_not_found: 'Verknüpfung nicht gefunden'
-    error_plugin_not_enabled: 'GTT FIWARE Plugin ist für dieses Projekt nicht aktiviert'
-    category_not_found: 'Kategorie nicht gefunden'
-    detail_not_found: 'Detailangabe nicht gefunden'
-    priority_not_found: 'Priorität nicht gefunden'
-    journal_not_found: 'Aufzeichnung nicht gefunden'
-    user_not_found: 'Benutzer nicht gefunden'
-    issue_not_found: 'Ticket nicht gefunden'
-    issue_deletion_error: 'Beim Versuch, das Ticket zu löschen, ist ein Fehler aufgetreten.'
-    attachement_not_found: 'Anlage nicht gefunden'
-    project_not_found: 'Projekt nicht gefunden'
-    status_not_found: 'Tracker nicht gefunden'
   # Validation messages referenced by symbol from the models
   # (message: :invalid_...), resolved lazily in the request locale.
   activerecord:
@@ -56,6 +41,36 @@ de:
         invalid_service_path: 'muss aus /-getrennten Ebenen aus Buchstaben, Ziffern und Unterstrichen bestehen (max. 10 Ebenen)'
         invalid_token_header: 'muss ein gültiger HTTP-Header-Name sein'
         invalid_subtype: 'muss ein JSON-LD-Term sein: Buchstaben und Ziffern, beginnend mit einem Buchstaben'
+  # Boundary crossing notes (#87)
+  field_geofence_notes: 'Notizen zur Projektgrenze'
+  text_geofence_notes_info: 'Fügt dem Ticket einen Kommentar hinzu, wenn die Entität die Projektgrenze betritt oder verlässt (verglichen zwischen Benachrichtigungen). Funktioniert am besten mit Gebiet auf "Überall": ein geografisch filternder Broker sendet außerhalb des Gebiets keine Benachrichtigungen mehr, sodass das Plugin ein Verlassen nie erkennen kann.'
+  text_geofence_notes_unavailable: 'Benötigt das GTT-Modul und eine Projektgrenze.'
+  text_geofence_entered: 'Die Entität hat die Projektgrenze betreten.'
+  text_geofence_left: 'Die Entität hat die Projektgrenze verlassen.'
+
+  # Guided subscription creation (#102)
+  gtt_fiware_wizard_back: 'Zurück'
+  gtt_fiware_wizard_next: 'Weiter'
+  gtt_fiware_wizard_show_all: 'Alle Felder anzeigen'
+  gtt_fiware_wizard_step_1: 'Verbindung'
+  gtt_fiware_wizard_step_2: 'Was beobachten'
+  gtt_fiware_wizard_step_3: 'Das Ticket'
+  gtt_fiware_wizard_step_4: 'Prüfen & veröffentlichen'
+  gtt_fiware_wizard_help_1: 'Der Subscription einen Namen geben und die Broker-Verbindung wählen, auf der sie registriert wird.'
+  gtt_fiware_wizard_help_2: 'Auswählen, welche Entitäten und Änderungen Redmine benachrichtigen. Leere Filter bedeuten: jede Änderung des Entitätstyps.'
+  gtt_fiware_wizard_help_3: 'Das Ticket definieren, das jede Benachrichtigung erstellt; ${...}-Platzhalter lesen Werte aus der Entität.'
+  gtt_fiware_wizard_help_4: 'Die Vorlagen gegen eine echte Entität des Brokers prüfen und dann die Subscription erstellen.'
+
+  # Tracker-driven issue details (#103)
+  text_issue_custom_field_values_info: 'Benutzerdefinierte Felder des gewählten Trackers. ${...}-Platzhalter werden gegen die Benachrichtigungsentität gerendert; leere Felder bleiben ungesetzt.'
+  text_subscription_template_member_info: 'Erstellte Tickets werden als dieses Mitglied verfasst; Berechtigungen und Workflow folgen diesem Benutzer.'
+
+  command_copy_failed: 'Der Befehl konnte nicht kopiert werden'
+  command_clipboard_unavailable: 'Zwischenablage nicht verfügbar; der Befehl steht in der Browser-Konsole'
+  field_subscription_template_watched_attrs_placeholder: 'temperature, humidity'
+  field_attachment_url_placeholder: 'https://example.com/photo.jpg'
+  field_attachment_filename_placeholder: 'photo-${id}.jpg'
+
   model:
     subscription_template:
       ld_entities_require_type: 'jeder NGSI-LD-Entitätsselektor braucht einen "type"'
@@ -74,8 +89,6 @@ de:
       duplicate_custom_term: 'Terme benutzerdefinierter Felder müssen innerhalb einer Zuordnung eindeutig sein'
       connection_not_ngsi_ld: 'Ticket-Übertragung erfordert eine NGSI-LD-Verbindung'
   field_subscription_template_fiware_servicepath: 'FIWARE Service Path'
-  gtt_fiware_settings_broker: 'FIWARE-Einstellungen'
-
   project_module_gtt_fiware_emission: 'GTT FIWARE Ticket-Übertragung'
   permission_gtt_fiware_emission: 'Tickets an FIWARE-Broker übertragen'
   label_emission_mappings: 'Ticket-Übertragung'
@@ -106,18 +119,13 @@ de:
     (vom Broker bereitgestellt)'
   command_copied: 'Befehl in die Zwischenablage kopiert'
   field_subscription_auth_token_placeholder: 'Bearer Token'
-  project_geometry_not_defined: 'Die Projektgrenzen sind nicht definiert'
   field_subscription_template_expression_query_placeholder: 'temperature > 30'
   field_subscription_template_expression_query: 'Abfrage'
   label_subscription_template: 'Subscription'
   field_subscription_template_attrs_placeholder: '["temperature"]'
-  project_geometry_not_supported_multipolygon: 'Die Projektgrenze ist ein Multipolygon,
-    das für räumliche Suchanfragen nicht unterstützt wird'
   subscription_unpublished_warning: 'Die Subscription konnte nicht vom Broker entfernt
     werden und ist weiterhin aktiv. Prüfen Sie den Autorisierungstoken und versuchen
     Sie es erneut.'
-  link_to_insert_project_geometry_hint: 'Die Projektgrenze wird dabei als räumliche
-    Suchmaske für die Subscription verwendet'
   gtt_fiware_subscription_template_variable_hint: 'Attributwerte können als <code>${Variable}</code>
     eingebettet werden.'
   field_subscription_template_expression_coords: 'Koordinaten (lat, lon)'
@@ -128,8 +136,9 @@ de:
   field_subscription_template_fiware_service_placeholder: 'smartcity'
   field_subscription_template_attachments_placeholder: '[{"filename": "image.jpg",
     "url": "https://example.com/image.jpg"}]'
-  field_subscription_template_threshold_create_hours_hint: 'Schwellenwert für die
-    Erstellung eines neuen Tickets in Stunden.'
+  field_subscription_template_threshold_create_hours_hint: 'Innerhalb dieses Fensters aktualisieren wiederholte Benachrichtigungen
+    derselben Entität das erste Ticket, statt Duplikate zu erstellen.
+    0 erstellt jedes Mal ein neues Ticket.'
 
   gtt_fiware_settings_attachment_download: 'Download von Benachrichtigungsanhängen'
   field_attachment_download_hosts: 'Zusätzlich erlaubte Hosts'
@@ -142,11 +151,9 @@ de:
     "${location}"}'
   subscription_unauthorized_error: 'Nicht berechtigt, diese Aktion durchzuführen'
   field_subscription_template_name_placeholder: 'Temperatur-Alarm'
-  field_subscription_auth_token_hint: 'Der Autorisierungs-Token, der in den Header
-    der Anfrage eingefügt wird. Wenn keine Autorisierung erforderlich ist, lassen
-    Sie das Feld leer. Der Token wird nicht in der Datenbank gespeichert. Wenn die
-    <code>PROXY</code>-Schaltfläche aktiviert ist (grün), wird die Anfrage über den
-    Server abgewickelt.'
+  field_subscription_auth_token_hint: 'Der Token wird nur für diese Aktion verwendet und nicht gespeichert.
+    Ob der Server oder der Browser ihn an den Broker sendet, bestimmt der
+    Authentifizierungsmodus der Verbindung.'
   field_subscription_template_expression_georel: 'Georel'
   link_to_publish_hint: 'Die Subscription an den Broker übermitteln'
   subscription_unpublished: 'Die Subscription beim Broker wurde aufgehoben'
@@ -155,7 +162,6 @@ de:
   field_subscription_template_status: 'Subscription Status'
   field_subscription_template_alteration_types: 'Änderungsarten'
   field_subscription_auth_token: 'Autorisierungs-Token'
-  gtt_fiware_subscription_template_geoquery: 'Geografische Abfrage'
   field_subscription_template_broker_url: 'Broker URL'
   field_subscription_template_expiration: 'Gültigkeitsdauer'
   field_subscription_template_entities_string: 'Entities (Array)'
@@ -197,7 +203,7 @@ de:
   button_create_and_publish: 'Erstellen und veröffentlichen'
   label_template_preview: 'Vorschau mit einer Beispiel-Entität'
   preview_loading: 'Beispiel-Entität wird vom Broker geladen...'
-  preview_entity_label: 'Gerendert mit'
+  preview_entity_label: 'Vorschau basiert auf'
   preview_geometry_label: 'Position gefunden'
   preview_no_connection: 'Wählen Sie zuerst eine Broker-Verbindung'
   preview_no_entity_type: 'Geben Sie zuerst einen Entitätstyp ein'
@@ -214,28 +220,24 @@ de:
   field_subscription_template_comment: 'Anmerkung'
   subscription_published_error: 'Es gab ein Problem bei der Übertragung der Subscription
     an den Broker'
-  gtt_fiware_subscription_template_notification: 'Ticket-Vorlage'
   field_subscription_template_expression_geometry_placeholder: 'Eine Geometrie auswählen'
   permission_manage_subscription_templates: 'Subscriptions verwalten'
   field_subscription_template_broker_url_placeholder: 'https://broker.example.com/'
   field_subscription_template_context: 'NGSI-LD Context'
   field_subscription_template_attrs: 'Attributes (Array)'
-  field_subscription_template_notification_user: 'Gesendet vom Nutzer'
+  field_subscription_template_notification_user: 'Tickets erstellen als'
   label_subscription_template_plural: 'Subscriptions'
   field_subscription_template_geometry_string: 'Ticket-Geometrie (GeoJSON)'
   field_subscription_template_fiware_service: 'FIWARE Service'
   link_to_unpublish_hint: 'Subscription vom Broker aufheben'
   field_subscription_template_subject_placeholder: 'Temperaturalarm in ${Room}'
-  gtt_fiware_subscription_template_general: 'Allgemein'
   field_subscription_template_entities_string_placeholder: '[{"idPattern": ".*", "type":
     "Room"}]'
   field_subscription_template_expression_georel_placeholder: 'near;maxDistance:1000'
   label_gtt_fiware_plural: 'FIWARE'
   field_subscription_template_subscription: 'Subscription ID'
   link_to_publish: 'Veröffentlichen'
-  link_to_insert_project_geometry: 'Projektgrenzen eintragen'
   field_subscription_template_notes_placeholder: 'Schreiben Sie eine Ticket-Notiz,
     anstatt ein neues Ticket zu erstellen, wenn ein Ticket innerhalb der festgelegten
     Zeitspanne erstellt worden ist.'
-  gtt_fiware_subscription_template_subject: 'Einstellungen für Subscriptions'
   general_action_error: Beim Ausführen dieser Aktion ist ein Fehler aufgetreten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,8 +37,6 @@ en:
   text_broker_connection_token_info: "Stored encrypted (database_cipher_key). Leave blank to keep the current token. Only used in stored mode; the relayed and browser modes take the token from the browser."
 
 
-  gtt_fiware_settings_broker: "FIWARE Settings"
-
   project_module_gtt_fiware_emission: "GTT FIWARE Issue Emission"
   permission_gtt_fiware_emission: "Emit issues to FIWARE brokers"
   label_emission_mappings: "Issue Emission"
@@ -67,7 +65,6 @@ en:
   field_attachment_download_content_types: "Allowed content types"
   text_attachment_download_content_types_info: "One content type per line, wildcards like image/* are supported. Leave blank to use the default list."
 
-  gtt_fiware_subscription_template_general: "General"
   field_subscription_template_standard: "NGSI standard"
   field_subscription_template_name: "Name"
   field_subscription_template_name_placeholder: "Temperature Alert"
@@ -84,7 +81,6 @@ en:
   field_subscription_template_comment: "Comment"
   field_subscription_template_comment_placeholder: "This comment is only used internally."
 
-  gtt_fiware_subscription_template_subject: "Subscription Settings"
   field_subscription_template_subscription: "Subscription ID"
   field_subscription_template_subscription_placeholder: "Subscription unique identifier
     (provided by the broker)"
@@ -92,11 +88,11 @@ en:
   field_subscription_template_entities_string_placeholder: "[{\"idPattern\": \".*\"\
     , \"type\": \"Room\"}]"
   field_subscription_template_attrs: "Attributes (array of)"
+  field_subscription_template_watched_attrs_placeholder: "temperature, humidity"
   field_subscription_template_attrs_placeholder: "[\"temperature\"]"
   field_subscription_template_expression_query: "Query"
   field_subscription_template_expression_query_placeholder: "temperature > 30"
 
-  gtt_fiware_subscription_template_geoquery: "Geospatial Query"
   field_subscription_template_expression_georel: "Georel"
   field_subscription_template_expression_georel_placeholder: "near;maxDistance:1000"
   field_subscription_template_expression_geometry: "Geometry"
@@ -106,7 +102,6 @@ en:
   field_subscription_template_alteration_types: "Alteration types"
   field_subscription_template_notify_on_metadata_change: "Notify on metadata change"
 
-  gtt_fiware_subscription_template_notification: "Issue Template"
   gtt_fiware_subscription_template_variable_hint: "Attribute readings can be embedded
     as <code>${variable}</code>."
   field_subscription_template_subject: "Subject"
@@ -115,10 +110,12 @@ en:
   field_subscription_template_description_placeholder: "The sensor in room ${Room}
     recorded a temperature of ${temperature}°C. \n* [ ] Open window \n* [ ] Turn on
     the air conditioning"
+  field_attachment_url_placeholder: "https://example.com/photo.jpg"
+  field_attachment_filename_placeholder: "photo-${id}.jpg"
   field_subscription_template_attachments_string: "Attachments (array of)"
   field_subscription_template_attachments_placeholder: "[{\"filename\": \"image.jpg\"\
     , \"url\": \"https://example.com/image.jpg\"}]"
-  field_subscription_template_notification_user: "Sent from user"
+  field_subscription_template_notification_user: "Create issues as"
   text_subscription_template_member_info: "The created issues are authored as this member; permissions and workflow follow this user."
   text_issue_custom_field_values_info: "Custom fields of the selected tracker. ${...} placeholders render against the notification entity; blank fields are left unset."
 
@@ -144,28 +141,22 @@ en:
   field_subscription_template_geometry_placeholder: "{\"type\": \"Feature\", \"geometry\"\
     : \"${location}\"}"
 
-  link_to_insert_project_geometry: "Insert project boundary"
-  link_to_insert_project_geometry_hint: "This will use the project boundary as the
-    geospatial query for the subscription"
-  project_geometry_not_defined: "Project boundary is not defined"
-  project_geometry_not_supported_multipolygon: "Project boundary is a multipolygon,
-    which is not supported for geospatial queries"
-
   field_subscription_auth_token: "Authorization token"
   field_subscription_auth_token_placeholder: "Bearer token"
-  field_subscription_auth_token_hint: "Authorization token to be included in the request
-    headers. Leave empty for no authorization. The token is not stored in the database.
-    When the <code>PROXY</code> button is enabled (green), the request will be proxied
-    through the server."
+  field_subscription_auth_token_hint: "Token used for this action only; it is not stored.
+    Whether the server or the browser sends it to the broker depends on the
+    connection's authentication mode."
 
   link_to_copy: "Clipboard"
   link_to_copy_hint: "Copy command to clipboard"
   command_copied: "Command copied to clipboard"
+  command_copy_failed: "The command could not be copied"
+  command_clipboard_unavailable: "Clipboard not available; the command is in the browser console"
 
   link_to_publish: "Publish"
   link_to_publish_hint: "Publish subscription to broker"
   subscription_published: "Subscription published to broker"
-  subscription_published_error: "There was a problem publishing the subscription from
+  subscription_published_error: "There was a problem publishing the subscription to
     the broker"
 
   link_to_unpublish: "Unpublish"
@@ -183,14 +174,14 @@ en:
   text_watched_attributes_info: "Comma-separated attribute names; notify only when one of these changes. Leave blank for all attributes."
   field_subscription_template_geo_area: "Area"
   field_geofence_notes: "Boundary notes"
-  text_geofence_notes_info: "Adds an issue note when the entity enters or leaves the project boundary, compared between notifications. Works best with Area set to Anywhere - a geo-filtered broker stops notifying outside the area, so a leave cannot be observed."
+  text_geofence_notes_info: "Adds an issue note when the entity enters or leaves the project boundary, compared between notifications. Works best with Area set to Anywhere - a geo-filtered broker stops notifying outside the area, so the plugin can never see the entity leave."
   text_geofence_notes_unavailable: "Requires the GTT module and a project boundary."
   text_geofence_entered: "The entity entered the project boundary."
   text_geofence_left: "The entity left the project boundary."
   label_geo_area_anywhere: "Anywhere"
   label_geo_area_boundary: "Within the project boundary"
   label_geo_area_custom: "Custom"
-  text_alteration_types_ld_info: "NGSI-LD notification triggers."
+  text_alteration_types_ld_info: "NGSI-LD has no separate change trigger: change and update both become entityUpdated."
   field_subscription_template_issue_geometry: "Issue geometry"
   label_issue_geometry_location: "Entity location"
   label_issue_geometry_custom: "Custom GeoJSON template"
@@ -202,7 +193,7 @@ en:
   button_create_and_publish: "Create and publish"
   label_template_preview: "Preview with a sample entity"
   preview_loading: "Fetching a sample entity from the broker..."
-  preview_entity_label: "Rendered against"
+  preview_entity_label: "Preview based on"
   preview_geometry_label: "location found"
   preview_no_connection: "Select a broker connection first"
   preview_no_entity_type: "Enter an entity type first"
@@ -223,24 +214,6 @@ en:
 
   subscription_unauthorized_error: "Unauthorized to perform this action"
   general_action_error: "There was an error performing this action"
-
-  gtt_fiware:
-    attachement_not_found: "Attachment not found"
-    category_not_found: "Category not found"
-    detail_not_found: "Detail not found"
-    issue_not_found: "Issue not found"
-    journal_not_found: "Journal not found"
-    priority_not_found: "Priority not found"
-    project_not_found: "Project not found"
-    relation_not_found: "Relation not found"
-    status_not_found: "Tracker not found"
-    tracker_not_found: "Status not found"
-    user_not_found: "User not found"
-    version_not_found: "Version not found"
-
-    issue_deletion_error: "There was an error when trying to delete the issue."
-
-    error_plugin_not_enabled: "GTT FIWARE plugin is not enabled for this project"
 
   # Validation messages referenced by symbol from the models
   # (message: :invalid_...), resolved lazily in the request locale.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,8 +37,6 @@ ja:
   text_broker_connection_token_info: "暗号化して保存されます（database_cipher_key）。現在のトークンを変更しない場合は空欄のままにしてください。保存モードでのみ使用され、サーバー経由モードとブラウザーモードではブラウザーで入力したトークンを使用します。"
 
 
-  gtt_fiware_settings_broker: "FIWARE設定"
-
   project_module_gtt_fiware_emission: "GTT FIWARE チケット送信"
   permission_gtt_fiware_emission: "FIWAREブローカーへのチケット送信"
   label_emission_mappings: "チケット送信"
@@ -67,90 +65,74 @@ ja:
   field_attachment_download_content_types: "許可するコンテンツタイプ"
   text_attachment_download_content_types_info: "1行に1タイプを指定します。image/* のようなワイルドカードが使えます。空欄の場合は既定のリストが使われます。"
 
-  gtt_fiware_subscription_template_general: "General"
   field_subscription_template_standard: "NGSI standard"
-  field_subscription_template_name: "Name"
-  field_subscription_template_name_placeholder: "Temperature Alert"
-  field_subscription_template_broker_url: "Broker URL"
+  field_subscription_template_name: "名称"
+  field_subscription_template_name_placeholder: "温度アラート"
+  field_subscription_template_broker_url: "ブローカーURL"
   field_subscription_template_broker_url_placeholder: "https://broker.example.com/"
-  field_subscription_template_status: "Subscription status"
+  field_subscription_template_status: "サブスクリプションのステータス"
   field_subscription_template_fiware_service: "FIWARE Service"
   field_subscription_template_fiware_service_placeholder: "smartcity"
   field_subscription_template_fiware_servicepath: "FIWARE Service Path"
   field_subscription_template_fiware_servicepath_placeholder: "/environment"
   field_subscription_template_context: "NGSI-LD Context"
   field_subscription_template_context_placeholder: "https://smartdatamodels.org/context.jsonld"
-  field_subscription_template_expiration: "Expiration date"
-  field_subscription_template_comment: "Comment"
-  field_subscription_template_comment_placeholder: ""
+  field_subscription_template_expiration: "有効期限"
+  field_subscription_template_comment: "コメント"
+  field_subscription_template_comment_placeholder: "このコメントは内部でのみ使用されます。"
 
-  gtt_fiware_subscription_template_subject: "Subscription Settings"
-  field_subscription_template_subscription: "Subscription ID"
-  field_subscription_template_subscription_placeholder: "Subscription unique identifier
-    (provided by the broker)"
-  field_subscription_template_entities_string: "Entities (array of)"
+  field_subscription_template_subscription: "サブスクリプションID"
+  field_subscription_template_subscription_placeholder: "サブスクリプションの一意の識別子（ブローカーが発行）"
+  field_subscription_template_entities_string: "エンティティ（配列）"
   field_subscription_template_entities_string_placeholder: "[{\"idPattern\": \".*\"\
     , \"type\": \"Room\"}]"
-  field_subscription_template_attrs: "Attributes (array of)"
+  field_subscription_template_attrs: "属性（配列）"
   field_subscription_template_attrs_placeholder: "[\"temperature\"]"
-  field_subscription_template_expression_query: "Query"
+  field_subscription_template_expression_query: "クエリ"
   field_subscription_template_expression_query_placeholder: "temperature > 30"
 
-  gtt_fiware_subscription_template_geoquery: "Geospatial Query"
   field_subscription_template_expression_georel: "Georel"
   field_subscription_template_expression_georel_placeholder: "near;maxDistance:1000"
-  field_subscription_template_expression_geometry: "Geometry"
-  field_subscription_template_expression_geometry_placeholder: "Select a geometry"
-  field_subscription_template_expression_coords: "Coordinates (lat, lon)"
+  field_subscription_template_expression_geometry: "ジオメトリ"
+  field_subscription_template_expression_geometry_placeholder: "ジオメトリを選択"
+  field_subscription_template_expression_coords: "座標（緯度, 経度）"
   field_subscription_template_expression_coords_placeholder: "lat1, lon1; lat2, lon2; lat3, lon3; lat1, lon1"
-  field_subscription_template_alteration_types: "Alteration types"
-  field_subscription_template_notify_on_metadata_change: "Notify on metadata change"
+  field_subscription_template_alteration_types: "変更タイプ"
+  field_subscription_template_notify_on_metadata_change: "メタデータ変更時に通知"
 
-  gtt_fiware_subscription_template_notification: "Issue Template"
-  gtt_fiware_subscription_template_variable_hint: "Attribute readings can be embedded
-    as <code>${variable}</code>."
-  field_subscription_template_subject: "Subject"
-  field_subscription_template_subject_placeholder: "Temperature Alert in ${Room}"
-  field_subscription_template_description: "Description"
+  gtt_fiware_subscription_template_variable_hint: "属性の値は <code>${variable}</code> の形式で埋め込めます。"
+  field_subscription_template_subject: "題名"
+  field_subscription_template_subject_placeholder: "${Room} の温度アラート"
+  field_subscription_template_description: "説明"
   field_subscription_template_description_placeholder: "The sensor in room ${Room}
     recorded a temperature of ${temperature}°C. \n* [ ] Open window \n* [ ] Turn on
     the air conditioning"
-  field_subscription_template_attachments_string: "Attachments (array of)"
+  field_subscription_template_attachments_string: "添付ファイル（配列）"
   field_subscription_template_attachments_placeholder: "[{\"filename\": \"image.jpg\"\
     , \"url\": \"https://example.com/image.jpg\"}]"
-  field_subscription_template_notification_user: "Sent from user"
-  field_subscription_template_threshold_create_hours: "Threshold (h)"
-  field_subscription_template_threshold_create_hours_hint: "Threshold to create new
-    issue in hours."
-  field_subscription_template_notes: "Issue notes"
-  field_subscription_template_notes_placeholder: "Post an issue note instead of creating
-    a new issue if an issue has been created within the threshold."
-  field_subscription_template_geometry_string: "Issue geometry (GeoJSON)"
+  field_subscription_template_notification_user: "チケットの作成者"
+  field_subscription_template_threshold_create_hours: "しきい値（時間）"
+  field_subscription_template_threshold_create_hours_hint: "この時間内に同じエンティティの通知が繰り返し届いた場合、新しいチケットを作らず最初のチケットを更新します。0にすると毎回新しいチケットを作成します。"
+  field_subscription_template_notes: "チケットの注記"
+  field_subscription_template_notes_placeholder: "しきい値内にチケットが作成済みの場合、新しいチケットは作成せずこの注記を追加します。"
+  field_subscription_template_geometry_string: "チケットのジオメトリ（GeoJSON）"
   field_subscription_template_geometry_placeholder: "{\"type\": \"Feature\", \"geometry\"\
     : \"${location}\"}"
 
-  link_to_insert_project_geometry: "Insert project boundary"
-  link_to_insert_project_geometry_hint: "This will use the project boundary as the
-    geospatial query for the subscription"
-  project_geometry_not_defined: "Project boundary is not defined"
-  project_geometry_not_supported_multipolygon: "Project boundary is a multipolygon,
-    which is not supported for geospatial queries"
+  field_subscription_auth_token: "認証トークン"
+  field_subscription_auth_token_placeholder: "Bearerトークン"
+  field_subscription_auth_token_hint: "このトークンはこの操作にのみ使用され、保存されません。サーバーとブラウザのどちらからブローカーに送信されるかは、接続の認証モードによって決まります。"
 
-  field_subscription_auth_token: "Authorization token"
-  field_subscription_auth_token_placeholder: "Bearer token"
-  field_subscription_auth_token_hint: "Authorization token to be included in the request headers. Leave empty for no authorization. The token is not stored in the database. When the <code>PROXY</code> button is enabled (green), the request will be proxied through the server."
+  link_to_copy: "クリップボード"
+  link_to_copy_hint: "コマンドをクリップボードにコピー"
+  command_copied: "コマンドをクリップボードにコピーしました"
 
-  link_to_copy: "Clipboard"
-  link_to_copy_hint: "Copy command to clipboard"
-  command_copied: "Command copied to clipboard"
+  link_to_publish: "公開"
+  link_to_publish_hint: "サブスクリプションをブローカーに公開"
+  subscription_published: "サブスクリプションをブローカーに公開しました"
+  subscription_published_error: "サブスクリプションのブローカーへの公開中に問題が発生しました"
 
-  link_to_publish: "Publish"
-  link_to_publish_hint: "Publish subscription to broker"
-  subscription_published: "Subscription published to broker"
-  subscription_published_error: "There was a problem publishing the subscription from
-    the broker"
-
-  link_to_unpublish: "Unpublish"
+  link_to_unpublish: "公開停止"
   link_to_sync: "同期"
   gtt_fiware_form_section_filters: "フィルター"
   gtt_fiware_form_section_issue_details: "チケットの詳細"
@@ -179,7 +161,7 @@ ja:
   button_create_and_publish: "作成して公開"
   label_template_preview: "サンプルエンティティでプレビュー"
   preview_loading: "ブローカーからサンプルエンティティを取得しています..."
-  preview_entity_label: "レンダリング対象:"
+  preview_entity_label: "プレビュー元:"
   preview_geometry_label: "位置情報あり"
   preview_no_connection: "先にブローカー接続を選択してください"
   preview_no_entity_type: "先にエンティティタイプを入力してください"
@@ -193,30 +175,12 @@ ja:
   subscription_sync_removed: "サブスクリプションはブローカーに存在しないため、保存されていたサブスクリプションIDを削除しました"
   subscription_sync_no_subscription: "このテンプレートには同期する公開済みサブスクリプションがありません"
   subscription_sync_error: "ブローカーに接続できず、サブスクリプションを同期できませんでした。認証トークンを確認して再試行してください。"
-  link_to_unpublish_hint: "Unpublish subscription to broker"
-  subscription_unpublished: "Subscription unpublished from broker"
+  link_to_unpublish_hint: "ブローカーのサブスクリプションを削除"
+  subscription_unpublished: "サブスクリプションの公開を停止しました"
   subscription_unpublished_warning: "ブローカーからサブスクリプションを削除できませんでした。
     サブスクリプションはまだ有効です。認証トークンを確認して再試行してください。"
 
-  subscription_unauthorized_error: "Unauthorized to perform this action"
-
-  gtt_fiware:
-    attachement_not_found: "Attachment not found"
-    category_not_found: "Category not found"
-    detail_not_found: "Detail not found"
-    issue_not_found: "Issue not found"
-    journal_not_found: "Journal not found"
-    priority_not_found: "Priority not found"
-    project_not_found: "Project not found"
-    relation_not_found: "Relation not found"
-    status_not_found: "Tracker not found"
-    tracker_not_found: "Status not found"
-    user_not_found: "User not found"
-    version_not_found: "Version not found"
-
-    issue_deletion_error: "There was an error when trying to delete the issue."
-
-    error_plugin_not_enabled: "GTT FIWARE plugin is not enabled for this project"
+  subscription_unauthorized_error: "この操作を実行する権限がありません"
 
   # Validation messages referenced by symbol from the models
   # (message: :invalid_...), resolved lazily in the request locale.
@@ -231,16 +195,46 @@ ja:
         invalid_service_path: "は英数字とアンダースコアを/で区切った形式である必要があります（最大10階層）"
         invalid_token_header: "は有効なHTTPヘッダー名である必要があります"
         invalid_subtype: "はJSON-LDタームである必要があります（英字で始まる英数字のみ）"
+  # Boundary crossing notes (#87)
+  field_geofence_notes: "境界の注記"
+  text_geofence_notes_info: "エンティティがプロジェクト境界を出入りしたときにチケットへ注記を追加します（通知間の位置を比較して判定）。エリアを「どこでも」にした場合に最も確実に動作します。地理フィルタのあるブローカーはエリア外では通知を送らないため、プラグインは「出た」ことを検知できません。"
+  text_geofence_notes_unavailable: "GTTモジュールとプロジェクト境界が必要です。"
+  text_geofence_entered: "エンティティがプロジェクト境界内に入りました。"
+  text_geofence_left: "エンティティがプロジェクト境界から出ました。"
+
+  # Guided subscription creation (#102)
+  gtt_fiware_wizard_back: "戻る"
+  gtt_fiware_wizard_next: "次へ"
+  gtt_fiware_wizard_show_all: "すべての項目を表示"
+  gtt_fiware_wizard_step_1: "接続"
+  gtt_fiware_wizard_step_2: "監視対象"
+  gtt_fiware_wizard_step_3: "チケット"
+  gtt_fiware_wizard_step_4: "確認と公開"
+  gtt_fiware_wizard_help_1: "サブスクリプションに名前を付け、登録先のブローカー接続を選択します。"
+  gtt_fiware_wizard_help_2: "どのエンティティのどの変更をRedmineに通知するかを選択します。フィルタを空にすると、そのエンティティタイプのすべての変更が対象になります。"
+  gtt_fiware_wizard_help_3: "通知ごとに作成するチケットを定義します。${...} プレースホルダーでエンティティの値を参照できます。"
+  gtt_fiware_wizard_help_4: "ブローカーの実際のエンティティに対してテンプレートをプレビューし、サブスクリプションを作成します。"
+
+  # Tracker-driven issue details (#103)
+  text_issue_custom_field_values_info: "選択したトラッカーのカスタムフィールドです。${...} プレースホルダーは通知エンティティの値に置き換えられます。空欄のフィールドは設定されません。"
+  text_subscription_template_member_info: "作成されるチケットの作成者はこのメンバーになります。権限とワークフローもこのユーザーに従います。"
+
+  general_action_error: "この操作の実行中にエラーが発生しました"
+  command_copy_failed: "コマンドをコピーできませんでした"
+  command_clipboard_unavailable: "クリップボードを利用できません。コマンドはブラウザのコンソールに出力されています"
+  field_subscription_template_watched_attrs_placeholder: "temperature, humidity"
+  field_attachment_url_placeholder: "https://example.com/photo.jpg"
+  field_attachment_filename_placeholder: "photo-${id}.jpg"
+
   model:
     subscription_template:
       ld_entities_require_type: "NGSI-LDのエンティティセレクタには \"type\" が必要です"
       ld_entities_no_type_pattern: "\"typePattern\" はNGSIv2専用です。NGSI-LDでは \"type\" で選択します"
       ld_entities_id_must_be_uri: "NGSI-LDのエンティティIDはURI形式である必要があります（例: urn:ngsi-ld:Sensor:001）"
       oneshot_is_ngsi_v2_only: "oneshotはNGSIv2専用です。NGSI-LDのサブスクリプションに単発モードはありません"
-      attrs_must_be_array_of_strings: "Attributes must be an array of strings"
-      must_be_valid_array_of_objects: "must be a valid array of objects"
-      geo_query_fields_must_be_all_or_none: "All geo query fields (Georel, Geometry,
-        Coordinates) must be provided or none of them"
+      attrs_must_be_array_of_strings: "属性は文字列の配列である必要があります"
+      must_be_valid_array_of_objects: "はオブジェクトの配列である必要があります"
+      geo_query_fields_must_be_all_or_none: "地理クエリの項目（Georel、ジオメトリ、座標）はすべて指定するか、すべて空にしてください"
     broker_connection:
       invalid_url: "はhttp(s)のURLである必要があります"
     emission_mapping:

--- a/doc/broker_scripts.md
+++ b/doc/broker_scripts.md
@@ -1,6 +1,6 @@
 # FIWARE Broker Scripts
 
-This document describes the scripts available in the `scripts` directory that
+This document describes the scripts available in the `doc/scripts` directory that
 help manage the FIWARE context broker.
 
 - [Register All Subscriptions](#register-all-subscriptions)
@@ -18,7 +18,7 @@ URL specified in the header for each subscription.
 **Usage:**
 
 ```bash
-./scripts/register_all_subscriptions.sh <api_key>
+./doc/scripts/register_all_subscriptions.sh <api_key>
 ```
 
 **Arguments:**
@@ -45,7 +45,7 @@ To prepend an environment variable to a command in the terminal, you can do so
 like this:
 
 ```bash
-BROKER_URL=your_broker_url ./scripts/register_all_subscriptions.sh <redmine_api_key>
+BROKER_URL=your_broker_url ./doc/scripts/register_all_subscriptions.sh <redmine_api_key>
 ```
 
 Replace `redmine_api_key` with your actual Redmine API key and `your_broker_url`
@@ -64,7 +64,7 @@ subscriptions, and then makes DELETE requests to the
 **Usage:**
 
 ```bash
-./scripts/delete_all_subscriptions.sh
+./doc/scripts/delete_all_subscriptions.sh
 ```
 
 **Environment Variables:**
@@ -84,9 +84,9 @@ To prepend an environment variable to a command in the terminal, you can do so
 like this:
 
 ```bash
-BROKER_URL=your_broker_url ./scripts/delete_all_subscriptions.sh
+BROKER_URL=your_broker_url ./doc/scripts/delete_all_subscriptions.sh
 ```
 
-Replace `your_broker_url` with your actual Redmine API key. This will set the
+Replace `your_broker_url` with your broker URL. This will set the
 `BROKER_URL` environment variable for the duration of the
 `delete_all_subscriptions.sh` script.

--- a/doc/examples/camera_sensor.md
+++ b/doc/examples/camera_sensor.md
@@ -30,7 +30,7 @@ following minimal settings:
 | **Description**   | `The speed camera sensor ${id} detected a speed of ${speed} km/h.`|
 | **Issue geometry**| `{ "type": "Feature", "geometry": "${location}" }`        |
 | **Attachments**   | `[{"filename": "SC_${timestamp}.jpg", "url": "${image}"}]`|
-| **Sent from user**| `api_user` (select the user who will send the issue)      |
+| **Create issues as**| `api_user` (the member the created issues are authored as) |
 
 Create the subscription template and publish it.
 

--- a/doc/examples/camera_sensor.md
+++ b/doc/examples/camera_sensor.md
@@ -13,7 +13,7 @@ following minimal settings:
 | Field             | Value                                                     |
 |-------------------|-----------------------------------------------------------|
 | **Name**          | `Speed Alert > 80 km/h`                                   |
-| **Broker URL**    | `your_broker_url` (e.g., `http://127.0.0.1:1026`)         |
+| **Connection** | select the FIWARE Connection for your broker (an administrator creates these, see [broker_connections.md](../broker_connections.md)) |
 
 ### Subscription Settings
 

--- a/doc/examples/location_sensor.md
+++ b/doc/examples/location_sensor.md
@@ -29,7 +29,7 @@ following minimal settings:
 | **Subject**       | `Location Alert`                                          |
 | **Description**   | `The location sensor ${id} entered the project area.`     |
 | **Issue geometry**| `{ "type": "Feature", "geometry": "${location}" }`        |
-| **Sent from user**| `api_user` (select the user who will send the issue)      |
+| **Create issues as**| `api_user` (the member the created issues are authored as) |
 
 Create the subscription template and publish it.
 

--- a/doc/examples/location_sensor.md
+++ b/doc/examples/location_sensor.md
@@ -13,14 +13,14 @@ following minimal settings:
 | Field             | Value                                                     |
 |-------------------|-----------------------------------------------------------|
 | **Name**    | `Location Alert`                                                |
-| **Broker URL** | `your_broker_url` (e.g., `http://127.0.0.1:1026`)            |
+| **Connection** | select the FIWARE Connection for your broker (an administrator creates these, see [broker_connections.md](../broker_connections.md)) |
 
 ### Subscription Settings
 
 | Field               | Value                                                   |
 |---------------------|---------------------------------------------------------|
 | **Entities**        | `[{ "idPattern": ".*", "type": "LocationSensor" }]`     |
-| **Geospatial Query**| Apply the project boundary by clicking "Insert project boundary"|
+| **Area** | select *Within the project boundary* (the project needs a boundary drawn in its GTT settings) |
 
 ### Issue Settings
 

--- a/doc/examples/temperature_sensor.md
+++ b/doc/examples/temperature_sensor.md
@@ -13,7 +13,7 @@ following minimal settings:
 | Field             | Value                                                     |
 |-------------------|-----------------------------------------------------------|
 | **Name**    | `Temperature Alert > 30°C`                                      |
-| **Broker URL** | `your_broker_url` (e.g., `http://127.0.0.1:1026`)            |
+| **Connection** | select the FIWARE Connection for your broker (an administrator creates these, see [broker_connections.md](../broker_connections.md)) |
 
 ### Subscription Settings
 

--- a/doc/examples/temperature_sensor.md
+++ b/doc/examples/temperature_sensor.md
@@ -30,7 +30,7 @@ following minimal settings:
 | **Description**   | `The temperature sensor ${id} recorded a temperature of ${temperature}°C.`|
 | **Notes**         | `The temperature reading has been updated to ${temperature}°C.`|
 | **Threshold (h)** | `24` (new issue if temperature remains high after 24h)    |
-| **Sent from user**| `api_user` (select the user who will send the issue)      |
+| **Create issues as**| `api_user` (the member the created issues are authored as) |
 
 Create the subscription template and publish it.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -17,9 +17,9 @@ FIWARE plugin and its API endpoints.
 Use a dedicated user with just the needed permissions as the subscription
 author, not an administrator.
 
-If you need a test broker, [FIWARE-Small-Bang](https://github.com/lets-fiware/FIWARE-Small-Bang)
+If you need a test broker, use [FIWARE-Small-Bang](https://github.com/lets-fiware/FIWARE-Small-Bang)
 (local) or [FIWARE-Big-Bang](https://github.com/lets-fiware/FIWARE-Big-Bang)
-(server) set one up.
+(server) to set one up.
 
 ### Redmine Permissions
 
@@ -99,14 +99,13 @@ curl -sX GET "${BROKER_URL}/v2/subscriptions" \
 - The coordinates in the location examples are in `[longitude, latitude]` format.
 - The `jq` command is used to format the JSON output for better readability.
 
-These cURL commands should help you interact with the FIWARE broker and test the
-Redmine GTT FIWARE plugin effectively. If you encounter any issues or need
-further assistance, please let us know!
+If something does not behave as described here, please open an issue in the
+[tracker](https://github.com/gtt-project/redmine_gtt_fiware/issues).
 
 #### CORS Issues
 
 If you encounter CORS issues, for example when you use FIWARE-Big-Bang, you can extend
-the Ngix configuration as follows:
+the Nginx configuration as follows:
 
 ```nginx
 [snip]

--- a/doc/issue_emission.md
+++ b/doc/issue_emission.md
@@ -77,6 +77,8 @@ them. For federation, configure the host name.
 ## Issues as NGSI-LD on demand
 
 Every issue is also available as an NGSI-LD entity at
-`GET /fiware/issues/<id>/entity` (session or API key). The issue page links to
-it from its "Also available in" list, next to PDF and Atom. This returns the
-same representation the emitter publishes.
+`GET /fiware/issues/<id>/entity` (session or API key). Like emission itself,
+this needs the instance identifier to be set; without it the endpoint answers
+404 and the link is not shown. The issue page links to it from its
+"Also available in" list, next to PDF and Atom. This returns the same
+representation the emitter publishes.

--- a/doc/release_verification.md
+++ b/doc/release_verification.md
@@ -81,8 +81,10 @@ podman run -d --name orion-v2 --network <redmine-network> -p 1026:1026 \
    token — an open broker also verifies the token-less stored path).
 2. Create a template with a query filter (e.g. `severity>3`) and geometry
    "Entity location", then publish it. The notification callback URL must be
-   reachable **from the Orion container** (see #101: the URL is built from the
-   publishing request's host, so publish from a host/alias Orion can resolve).
+   reachable **from the Orion container**. The URL is built from
+   Administration > Settings > Host name; when no host name is configured it
+   falls back to the publishing request's host, so make sure whichever
+   applies resolves from inside the Orion container.
 3. Three-phase filter test — create an entity below the threshold, update it
    to the boundary, then past it:
 

--- a/doc/scripts/delete_all_subscriptions.sh
+++ b/doc/scripts/delete_all_subscriptions.sh
@@ -13,11 +13,11 @@ if [ -n "$BROKER_TOKEN" ]; then
 fi
 
 # Check if FIWARE_SERVICE and FIWARE_SERVICEPATH are provided
-if [ -z "$FIWARE_SERVICE" ]; then
+if [ -n "$FIWARE_SERVICE" ]; then
   HEADERS+=(-H "Fiware-Service: $FIWARE_SERVICE")
 fi
 
-if [ -z "$FIWARE_SERVICEPATH" ]; then
+if [ -n "$FIWARE_SERVICEPATH" ]; then
   HEADERS+=(-H "Fiware-ServicePath: $FIWARE_SERVICEPATH")
 fi
 

--- a/doc/scripts/register_all_subscriptions.sh
+++ b/doc/scripts/register_all_subscriptions.sh
@@ -22,11 +22,11 @@ if [ -n "$BROKER_TOKEN" ]; then
 fi
 
 # Check if FIWARE_SERVICE and FIWARE_SERVICEPATH are provided
-if [ -z "$FIWARE_SERVICE" ]; then
+if [ -n "$FIWARE_SERVICE" ]; then
   HEADERS+=(-H "Fiware-Service: $FIWARE_SERVICE")
 fi
 
-if [ -z "$FIWARE_SERVICEPATH" ]; then
+if [ -n "$FIWARE_SERVICEPATH" ]; then
   HEADERS+=(-H "Fiware-ServicePath: $FIWARE_SERVICEPATH")
 fi
 

--- a/doc/subscription_template.md
+++ b/doc/subscription_template.md
@@ -56,7 +56,7 @@ visible fields.
 
 The fields follow the selected tracker: fields the tracker disables are
 hidden, the status list offers what the tracker's workflow allows for the
-*Sent from user* member, and the tracker's own custom fields appear.
+*Create issues as* member, and the tracker's own custom fields appear.
 
 - **Description** and **Issue notes** templates (`${...}` placeholders work
   here too). The notes template is used when a notification updates an
@@ -80,7 +80,7 @@ hidden, the status list offers what the tracker's workflow allows for the
 
   ![Custom field templates](subscription_form_custom_fields.png)
 
-- **Sent from user** (required): the member the issues are authored as. It
+- **Create issues as** (required): the member the issues are authored as. It
   decides the author, the permissions the issue is created with, and the
   workflow statuses offered above, so use a dedicated user with just the
   needed permissions, not an administrator.

--- a/init.rb
+++ b/init.rb
@@ -12,6 +12,10 @@ Redmine::Plugin.register :redmine_gtt_fiware do
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'
+  # redmine_gtt is a hard dependency (README always said so, but it was not
+  # enforced): geometry conversion goes through RedmineGtt::Conversions, and
+  # the subscription form reads the project boundary its migration adds.
+  requires_redmine_plugin :redmine_gtt, :version_or_higher => '0.0.1'
 
   # Plugin settings with default values and partial view for settings
   settings(


### PR DESCRIPTION
Final PR from the maintainer review: documentation accuracy and internationalization. Two commits, one per concern.

## Docs and helper scripts

- The three tutorial examples described the pre-v3.0 form: a **Broker URL** field on the template (connections are admin-managed since #67) and an **Insert project boundary** link that no longer exists (the **Area** radio replaced it). Rewritten to the current UI.
- Both helper shell scripts added the tenant headers exactly when the variables were **not** set (inverted `-z` tests), so a tenant-scoped broker never received them. `broker_scripts.md` also pointed at a `scripts/` directory that does not exist and told readers to replace a broker URL "with your actual Redmine API key".
- `init.rb` now enforces the `redmine_gtt` dependency the README always claimed; installing without it broke at runtime anyway, just later and less clearly. README gains a Development section (how to run the Ruby and Vitest suites).
- Smaller accuracy fixes: the on-demand entity endpoint documents its instance-identifier precondition; `release_verification.md` no longer claims the callback URL is always built from the request host; a broken sentence, the "Ngix" typo, an http link, a filler paragraph.

## i18n

- **Full en/ja/de key parity.** 18-19 keys were missing from ja/de entirely, all user-visible: the wizard steps and help texts, the boundary-notes feature including the journal note text (Japanese users received English notes in their issues), and the member/custom-field hints.
- **The Japanese UI is actually Japanese now.** A large ja block still carried English values: form labels, publish/copy messages, the threshold hint. Translated.
- The auth-token hint described a **PROXY button** removed in #95; it now explains what really decides where the token goes (the connection's authentication mode). "Sent from user" becomes "Create issues as" in all three languages, docs included.
- The copy/publish JS responses used hard-coded English strings; they use the locale now (the `command_copied` key existed in all three languages, referenced by nothing). The publish/unpublish list icons get the hover hints whose keys also existed unused.
- **Dead keys removed** from all three locales, each verified by grep before deletion: the four pre-#66 form section headings, the insert-project-boundary trio, the unused settings-tab key, and the whole `gtt_fiware.*` namespace of the read API removed in #60 (whose status/tracker messages had been swapped in every locale, fittingly for keys nothing read).
- The list partial stops piping plain values through `textilizable`, which wiki-rendered user data into `<p>`-wrapped cells for no benefit.

## Verification

YAML validity and full leaf-key parity checked programmatically for all three locales (no missing, no extra keys). Full suite: 355 runs, 1215 assertions, 0 failures; 64 JS tests pass.

Not included, deliberately: moving the two inline `<script>` blocks into assets, form-prologue helper extraction, and the label `for=` accessibility pass. Those are real but carry regression risk disproportionate to this PR; follow-up issue to come.
