### PR TITLE
Emission: delete broker-side attributes that disappear locally

### DIFF
--- a/lib/redmine_gtt_fiware/emission_refresh.rb
+++ b/lib/redmine_gtt_fiware/emission_refresh.rb
@@ -1,0 +1,85 @@
+module RedmineGttFiware
+  # Brings an already-existing broker entity in line with the current local
+  # representation (#146). The Emitter lands here when its create attempt
+  # answered 409.
+  #
+  # Two divergences need more than a plain attribute update:
+  #
+  # - Attributes that appeared locally after the first emission (a field
+  #   newly exposed in the mapping, a geometry added to the issue). The
+  #   update goes through POST /entities/{id}/attrs (append, which also
+  #   overwrites existing attributes) rather than PATCH, because brokers on
+  #   spec revisions <= 1.5 ignore attributes they do not know on the PATCH
+  #   and would silently drop the new ones.
+  #
+  # - Attributes the broker still has but the current representation no
+  #   longer carries (assignee cleared, exposure switched off, geometry
+  #   removed). Each is removed with DELETE /entities/{id}/attrs/{name}
+  #   (ETSI GS CIM 009 clause 5.6.5) - deliberately NOT with the
+  #   urn:ngsi-ld:null value of clause 4.5.0: brokers that do not implement
+  #   the null convention (GeonicDB, verified 2026-08-05) store the null URN
+  #   as a literal attribute value, which is worse than the stale value it
+  #   was meant to remove. The attribute DELETE has been in the spec since
+  #   the earliest revisions and is unambiguous everywhere.
+  #
+  # The stale set comes from reading the broker's entity back (fetch and
+  # diff), not from a local memory of past emissions: it needs no schema,
+  # and it self-heals when the broker was changed by someone else. When the
+  # read fails the deletion pass is skipped for this run; the next update
+  # gets another chance.
+  class EmissionRefresh
+    # Not attributes: identity, context, and the broker-managed timestamps
+    # (CIM 009 system attributes, which a normalized entity may embed).
+    NON_ATTRIBUTE_KEYS = %w[id type @context createdAt modifiedAt].freeze
+
+    def initialize(connection, entity)
+      @connection = connection
+      @entity = entity
+    end
+
+    # Returns the response the Emitter judges: the append response when it
+    # failed or nothing was stale, otherwise the first failing deletion (or
+    # the append response when every deletion went through).
+    def call
+      stale = stale_attribute_names
+      response = request(:post, 'attrs', @entity.except('id', 'type'))
+      return response unless response.is_a?(Net::HTTPSuccess)
+
+      stale.each do |name|
+        deletion = request(:delete, "attrs/#{ERB::Util.url_encode(name)}", nil)
+        # 404 = someone else already removed it; that is the desired state.
+        next if deletion.is_a?(Net::HTTPSuccess) || deletion.is_a?(Net::HTTPNotFound)
+
+        return deletion
+      end
+      response
+    end
+
+    private
+
+    # The broker's attribute names minus the current local ones.
+    def stale_attribute_names
+      remote = fetch_remote_entity
+      return [] if remote.nil?
+
+      remote.keys - NON_ATTRIBUTE_KEYS - @entity.keys
+    end
+
+    def fetch_remote_entity
+      response = request(:get, nil, nil)
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      parsed = JSON.parse(response.body)
+      parsed.is_a?(Hash) ? parsed : nil
+    rescue JSON::ParserError
+      nil
+    end
+
+    def request(method, subresource, body)
+      resource = ["entities/#{@entity['id']}", subresource].compact.join('/')
+      BrokerHttp.request(method, "#{@connection.api_base}/#{resource}",
+                         connection: @connection, token: @connection.auth_token,
+                         body: body, content_type: body ? 'application/ld+json' : nil)
+    end
+  end
+end

--- a/lib/redmine_gtt_fiware/emission_refresh.rb
+++ b/lib/redmine_gtt_fiware/emission_refresh.rb
@@ -1,3 +1,6 @@
+require 'erb'
+require 'net/http'
+
 module RedmineGttFiware
   # Brings an already-existing broker entity in line with the current local
   # representation (#146). The Emitter lands here when its create attempt

--- a/lib/redmine_gtt_fiware/emitter.rb
+++ b/lib/redmine_gtt_fiware/emitter.rb
@@ -47,11 +47,11 @@ module RedmineGttFiware
         each_emission(issue) do |mapping, connection|
           entity = IssueEntity.new(issue, mapping).to_h
           response = request(connection, :post, 'entities', entity)
-          # 409: the entity exists - update its attributes instead. The id
-          # and type are immutable and must not be in the PATCH body.
+          # 409: the entity exists - EmissionRefresh updates its attributes
+          # and deletes the ones the current representation no longer
+          # carries (#146).
           if response.is_a?(Net::HTTPConflict)
