### PR TITLE
View polish: inline scripts to assets, form-state helper, label associations

### DIFF
--- a/app/controllers/subscription_templates_controller.rb
+++ b/app/controllers/subscription_templates_controller.rb
@@ -4,6 +4,10 @@ require 'uri'
 class SubscriptionTemplatesController < ApplicationController
   layout 'base'
 
+  # Redmine only auto-includes the helper matching the controller name, so
+  # the form-state helper (#145) needs an explicit declaration.
+  helper SubscriptionTemplateFormHelper
+
   # See SubscriptionIssuesController: the explicit declaration keeps the
   # framework-default forgery protection visible to static analysis.
   protect_from_forgery with: :exception

--- a/app/helpers/subscription_template_form_helper.rb
+++ b/app/helpers/subscription_template_form_helper.rb
@@ -1,0 +1,88 @@
+# View state for the subscription template form partials (#145). These are
+# pure derivations from the template and project; extracting them keeps the
+# partials markup-only and makes the branching unit-testable.
+#
+# All names carry the gtt_fiware_ prefix because Rails mixes every helper
+# module into every view: unprefixed names like geometry_mode would be one
+# core or plugin update away from a collision.
+module SubscriptionTemplateFormHelper
+  # A structured picker can only represent flat hashes with known keys;
+  # anything richer falls back to the raw JSON textarea. `rows` is what the
+  # picker renders, including the blank starter row (the add link clones the
+  # last row, so with zero rows it would silently do nothing).
+  PickerState = Struct.new(:pickerable, :rows) do
+    alias_method :pickerable?, :pickerable
+  end
+
+  # The boundary radio needs a project polygon from redmine_gtt (#87).
+  def gtt_fiware_project_boundary_available?(project)
+    project.module_enabled?('gtt') && project.geom.present? &&
+      project.geojson.present? &&
+      project.geojson.as_json&.dig('geometry', 'type') == 'Polygon'
+  end
+
+  # Geo area radio state: anywhere (no geo fields), boundary (project
+  # polygon, coveredBy) or custom georel/coords. 'boundary' only when its
+  # radio is actually rendered; otherwise the stored fields show as a custom
+  # query.
+  def gtt_fiware_geo_mode(template, boundary_available)
+    return 'anywhere' if template.expression_georel.blank?
+
+    if boundary_available && template.expression_georel == 'coveredBy' &&
+       template.expression_geometry == 'polygon'
+      'boundary'
+    else
+      'custom'
+    end
+  end
+
+  # The comma-separated form of the watched attributes JSON array; blank when
+  # the stored value is not one.
+  def gtt_fiware_watched_attrs_list(template)
+    parsed = JSON.parse(template.attrs.to_s)
+    parsed.is_a?(Array) ? parsed.join(', ') : ''
+  rescue JSON::ParserError
+    ''
+  end
+
+  # Entity rows are pickerable when every stored entry is a flat hash of
+  # type + (idPattern | id).
+  def gtt_fiware_entity_picker(template)
+    entities = template.entities.is_a?(Array) ? template.entities : []
+    pickerable = entities.all? do |entity|
+      entity.is_a?(Hash) && entity['type'].present? &&
+        (entity.keys - %w[type idPattern id]).empty? &&
+        entity.keys.count { |key| %w[idPattern id].include?(key) } <= 1
+    end
+    rows = pickerable ? entities : []
+    rows = [{ 'type' => '', 'idPattern' => '.*' }] if rows.empty? && pickerable
+    PickerState.new(pickerable, rows)
+  end
+
+  # Issue geometry radio: the common case is mapping the entity's location
+  # GeoProperty; custom keeps a raw GeoJSON template; none clears it. New
+  # templates default to the entity's location (#102). A stored blank stays
+  # None.
+  def gtt_fiware_geometry_mode(template)
+    if template.geometry.blank?
+      template.new_record? ? 'location' : 'none'
+    elsif template.geometry == '${location}'
+      'location'
+    else
+      'custom'
+    end
+  end
+
+  # Attachment rows are pickerable when every stored entry is a flat hash of
+  # url/filename/description. Rows with a blank URL are skipped on
+  # serialization, so the blank starter row is harmless.
+  def gtt_fiware_attachment_picker(template)
+    attachments = template.attachments.is_a?(Array) ? template.attachments : []
+    pickerable = attachments.all? do |attachment|
+      attachment.is_a?(Hash) && (attachment.keys - %w[url filename description]).empty?
+    end
+    rows = pickerable ? attachments : []
+    rows = [{}] if rows.empty? && pickerable
+    PickerState.new(pickerable, rows)
+  end
+end

--- a/app/views/broker_connections/_form.html.erb
+++ b/app/views/broker_connections/_form.html.erb
@@ -89,20 +89,6 @@
   </div>
 </div>
 
