### PR TITLE
Bump plugin version to 3.3.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '3.2.1'
+  version '3.3.0'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Release cut for the 2026-08 maintainer review (PRs #137-#144). Minor version rather than a patch: broker URL construction changes for path-prefixed brokers, the NGSI conformance fixes change published payloads, new save-time validations reject input that used to be accepted (and fail at publish time instead), and two data migrations run on upgrade. Both migrations are automatic; there is no manual upgrade step.