-            attrs = entity.except('id', 'type')
-            response = request(connection, :patch, "entities/#{entity['id']}/attrs", attrs)
+            response = EmissionRefresh.new(connection, entity).call
           end
           log_failure(issue, connection, response) unless response.is_a?(Net::HTTPSuccess)
         end

--- a/test/unit/emitter_test.rb
+++ b/test/unit/emitter_test.rb
@@ -58,12 +58,28 @@ class EmitterTest < ActiveSupport::TestCase
     assert_equal 'WorkOrder', body.dig('subtype', 'value')
   end
 
-  # 409 means the entity exists: update its attributes, without the immutable
-  # id/type in the PATCH body.
-  def test_conflict_falls_back_to_a_patch
+  def remote_entity_response(extra_attributes = {})
+    entity = {
+      'id' => 'urn:ngsi-ld:Issue:redmine:test-town:1', 'type' => 'Issue',
+      'title' => { 'type' => 'Property', 'value' => 'Emitted issue' },
+      'createdAt' => '2026-08-01T00:00:00Z', 'modifiedAt' => '2026-08-01T00:00:00Z'
+    }.merge(extra_attributes)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.stubs(:body).returns(entity.to_json)
+    response
+  end
+
+  def no_content_response
+    Net::HTTPNoContent.new('1.1', '204', 'No Content')
+  end
+
+  # 409 means the entity exists: read it back, bring its attributes in line
+  # via append (POST ../attrs, which unlike PATCH also lands attributes the
+  # broker did not have yet), without the immutable id/type in the body.
+  def test_conflict_falls_back_to_an_attribute_append
     conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
     requests = []
-    responses = [conflict, Net::HTTPNoContent.new('1.1', '204', 'No Content')]
+    responses = [conflict, remote_entity_response, no_content_response]
     Net::HTTP.any_instance.stubs(:request).with { |req| requests << req; true }
              .returns(*responses)
 
@@ -71,13 +87,89 @@ class EmitterTest < ActiveSupport::TestCase
       build_issue.save!
     end
 
-    patch = requests.find { |r| r.is_a?(Net::HTTP::Patch) }
-    assert_not_nil patch, '409 must be followed by a PATCH'
-    assert_match %r{/ngsi-ld/v1/entities/urn:ngsi-ld:Issue:redmine:test-town:\d+/attrs\z}, patch.path
-    body = JSON.parse(patch.body)
+    get = requests.find { |r| r.is_a?(Net::HTTP::Get) }
+    assert_not_nil get, 'the 409 must trigger a read-back of the broker entity'
+    append = requests.find { |r| r.is_a?(Net::HTTP::Post) && r.path.end_with?('/attrs') }
+    assert_not_nil append, '409 must be followed by an attribute append'
+    assert_match %r{/ngsi-ld/v1/entities/urn:ngsi-ld:Issue:redmine:test-town:\d+/attrs\z}, append.path
+    body = JSON.parse(append.body)
     assert_nil body['id']
     assert_nil body['type']
     assert body.key?('status')
+    assert_not requests.any? { |r| r.is_a?(Net::HTTP::Delete) },
+               'nothing was stale, so no attribute must be deleted'
+  end
+
+  # Attributes the broker still has but the current representation no longer
+  # carries are removed with per-attribute DELETEs (#146).
+  def test_conflict_deletes_stale_broker_attributes
+    conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
+    remote = remote_entity_response(
+      'assignee' => { 'type' => 'Property', 'value' => 'Former Assignee' },
+      'refersTo' => { 'type' => 'Relationship', 'object' => 'urn:x:gone' }
+    )
+    requests = []
+    responses = [conflict, remote, no_content_response, no_content_response, no_content_response]
+    Net::HTTP.any_instance.stubs(:request).with { |req| requests << req; true }
+             .returns(*responses)
+
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      build_issue.save!
+    end
+
+    deletes = requests.select { |r| r.is_a?(Net::HTTP::Delete) }.map(&:path)
+    assert_equal 2, deletes.length, 'each stale attribute must be deleted individually'
+    assert deletes.any? { |path| path.end_with?('/attrs/assignee') }
+    assert deletes.any? { |path| path.end_with?('/attrs/refersTo') }
+    assert_not deletes.any? { |path| path.include?('/attrs/title') },
+               'attributes the representation still carries must not be deleted'
+  end
+
+  # A stale attribute already gone on the broker (deleted concurrently) is
+  # the desired state, not a failure.
+  def test_stale_attribute_deletion_tolerates_a_404
+    conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
+    remote = remote_entity_response('assignee' => { 'type' => 'Property', 'value' => 'x' })
+    not_found = Net::HTTPNotFound.new('1.1', '404', 'Not Found')
+    Net::HTTP.any_instance.stubs(:request)
+             .returns(conflict, remote, no_content_response, not_found)
+
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).never
+      build_issue.save!
+    end
+  end
+
+  # A failing deletion is reported like any other broker failure.
+  def test_failed_stale_attribute_deletion_is_logged
+    conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
+    remote = remote_entity_response('assignee' => { 'type' => 'Property', 'value' => 'x' })
+    Net::HTTP.any_instance.stubs(:request)
+             .returns(conflict, remote, no_content_response, error_response)
+
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).with { |msg| msg.include?('answered 500') }
+      build_issue.save!
+    end
+  end
+
+  # An unreadable broker entity skips the deletion pass for this run (the
+  # next update gets another chance); the append itself must still happen.
+  def test_conflict_with_a_failed_read_back_still_appends
+    conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
+    requests = []
+    responses = [conflict, error_response, no_content_response]
+    Net::HTTP.any_instance.stubs(:request).with { |req| requests << req; true }
+             .returns(*responses)
+
+    with_settings plugin_redmine_gtt_fiware: EMISSION_SETTINGS do
+      Rails.logger.expects(:error).never
+      build_issue.save!
+    end
+
+    assert requests.any? { |r| r.is_a?(Net::HTTP::Post) && r.path.end_with?('/attrs') },
+           'the append must run even when the read-back failed'
+    assert_not requests.any? { |r| r.is_a?(Net::HTTP::Patch) }
   end
 
   def test_issue_destroy_emits_a_delete