-<%= javascript_tag do %>
-(function() {
-  var standardSelect = document.getElementById('broker_connection_standard');
-  if (!standardSelect) return;
-  function applyStandard() {
-    var isLd = standardSelect.value === 'NGSI-LD';
-    document.querySelectorAll('.js-ngsi-v2-only').forEach(function(el) {
-      el.style.display = isLd ? 'none' : '';
-    });
-    document.querySelectorAll('.js-ngsi-ld-only').forEach(function(el) {
-      el.style.display = isLd ? '' : 'none';
-    });
-  }
-  standardSelect.addEventListener('change', applyStandard);
-  applyStandard();
-})();
-<% end %>
+<%# Standard-aware field toggling lives in the asset, where the Vitest suite
+    covers it (#145). %>
+<%= javascript_include_tag 'gtt_fiware_connection_form', plugin: 'redmine_gtt_fiware' %>

--- a/app/views/subscription_templates/_attachment_row.html.erb
+++ b/app/views/subscription_templates/_attachment_row.html.erb
@@ -2,9 +2,9 @@
     once inside the picker's <template> prototype, which the add link clones
     -- so adding still works when every row has been removed. %>
 <span class="gtt-fiware-attachment-row" style="display: block; margin-bottom: 4px;">
-  <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" placeholder="<%= l(:field_attachment_url_placeholder) %>" size="35" />
-  <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" placeholder="<%= l(:field_attachment_filename_placeholder) %>" size="20" />
-  <input type="text" class="js-attachment-description" value="<%= attachment['description'] %>" placeholder="<%= l(:field_description) %>" size="20" />
+  <input type="text" class="js-attachment-url" value="<%= attachment['url'] %>" aria-label="<%= l(:label_attachment_url) %>" placeholder="<%= l(:field_attachment_url_placeholder) %>" size="35" />
+  <input type="text" class="js-attachment-filename" value="<%= attachment['filename'] %>" aria-label="<%= l(:label_attachment_filename) %>" placeholder="<%= l(:field_attachment_filename_placeholder) %>" size="20" />
+  <input type="text" class="js-attachment-description" value="<%= attachment['description'] %>" aria-label="<%= l(:field_description) %>" placeholder="<%= l(:field_description) %>" size="20" />
   <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
   <a href="#" class="js-attachment-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
 </span>

--- a/app/views/subscription_templates/_entity_row.html.erb
+++ b/app/views/subscription_templates/_entity_row.html.erb
@@ -2,12 +2,12 @@
     and once inside the picker's <template> prototype, which the add link
     clones -- so adding still works when every row has been removed. %>
 <span class="gtt-fiware-entity-row" style="display: block; margin-bottom: 4px;">
-  <input type="text" class="js-entity-type" value="<%= entity['type'] %>" placeholder="<%= l(:field_subscription_template_entity_type_placeholder) %>" size="25" />
-  <select class="js-entity-match-kind">
+  <input type="text" class="js-entity-type" value="<%= entity['type'] %>" aria-label="<%= l(:label_entity_type) %>" placeholder="<%= l(:field_subscription_template_entity_type_placeholder) %>" size="25" />
+  <select class="js-entity-match-kind" aria-label="<%= l(:label_entity_match_kind) %>">
     <option value="idPattern" <%= 'selected' if entity.key?('idPattern') || !entity.key?('id') %>><%= l(:label_entity_match_pattern) %></option>
     <option value="id" <%= 'selected' if entity.key?('id') %>><%= l(:label_entity_match_id) %></option>
   </select>
-  <input type="text" class="js-entity-match-value" value="<%= entity['idPattern'] || entity['id'] %>" size="25" />
+  <input type="text" class="js-entity-match-value" value="<%= entity['idPattern'] || entity['id'] %>" aria-label="<%= l(:label_entity_match_value) %>" size="25" />
   <%# Redmine 6 icons are SVG sprites; a bare icon-del anchor renders 0x0. %>
   <a href="#" class="js-entity-remove icon-only icon-del" title="<%= l(:button_delete) %>" aria-label="<%= l(:button_delete) %>"><%= sprite_icon('del') %></a>
 </span>

--- a/app/views/subscription_templates/_form_basics.html.erb
+++ b/app/views/subscription_templates/_form_basics.html.erb
@@ -1,13 +1,4 @@
-<%
-  # Entity rows are pickerable when every stored entry is a flat hash of
-  # type + (idPattern | id). Anything else falls back to raw JSON editing.
-  entities = @subscription_template.entities.is_a?(Array) ? @subscription_template.entities : []
-  entities_pickerable = entities.all? do |e|
-    e.is_a?(Hash) && e['type'].present? && (e.keys - %w[type idPattern id]).empty? && e.keys.count { |k| %w[idPattern id].include?(k) } <= 1
-  end
-  entity_rows = entities_pickerable ? entities : []
-  entity_rows = [{ 'type' => '', 'idPattern' => '.*' }] if entity_rows.empty? && entities_pickerable
-%>
+<% entity_picker = gtt_fiware_entity_picker(@subscription_template) %>
 
 <div class="box tabular">
   <p data-wizard-step="1"><%= f.text_field :name, required: true, size: 75, placeholder: l(:field_subscription_template_name_placeholder) %></p>
@@ -32,8 +23,8 @@
   <%# Structured entity picker (#66); serialized into entities_string on submit. %>
   <p data-wizard-step="2">
     <%= content_tag :label, l(:field_subscription_template_entities) %>
-    <span id="gtt-fiware-entity-rows" <%= 'style=display:none;'.html_safe unless entities_pickerable %>>
-      <% entity_rows.each do |entity| %>
+    <span id="gtt-fiware-entity-rows" <%= 'style=display:none;'.html_safe unless entity_picker.pickerable? %>>
+      <% entity_picker.rows.each do |entity| %>
         <%= render 'entity_row', entity: entity %>
       <% end %>
       <a href="#" id="gtt-fiware-entity-add"><%= l(:label_entity_filter_add) %></a>
@@ -43,7 +34,7 @@
     </span>
     <a href="#" class="js-json-toggle" data-target="entities" style="font-size: 0.9em;"><%= l(:label_edit_as_json) %></a>
   </p>
-  <p id="gtt-fiware-entities-json" data-wizard-step="2" <%= 'class=hidden'.html_safe if entities_pickerable %>>
+  <p id="gtt-fiware-entities-json" data-wizard-step="2" <%= 'class=hidden'.html_safe if entity_picker.pickerable? %>>
     <%= f.text_area :entities_string, rows: 4,
           placeholder: JSON.pretty_generate(JSON.parse(l(:field_subscription_template_entities_string_placeholder))),
           value: (@subscription_template.entities.presence ? JSON.pretty_generate(@subscription_template.entities) : '') %>

--- a/app/views/subscription_templates/_form_filters.html.erb
+++ b/app/views/subscription_templates/_form_filters.html.erb
@@ -1,33 +1,13 @@
 <%
-  project_boundary_available = @project.module_enabled?('gtt') && @project.geom.present? &&
-                               @project.geojson.present? &&
-                               JSON.parse(@project.geojson.to_json).dig('geometry', 'type') == 'Polygon'
-  # Geo area radio state: anywhere (no geo fields), boundary (project polygon,
-  # coveredBy) or custom georel/coords. 'boundary' only when its radio is
-  # actually rendered; otherwise the stored fields show as a custom query.
-  geo_mode =
-    if @subscription_template.expression_georel.blank?
-      'anywhere'
-    elsif project_boundary_available &&
-          @subscription_template.expression_georel == 'coveredBy' &&
-          @subscription_template.expression_geometry == 'polygon'
-      'boundary'
-    else
-      'custom'
-    end
-  attrs_list = begin
-    parsed = JSON.parse(@subscription_template.attrs.to_s)
-    parsed.is_a?(Array) ? parsed.join(', ') : ''
-  rescue JSON::ParserError
-    ''
-  end
+  project_boundary_available = gtt_fiware_project_boundary_available?(@project)
+  geo_mode = gtt_fiware_geo_mode(@subscription_template, project_boundary_available)
 %>
 
 <div class="box tabular">
   <%# Comma-separated watched attributes; serialized into the attrs JSON array. %>
   <p>
-    <%= content_tag :label, l(:field_subscription_template_watched_attributes) %>
-    <input type="text" id="gtt-fiware-attrs-input" size="75" value="<%= attrs_list %>" placeholder="<%= l(:field_subscription_template_watched_attrs_placeholder) %>" />
+    <%= content_tag :label, l(:field_subscription_template_watched_attributes), for: 'gtt-fiware-attrs-input' %>
+    <input type="text" id="gtt-fiware-attrs-input" size="75" value="<%= gtt_fiware_watched_attrs_list(@subscription_template) %>" placeholder="<%= l(:field_subscription_template_watched_attrs_placeholder) %>" />
     <em class="info"><%= l(:text_watched_attributes_info) %></em>
   </p>
   <%= f.hidden_field :attrs %>
@@ -58,9 +38,6 @@
     <p class="min-width"><%= f.select :expression_geometry, SubscriptionTemplate::GEOMETRIES, include_blank: true %></p>
     <p><%= f.text_field :expression_coords, size: 75, placeholder: l(:field_subscription_template_expression_coords_placeholder) %></p>
   </span>
-  <% if geo_mode != 'custom' %>
-    <%# Keep the underlying fields submitted even when the custom block is hidden. %>
-  <% end %>
 
   <p>
     <%= content_tag :label, l(:field_subscription_template_alteration_types) %>

--- a/app/views/subscription_templates/_form_issue_details.html.erb
+++ b/app/views/subscription_templates/_form_issue_details.html.erb
@@ -1,26 +1,6 @@
 <%
-  # Issue geometry radio: the common case is mapping the entity's location
-  # GeoProperty; custom keeps a raw GeoJSON template; none clears it.
-  # New templates default to the entity's location (#102): mapping the
-  # GeoProperty is the overwhelmingly common case. A stored blank stays None.
-  geometry_mode =
-    if @subscription_template.geometry.blank?
-      @subscription_template.new_record? ? 'location' : 'none'
-    elsif @subscription_template.geometry == '${location}'
-      'location'
-    else
-      'custom'
-    end
-
-  attachments = @subscription_template.attachments.is_a?(Array) ? @subscription_template.attachments : []
-  attachments_pickerable = attachments.all? do |a|
-    a.is_a?(Hash) && (a.keys - %w[url filename description]).empty?
-  end
-  attachment_rows = attachments_pickerable ? attachments : []
-  # A blank starter row, like the entity picker: the add link clones the last
-  # row, so with zero rows it would silently do nothing. Rows with a blank URL
-  # are skipped on serialization.
-  attachment_rows = [{}] if attachment_rows.empty? && attachments_pickerable
+  geometry_mode = gtt_fiware_geometry_mode(@subscription_template)
+  attachment_picker = gtt_fiware_attachment_picker(@subscription_template)
 %>
 
 <div class="box tabular">
@@ -46,8 +26,8 @@
   <%# Attachment rows (#66); serialized into attachments_string on submit. %>
   <p>
     <%= content_tag :label, l(:field_subscription_template_attachments) %>
-    <span id="gtt-fiware-attachment-rows" <%= 'style=display:none;'.html_safe unless attachments_pickerable %>>
-      <% attachment_rows.each do |attachment| %>
+    <span id="gtt-fiware-attachment-rows" <%= 'style=display:none;'.html_safe unless attachment_picker.pickerable? %>>
+      <% attachment_picker.rows.each do |attachment| %>
         <%= render 'attachment_row', attachment: attachment %>
       <% end %>
       <a href="#" id="gtt-fiware-attachment-add"><%= l(:label_attachment_template_add) %></a>
@@ -57,7 +37,7 @@
     </span>
     <a href="#" class="js-json-toggle" data-target="attachments" style="font-size: 0.9em;"><%= l(:label_edit_as_json) %></a>
   </p>
-  <p id="gtt-fiware-attachments-json" <%= 'class=hidden'.html_safe if attachments_pickerable %>>
+  <p id="gtt-fiware-attachments-json" <%= 'class=hidden'.html_safe if attachment_picker.pickerable? %>>
     <%= f.text_area :attachments_string, rows: 4,
           placeholder: JSON.pretty_generate(JSON.parse(l(:field_subscription_template_attachments_placeholder))),
           value: (@subscription_template.attachments.presence ? JSON.pretty_generate(@subscription_template.attachments) : '') %>
@@ -67,20 +47,20 @@
       workflow-allowed for the tracker/member pair (refetched by the form JS
       on change), and core fields the tracker disables are hidden. %>
   <p class="min-width">
-    <%= content_tag :label, l(:label_issue_status) %>
+    <%= content_tag :label, l(:label_issue_status), for: 'subscription_template_issue_status_id' %>
     <%= f.collection_select :issue_status_id, form_issue_statuses, :id, :name, {},
           data: { statuses_url: allowed_statuses_project_subscription_templates_path(@project) } %>
   </p>
   <p class="min-width js-issue-core-field" data-field="priority_id">
-    <%= content_tag :label, l(:field_priority) %>
+    <%= content_tag :label, l(:field_priority), for: 'subscription_template_issue_priority_id' %>
     <%= f.collection_select :issue_priority_id, @issue_priorities, :id, :name %>
   </p>
   <p class="min-width js-issue-core-field" data-field="category_id">
-    <%= content_tag :label, l(:label_issue_category) %>
+    <%= content_tag :label, l(:label_issue_category), for: 'subscription_template_issue_category_id' %>
     <%= f.collection_select :issue_category_id, @issue_categories, :id, :name, include_blank: true %>
   </p>
   <p class="min-width js-issue-core-field" data-field="fixed_version_id">
-    <%= content_tag :label, l(:label_version) %>
+    <%= content_tag :label, l(:label_version), for: 'subscription_template_version_id' %>
     <%= f.collection_select :version_id, @project.versions, :id, :name, include_blank: true %>
   </p>
   <%# Per-tracker custom fields (#103, phase 2): every tracker's fields are
@@ -110,7 +90,7 @@
   <% end %>
 
   <p class="min-width">
-    <%= content_tag :label, l(:field_subscription_template_notification_user) %>
+    <%= content_tag :label, l(:field_subscription_template_notification_user), for: 'subscription_template_member_id' %>
     <%= f.collection_select :member_id, @project.members, :id, :name %>
     <em class="info"><%= l(:text_subscription_template_member_info) %></em>
   </p>

--- a/app/views/subscription_templates/_list.html.erb
+++ b/app/views/subscription_templates/_list.html.erb
@@ -1,12 +1,16 @@
 <% if subscription_templates.any? %>
+  <%# Row action handling (publish/unpublish list refresh, notifications,
+      browser token header) lives in the asset, where the Vitest suite covers
+      it (#145). %>
+  <%= javascript_include_tag 'gtt_fiware_list', plugin: 'redmine_gtt_fiware' %>
+
   <%# The token box is only useful for connections whose token is typed in the
       browser (proxied / browser). A list of purely stored-auth templates needs
       no token at all, so it is hidden then (#95). %>
-  <% needs_browser_token = subscription_templates.any? { |t| t.broker_connection&.browser_token? } %>
-  <% if needs_browser_token %>
+  <% if subscription_templates.any? { |t| t.broker_connection&.browser_token? } %>
     <div class="box tabular">
       <p class="min-width">
-        <%= content_tag :label, l(:field_subscription_auth_token) %>
+        <%= content_tag :label, l(:field_subscription_auth_token), for: 'subscription_auth_token' %>
         <%= text_field_tag :subscription_auth_token, "", :size => 60, :placeholder => l(:field_subscription_auth_token_placeholder) %>
         <br><small><i><%= l(:field_subscription_auth_token_hint).html_safe %></i></small>
       </p>
@@ -31,41 +35,6 @@
       <%= render collection: subscription_templates.sort_by(&:name), partial: 'subscription_templates/subscription_template' %>
     </tbody>
   </table>
-
-  <% if needs_browser_token %>
-  <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      if (Rails) {
-        document.addEventListener('ajax:beforeSend', function(event) {
-          var xhr = event.detail[0];
-          xhr.setRequestHeader('FIWARE-Broker-Auth-Token', document.getElementById('subscription_auth_token').value);
-        });
-
-        document.addEventListener('ajax:success', function(event) {
-          var detail = event.detail;
-          var data = detail[0], status = detail[1], xhr = detail[2];
-
-          // Check if event.target has the class 'copy-command-link'
-          if (!event.target.classList.contains('copy-command-link')) {
-            // Update the subscription templates list with the response data
-            document.getElementById('subscriptionTemplateList').innerHTML = xhr.responseText;
-          }
-
-          showNotification(xhr.getResponseHeader('X-Redmine-Message'));
-        });
-
-        document.addEventListener('ajax:error', function(event) {
-          var detail = event.detail;
-          var data = detail[0], status = detail[1], xhr = detail[2];
-
-          console.error("Error during publish:", data);
-          showNotification(xhr.getResponseHeader('X-Redmine-Message'));
-        });
-      }
-
-    });
-  </script>
-  <% end %>
 
   <div id="temporaryNotification" class="temporaryNotification"></div>
 <% else %>

