### PR TITLE
Bump plugin version to 3.4.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt_fiware do
   author_url 'https://github.com/dkastl'
   url 'https://github.com/gtt-project/redmine_gtt_fiware'
   description 'Adds FIWARE integration capabilities for GTT projects'
-  version '3.3.0'
+  version '3.4.0'
 
   # Specify the minimum required Redmine version
   requires_redmine :version_or_higher => '6.0.0'


### PR DESCRIPTION
Cuts v3.4.0, which clears the deferred maintainer-review backlog.

Minor version rather than a patch: emission now deletes broker-side
attributes that the current issue representation no longer carries, so an
existing broker entity looks different after the first update on the new
version. No migrations and no manual upgrade step.

Contents since v3.3.0:

- #150 (issue #146): on the 409 update path the emitter reads the broker's
  entity back, appends the current attributes via `POST /entities/{id}/attrs`,
  and removes the stale ones with a per-attribute `DELETE`.
- #149 (issue #145): the two remaining inline scripts moved into asset files
  with Vitest coverage, the form partials' view logic moved into a unit-tested
  helper, and single-control labels gained `for=`/aria-labels. Publishing on a
  stored-auth connection now shows its result, which it never did before.
- #148: `doc/release_verification.md` records the geoQ notification-filter
  verification result.

Release notes go on the tag once this merges.