@@ -188,11 +280,11 @@ class EmitterTest < ActiveSupport::TestCase
     assert issue.persisted?
   end
 
-  # 409 -> PATCH fallback where the PATCH also fails: the failure of the
-  # second request is the one reported.
-  def test_conflict_then_failed_patch_is_logged
+  # 409 -> append fallback where the append also fails: the failure of the
+  # update request is the one reported.
+  def test_conflict_then_failed_append_is_logged
     conflict = Net::HTTPConflict.new('1.1', '409', 'Conflict')
-    responses = [conflict, error_response]
+    responses = [conflict, remote_entity_response, error_response]
     requests = []
     Net::HTTP.any_instance.stubs(:request).with { |req| requests << req; true }
              .returns(*responses)
@@ -200,7 +292,8 @@ class EmitterTest < ActiveSupport::TestCase
       Rails.logger.expects(:error).with { |msg| msg.include?('answered 500') }
       build_issue.save!
     end
-    assert requests.any? { |r| r.is_a?(Net::HTTP::Patch) }, 'the 409 must trigger the PATCH fallback'
+    assert requests.any? { |r| r.is_a?(Net::HTTP::Post) && r.path.end_with?('/attrs') },
+           'the 409 must trigger the append fallback'
   end
 
   # DELETE answering 404 means "never emitted or already gone": deliberately


### PR DESCRIPTION
Closes #146. From the 2026-08 conformance audit.

## Problem

The emitter upserts with POST /entities and fell back to PATCH /entities/{id}/attrs on 409. Attributes that disappear locally (assignee cleared, exposure switched off, geometry removed) were never deleted broker-side, so stale values persisted indefinitely. And on brokers implementing spec revisions <= 1.5, attributes added locally after the first emission never arrived, because those brokers ignore unknown attributes on the PATCH.

## Approach

On 409 the update now runs through a new `EmissionRefresh` collaborator:

1. **Read back and diff.** The broker's entity is fetched and its attribute names diffed against the current local representation. No new table or emission memory: fetch-and-diff needs no schema and self-heals when the broker was changed by someone else. A failed read-back skips the deletion pass for that run only.
2. **Append instead of PATCH.** The attribute update moves to `POST /entities/{id}/attrs` (overwrite semantics), so newly appearing attributes land on old-spec brokers too.
3. **Per-attribute DELETE for stale attributes** (CIM 009 clause 5.6.5), with 404 tolerated as the desired state.

## Why not urn:ngsi-ld:null

The issue proposed the NGSI-LD null value (clause 4.5.0), and it was the first implementation here. Live verification against GeonicDB killed it: the broker does not implement the convention and stored the literal string `urn:ngsi-ld:null` as the attribute value, which is worse than the stale value it was meant to remove. The per-attribute DELETE has been in the spec since the earliest revisions and is unambiguous on every broker. The class comment documents this so the decision is not re-litigated blind.

## Verification

- Unit: emitter suite 14 → 19 runs (read-back conversation, per-attribute deletes, 404 tolerance, failed-delete logging, failed read-back still appends). Full plugin suite green.
- Live against GeonicDB (`gtt_fiware_dev`): clearing assignee and description removed both attributes from the broker entity; re-adding the description brought it back through the append; the entity was fully removed on issue destroy.