--- a/assets/javascripts/gtt_fiware_connection_form.js
+++ b/assets/javascripts/gtt_fiware_connection_form.js
@@ -1,0 +1,35 @@
+/* Broker connection form behaviour (#145): shows only the fields that apply
+ * to the selected standard, previously an inline script in
+ * broker_connections/_form.html.erb.
+ *
+ * Same js-ngsi-v2-only / js-ngsi-ld-only convention as the template form
+ * (gtt_fiware_form.js), keyed off the standard select instead of the
+ * connection select. Hidden values are kept, not cleared, so switching the
+ * standard back does not lose input.
+ *
+ * Exposes window.GttFiwareConnectionForm.init for the tests.
+ */
+(function() {
+  'use strict';
+
+  function init() {
+    var standardSelect = document.getElementById('broker_connection_standard');
+    if (!standardSelect) { return; }
+
+    function applyStandard() {
+      var isLd = standardSelect.value === 'NGSI-LD';
+      document.querySelectorAll('.js-ngsi-v2-only').forEach(function(el) {
+        el.style.display = isLd ? 'none' : '';
+      });
+      document.querySelectorAll('.js-ngsi-ld-only').forEach(function(el) {
+        el.style.display = isLd ? '' : 'none';
+      });
+    }
+
+    standardSelect.addEventListener('change', applyStandard);
+    applyStandard();
+  }
+
+  window.GttFiwareConnectionForm = { init: init };
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/assets/javascripts/gtt_fiware_list.js
+++ b/assets/javascripts/gtt_fiware_list.js
@@ -1,0 +1,54 @@
+/* Subscription template list behaviour (#145): the rails-ujs handlers for
+ * the row action links (publish, unpublish, sync, copy), previously an
+ * inline script in _list.html.erb.
+ *
+ * Two response kinds arrive here:
+ *   - server-side publish/unpublish answer with re-rendered rows (text/html)
+ *     and the outcome message in the X-Redmine-Message header; the list is
+ *     swapped and the message shown,
+ *   - sync, copy and browser-mode publish/unpublish answer with JS
+ *     (text/javascript) that rails-ujs executes and that updates the page
+ *     itself; the list must NOT be overwritten with the script source.
+ *
+ * The broker token header is only attached when the token box exists, i.e.
+ * when some connection on the page authenticates from the browser (#95).
+ *
+ * Exposes window.GttFiwareList.init for the tests.
+ */
+(function() {
+  'use strict';
+
+  function init() {
+    var list = document.getElementById('subscriptionTemplateList');
+    if (!list) { return; }
+
+    document.addEventListener('ajax:beforeSend', function(event) {
+      var tokenInput = document.getElementById('subscription_auth_token');
+      if (!tokenInput) { return; }
+      var xhr = event.detail[0];
+      xhr.setRequestHeader('FIWARE-Broker-Auth-Token', tokenInput.value);
+    });
+
+    document.addEventListener('ajax:success', function(event) {
+      var xhr = event.detail[2];
+      var contentType = xhr.getResponseHeader('Content-Type') || '';
+      if (contentType.indexOf('text/html') !== -1) {
+        list.innerHTML = xhr.responseText;
+      }
+      notifyFromHeader(xhr);
+    });
+
+    document.addEventListener('ajax:error', function(event) {
+      var xhr = event.detail[2];
+      notifyFromHeader(xhr);
+    });
+  }
+
+  function notifyFromHeader(xhr) {
+    var message = xhr.getResponseHeader('X-Redmine-Message');
+    if (message) { window.showNotification(message); }
+  }
+
+  window.GttFiwareList = { init: init };
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -70,6 +70,8 @@ de:
   field_subscription_template_watched_attrs_placeholder: 'temperature, humidity'
   field_attachment_url_placeholder: 'https://example.com/photo.jpg'
   field_attachment_filename_placeholder: 'photo-${id}.jpg'
+  label_attachment_url: "Anhang-URL"
+  label_attachment_filename: "Dateiname"
 
   model:
     subscription_template:
@@ -183,6 +185,9 @@ de:
   field_subscription_template_entity_type_placeholder: 'TemperatureSensor'
   label_entity_match_pattern: 'ID-Muster'
   label_entity_match_id: 'Exakte ID'
+  label_entity_type: "Entitätstyp"
+  label_entity_match_kind: "Zuordnung nach"
+  label_entity_match_value: "ID oder Muster"
   label_entity_filter_add: 'Entitätsfilter hinzufügen'
   label_edit_as_json: 'Als JSON bearbeiten'
   field_subscription_template_watched_attributes: 'Beobachtete Attribute'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,8 @@ en:
     the air conditioning"
   field_attachment_url_placeholder: "https://example.com/photo.jpg"
   field_attachment_filename_placeholder: "photo-${id}.jpg"
+  label_attachment_url: "Attachment URL"
+  label_attachment_filename: "File name"
   field_subscription_template_attachments_string: "Attachments (array of)"
   field_subscription_template_attachments_placeholder: "[{\"filename\": \"image.jpg\"\
     , \"url\": \"https://example.com/image.jpg\"}]"
@@ -168,6 +170,9 @@ en:
   field_subscription_template_entity_type_placeholder: "TemperatureSensor"
   label_entity_match_pattern: "ID pattern"
   label_entity_match_id: "Exact ID"
+  label_entity_type: "Entity type"
+  label_entity_match_kind: "Match by"
+  label_entity_match_value: "ID or pattern"
   label_entity_filter_add: "Add entity filter"
   label_edit_as_json: "Edit as JSON"
   field_subscription_template_watched_attributes: "Watched attributes"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -141,6 +141,9 @@ ja:
   field_subscription_template_entity_type_placeholder: "TemperatureSensor"
   label_entity_match_pattern: "IDパターン"
   label_entity_match_id: "ID完全一致"
+  label_entity_type: "エンティティタイプ"
+  label_entity_match_kind: "一致方法"
+  label_entity_match_value: "IDまたはパターン"
   label_entity_filter_add: "エンティティフィルターを追加"
   label_edit_as_json: "JSONで編集"
   field_subscription_template_watched_attributes: "監視する属性"
@@ -225,6 +228,8 @@ ja:
   field_subscription_template_watched_attrs_placeholder: "temperature, humidity"
   field_attachment_url_placeholder: "https://example.com/photo.jpg"
   field_attachment_filename_placeholder: "photo-${id}.jpg"
+  label_attachment_url: "添付ファイルのURL"
+  label_attachment_filename: "ファイル名"
 
   model:
     subscription_template:

--- a/test/javascripts/connection_form.test.js
+++ b/test/javascripts/connection_form.test.js
@@ -1,0 +1,62 @@
+// The broker connection form (gtt_fiware_connection_form.js): fields that
+// only apply to one standard follow the standard select, same
+// js-ngsi-*-only convention as the template form.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+beforeAll(() => {
+  window.eval(readFileSync(
+    join(here, '../../assets/javascripts/gtt_fiware_connection_form.js'), 'utf8'
+  ));
+});
+
+function buildForm(standard) {
+  document.body.innerHTML = `
+    <select id="broker_connection_standard">
+      <option value="NGSIv2" ${standard === 'NGSIv2' ? 'selected' : ''}>NGSIv2</option>
+      <option value="NGSI-LD" ${standard === 'NGSI-LD' ? 'selected' : ''}>NGSI-LD</option>
+    </select>
+    <p class="js-ngsi-v2-only" id="servicepath"></p>
+    <p class="js-ngsi-ld-only" id="context"></p>
+    <div class="js-ngsi-ld-only" id="emission"></div>`;
+  window.GttFiwareConnectionForm.init();
+}
+
+function displayOf(id) {
+  return document.getElementById(id).style.display;
+}
+
+describe('broker connection standard toggle', () => {
+  it('shows only the LD fields when NGSI-LD is selected', () => {
+    buildForm('NGSI-LD');
+    expect(displayOf('servicepath')).toBe('none');
+    expect(displayOf('context')).toBe('');
+    expect(displayOf('emission')).toBe('');
+  });
+
+  it('shows only the v2 fields when NGSIv2 is selected', () => {
+    buildForm('NGSIv2');
+    expect(displayOf('servicepath')).toBe('');
+    expect(displayOf('context')).toBe('none');
+    expect(displayOf('emission')).toBe('none');
+  });
+
+  it('follows a change of the select', () => {
+    buildForm('NGSI-LD');
+    const select = document.getElementById('broker_connection_standard');
+    select.value = 'NGSIv2';
+    select.dispatchEvent(new Event('change'));
+    expect(displayOf('servicepath')).toBe('');
+    expect(displayOf('emission')).toBe('none');
+  });
+
+  it('does nothing on pages without the select', () => {
+    document.body.innerHTML = '<p class="js-ngsi-v2-only"></p>';
+    expect(() => window.GttFiwareConnectionForm.init()).not.toThrow();
+  });
+});

--- a/test/javascripts/list_actions.test.js
+++ b/test/javascripts/list_actions.test.js
@@ -1,0 +1,91 @@
+// The subscription template list (gtt_fiware_list.js): rails-ujs response
+// handling for the row action links.
+//
+// The contract under test: HTML responses (server-side publish/unpublish)
+// replace the list rows and show the X-Redmine-Message outcome; JS responses
+// (sync, copy, browser-mode publish/unpublish) are executed by rails-ujs and
+// update the page themselves, so the handler must leave the list alone. The
+// broker token request header is only attached while the token box exists.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+beforeAll(() => {
+  document.body.innerHTML = `
+    <p class="min-width"><input type="text" id="subscription_auth_token" /></p>
+    <table><tbody id="subscriptionTemplateList"><tr id="original"></tr></tbody></table>
+    <div id="temporaryNotification"></div>`;
+  window.eval(readFileSync(join(here, '../../assets/javascripts/gtt_fiware.js'), 'utf8'));
+  window.eval(readFileSync(join(here, '../../assets/javascripts/gtt_fiware_list.js'), 'utf8'));
+  window.GttFiwareList.init();
+});
+
+beforeEach(() => {
+  document.getElementById('subscriptionTemplateList').innerHTML = '<tr id="original"></tr>';
+  document.getElementById('temporaryNotification').textContent = '';
+});
+
+function fakeXhr({ contentType = 'text/html', message = null, responseText = '' } = {}) {
+  const headers = { 'Content-Type': contentType, 'X-Redmine-Message': message };
+  return {
+    responseText,
+    getResponseHeader(name) { return headers[name] ?? null; },
+    setRequestHeader: vi.fn()
+  };
+}
+
+function fire(type, detail) {
+  document.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
+describe('subscription template list', () => {
+  it('attaches the broker token header to outgoing requests', () => {
+    document.getElementById('subscription_auth_token').value = 'secret-token';
+    const xhr = fakeXhr();
+    fire('ajax:beforeSend', [xhr, {}]);
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('FIWARE-Broker-Auth-Token', 'secret-token');
+  });
+
+  it('sends no token header while the token box is absent', () => {
+    const box = document.getElementById('subscription_auth_token');
+    const parent = box.parentNode;
+    parent.removeChild(box);
+    const xhr = fakeXhr();
+    fire('ajax:beforeSend', [xhr, {}]);
+    expect(xhr.setRequestHeader).not.toHaveBeenCalled();
+    parent.appendChild(box);
+  });
+
+  it('swaps the rows and shows the outcome for an HTML response', () => {
+    const xhr = fakeXhr({
+      contentType: 'text/html; charset=utf-8',
+      message: 'Subscription published',
+      responseText: '<tr id="replaced"></tr>'
+    });
+    fire('ajax:success', [null, 'OK', xhr]);
+    expect(document.getElementById('replaced')).not.toBeNull();
+    expect(document.getElementById('original')).toBeNull();
+    expect(document.getElementById('temporaryNotification').textContent).toBe('Subscription published');
+  });
+
+  it('leaves the rows alone for a JS response (sync, copy)', () => {
+    const xhr = fakeXhr({
+      contentType: 'text/javascript; charset=utf-8',
+      responseText: 'showNotification("done");'
+    });
+    fire('ajax:success', [null, 'OK', xhr]);
+    expect(document.getElementById('original')).not.toBeNull();
+    expect(document.getElementById('temporaryNotification').textContent).toBe('');
+  });
+
+  it('shows the outcome header on an error response', () => {
+    const xhr = fakeXhr({ message: 'Broker rejected the subscription' });
+    fire('ajax:error', [null, 'Bad Request', xhr]);
+    expect(document.getElementById('original')).not.toBeNull();
+    expect(document.getElementById('temporaryNotification').textContent).toBe('Broker rejected the subscription');
+  });
+});

--- a/test/unit/subscription_template_form_helper_test.rb
+++ b/test/unit/subscription_template_form_helper_test.rb
@@ -1,0 +1,119 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+# The form-state derivations behind the template form partials (#145): geo
+# area and issue geometry radio state, watched attributes formatting, and the
+# structured-picker/JSON-mode decision for entities and attachments.
+class SubscriptionTemplateFormHelperTest < ActiveSupport::TestCase
+  include SubscriptionTemplateFormHelper
+
+  def template(attributes = {})
+    SubscriptionTemplate.new(attributes)
+  end
+
+  # --- geo area mode ----------------------------------------------------------
+
+  def test_geo_mode_is_anywhere_without_a_georel
+    assert_equal 'anywhere', gtt_fiware_geo_mode(template, true)
+  end
+
+  def test_geo_mode_is_boundary_for_the_project_polygon_triple
+    boundary = template(expression_georel: 'coveredBy', expression_geometry: 'polygon',
+                        expression_coords: '1,2;3,4;1,2')
+    assert_equal 'boundary', gtt_fiware_geo_mode(boundary, true)
+  end
+
+  # Without the boundary radio the same stored triple must show as a custom
+  # query, not silently map to a radio that is not rendered.
+  def test_geo_mode_falls_back_to_custom_when_the_boundary_is_unavailable
+    boundary = template(expression_georel: 'coveredBy', expression_geometry: 'polygon')
+    assert_equal 'custom', gtt_fiware_geo_mode(boundary, false)
+  end
+
+  def test_geo_mode_is_custom_for_other_geo_queries
+    near = template(expression_georel: 'near;maxDistance:1000', expression_geometry: 'point')
+    assert_equal 'custom', gtt_fiware_geo_mode(near, true)
+  end
+
+  # --- project boundary availability ------------------------------------------
+
+  def test_boundary_requires_the_gtt_module_and_a_polygon
+    project = stub(module_enabled?: true, geom: 'geom',
+                   geojson: { 'geometry' => { 'type' => 'Polygon', 'coordinates' => [] } })
+    assert gtt_fiware_project_boundary_available?(project)
+
+    no_module = stub(module_enabled?: false)
+    assert_not gtt_fiware_project_boundary_available?(no_module)
+
+    point = stub(module_enabled?: true, geom: 'geom',
+                 geojson: { 'geometry' => { 'type' => 'Point', 'coordinates' => [] } })
+    assert_not gtt_fiware_project_boundary_available?(point)
+  end
+
+  # --- watched attributes -----------------------------------------------------
+
+  def test_watched_attrs_list_joins_the_stored_array
+    assert_equal 'severity, status', gtt_fiware_watched_attrs_list(template(attrs: '["severity","status"]'))
+  end
+
+  def test_watched_attrs_list_is_blank_for_non_arrays_and_bad_json
+    assert_equal '', gtt_fiware_watched_attrs_list(template(attrs: '{"a":1}'))
+    assert_equal '', gtt_fiware_watched_attrs_list(template(attrs: 'not json'))
+    assert_equal '', gtt_fiware_watched_attrs_list(template)
+  end
+
+  # --- entity picker ----------------------------------------------------------
+
+  def test_entity_picker_offers_a_starter_row_for_a_blank_template
+    picker = gtt_fiware_entity_picker(template)
+    assert picker.pickerable?
+    assert_equal [{ 'type' => '', 'idPattern' => '.*' }], picker.rows
+  end
+
+  def test_entity_picker_accepts_flat_type_and_pattern_rows
+    entities = [{ 'type' => 'RoadDamage', 'idPattern' => '.*' }, { 'type' => 'Sensor', 'id' => 'urn:x:1' }]
+    picker = gtt_fiware_entity_picker(template(entities: entities))
+    assert picker.pickerable?
+    assert_equal entities, picker.rows
+  end
+
+  def test_entity_picker_falls_back_to_json_mode_for_richer_entries
+    extra_key = [{ 'type' => 'Sensor', 'idPattern' => '.*', 'scope' => '/x' }]
+    assert_not gtt_fiware_entity_picker(template(entities: extra_key)).pickerable?
+
+    both_matchers = [{ 'type' => 'Sensor', 'idPattern' => '.*', 'id' => 'urn:x:1' }]
+    assert_not gtt_fiware_entity_picker(template(entities: both_matchers)).pickerable?
+
+    no_type = [{ 'idPattern' => '.*' }]
+    assert_not gtt_fiware_entity_picker(template(entities: no_type)).pickerable?
+  end
+
+  # --- issue geometry mode ----------------------------------------------------
+
+  def test_geometry_mode_defaults_new_templates_to_the_entity_location
+    assert_equal 'location', gtt_fiware_geometry_mode(template)
+  end
+
+  def test_geometry_mode_keeps_a_stored_blank_as_none
+    persisted = template
+    persisted.stubs(:new_record?).returns(false)
+    assert_equal 'none', gtt_fiware_geometry_mode(persisted)
+  end
+
+  def test_geometry_mode_recognizes_the_location_placeholder_and_custom_json
+    assert_equal 'location', gtt_fiware_geometry_mode(template(geometry: '${location}'))
+    assert_equal 'custom', gtt_fiware_geometry_mode(template(geometry: { 'type' => 'Point' }))
+  end
+
+  # --- attachment picker ------------------------------------------------------
+
+  def test_attachment_picker_offers_a_starter_row_for_a_blank_template
+    picker = gtt_fiware_attachment_picker(template)
+    assert picker.pickerable?
+    assert_equal [{}], picker.rows
+  end
+
+  def test_attachment_picker_falls_back_to_json_mode_for_unknown_keys
+    rows = [{ 'url' => 'https://x', 'headers' => { 'X' => 'y' } }]
+    assert_not gtt_fiware_attachment_picker(template(attachments: rows)).pickerable?
+  end
+end


### PR DESCRIPTION
Closes #145. Deferred from the 2026-08 maintainer review.

## Inline scripts move to assets (Vitest-covered)

- **`gtt_fiware_list.js`** takes over the rails-ujs handlers from `_list.html.erb`. Two behavior fixes come with the move:
  - The handlers now attach whenever the list exists. Previously they only rendered when a browser-token connection was on the page, so for stored-auth connections a server-side publish/unpublish succeeded invisibly: no row refresh, no outcome message. Verified live on the dev instance (all-stored): a rejected publish now swaps the rows and shows the X-Redmine-Message outcome.
  - HTML and JS responses are told apart by `Content-Type` instead of excluding one link class. The old class-based exclusion covered copy but not sync, so a sync response could be written into the table body as raw JS source.
- **`gtt_fiware_connection_form.js`** takes over the NGSI standard toggle from `broker_connections/_form.html.erb` (same `js-ngsi-*-only` convention as the template form).

## Form-state helper

The logic-heavy ERB prologues of `_form_filters`, `_form_basics` and `_form_issue_details` move into `SubscriptionTemplateFormHelper`: geo area mode, project boundary availability, watched-attributes formatting, entity/attachment picker state, and issue geometry mode. The partials keep markup only, and the branching is now unit-tested (15 runs). The helper is declared on the controller because Redmine only auto-includes the helper matching the controller name.

## Label associations

Labels with a single control get `for=` (watched attributes, status, priority, category, version, notification user, browser token box), following the pattern the custom-field rows already used. The entity/attachment picker row inputs and the match-kind select get `aria-label`s; five new locale keys added to en/ja/de. Grouped radio/checkbox rows keep plain labels, matching core convention.

## Tests

- Ruby: 355 → 370 runs, 0 failures (full plugin suite in the container).
- Vitest: 64 → 73 tests (new `list_actions.test.js`, `connection_form.test.js`).
- Live verification on the dev instance: stored-auth publish feedback, copy JS response leaving the list intact, connection standard toggle, label click focusing its input, boundary geo mode derived from a real stored triple.